### PR TITLE
[TRL-131] infra: 설정 파일 외부 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+src/main/resources/*.yml
 
 ### STS ###
 .apt_generated

--- a/scripts/run_new_was.sh
+++ b/scripts/run_new_was.sh
@@ -20,6 +20,6 @@ if [ ! -z ${TARGET_PID} ]; then
   sudo kill ${TARGET_PID}
 fi
 
-nohup java -jar -Dserver.port=${TARGET_PORT} /home/ec2-user/trilo/build/libs/* > /home/ec2-user/nohup.out 2>&1 &
+nohup java -jar -Dserver.port=${TARGET_PORT} -Dspring.profiles.active=prod -Dspring.config.location=/home/ec2-user/application-prod.yml /home/ec2-user/trilo/build/libs/* > /home/ec2-user/nohup.out 2>&1 &
 echo "> Now new WAS runs at ${TARGET_PORT}."
 exit 0

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,2 +1,0 @@
-deploy-module:
-  version: 0.0.1

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,6 @@
+spring:
+  profiles:
+    active: test
+
+deploy-module:
+  version: 0.0.3


### PR DESCRIPTION
# JIRA 티켓
- [TRL-131]
---
# 작업 내역
- 기존에는 application.yml이 github에 그대로 배포됐는데 설정 파일을 배포 서버의 프로젝트 폴더 밖에 올려두고, 애플리케이션 로딩 시점에 참조하도록 변경하였습니다.
- 로컬에서는 application-local.yml을 기반으로 애플리케이션 설정을 구성하고, 배포환경에서는 application-prod.yml을 기반으로 애플리케이션 설정을 구성합니다.
- 다음 배포 전에, 설정 파일을 변경하면 배포 후 변경된 설정이 반영됩니다.
---


[TRL-131]: https://cosain.atlassian.net/browse/TRL-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ