### PR TITLE
[TRL-143] chore: SpringSecurity 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,10 @@ dependencies {
 	// REST Docs
 	asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor' // (3) 스니펫 조각들 연동할 수 있는 의존성
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc' // (4) mockMvc 사용(@WebMvcTest 활용, Controller Layer 단위 테스트)
+
+	// Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
 }
 
 test {

--- a/src/main/java/com/cosain/trilo/config/security/SecurityConfig.java
+++ b/src/main/java/com/cosain/trilo/config/security/SecurityConfig.java
@@ -1,0 +1,26 @@
+package com.cosain.trilo.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
+
+        http
+                .authorizeHttpRequests(request -> request
+                        .requestMatchers(HttpMethod.GET, "/deploy/**").permitAll()
+                        .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
+
+}


### PR DESCRIPTION
# JIRA 티켓
[TRL-143]

---
# 작업 내역

Spring Security 기본 설정으로 인해 모든 요청에 인증이 필요하므로 이전에 정의해둔 deploy 관련 API 접근만 허용하는 설정 추가해서 등록

[TRL-143]: https://cosain.atlassian.net/browse/TRL-143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ