### PR TITLE
[TRL-119] feat: Access 토큰 재발급 기능 구현

### DIFF
--- a/src/main/java/com/cosain/trilo/auth/application/AuthService.java
+++ b/src/main/java/com/cosain/trilo/auth/application/AuthService.java
@@ -1,0 +1,42 @@
+package com.cosain.trilo.auth.application;
+
+import com.cosain.trilo.auth.domain.TokenRepository;
+import com.cosain.trilo.auth.infra.TokenAnalyzer;
+import com.cosain.trilo.auth.infra.TokenProvider;
+import com.cosain.trilo.common.exception.NotExistRefreshTokenException;
+import com.cosain.trilo.common.exception.NotValidTokenException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final TokenRepository tokenRepository;
+    private final TokenProvider tokenProvider;
+    private final TokenAnalyzer tokenAnalyzer;
+
+    @Transactional
+    public String reissueAccessToken(String refreshToken){
+        checkIfValidTokenOrThrow(refreshToken);
+        checkIfInRedisOrThrow(refreshToken);
+        tokenRepository.deleteTokenBy(refreshToken);
+        return tokenProvider.createAccessToken(getAuthentication());
+    }
+    private void checkIfValidTokenOrThrow(String refreshToken){
+        if(!tokenAnalyzer.validateToken(refreshToken)){
+            throw new NotValidTokenException();
+        }
+    }
+    private void checkIfInRedisOrThrow(String refreshToken){
+        if(!tokenRepository.existsById(refreshToken)){
+            throw new NotExistRefreshTokenException();
+        }
+    }
+    private Authentication getAuthentication(){
+        return SecurityContextHolder.getContext().getAuthentication();
+    }
+}

--- a/src/main/java/com/cosain/trilo/auth/domain/TokenRepository.java
+++ b/src/main/java/com/cosain/trilo/auth/domain/TokenRepository.java
@@ -4,4 +4,5 @@ import org.springframework.data.repository.CrudRepository;
 
 public interface TokenRepository extends CrudRepository<Token, String> {
 
+    void deleteTokenBy(String refreshToken);
 }

--- a/src/main/java/com/cosain/trilo/auth/presentation/AuthRestController.java
+++ b/src/main/java/com/cosain/trilo/auth/presentation/AuthRestController.java
@@ -1,0 +1,26 @@
+package com.cosain.trilo.auth.presentation;
+
+import com.cosain.trilo.auth.application.AuthService;
+import com.cosain.trilo.auth.presentation.dto.AuthResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthRestController {
+
+    private final AuthService authService;
+
+    @PostMapping("/reissue")
+    public ResponseEntity<AuthResponse> reissueAccessToken(@CookieValue(value = "refreshToken", required = true) String refreshToken){
+        String accessToken = authService.reissueAccessToken(refreshToken);
+        return ResponseEntity.ok(AuthResponse.from(accessToken));
+    }
+}

--- a/src/main/java/com/cosain/trilo/auth/presentation/dto/AuthResponse.java
+++ b/src/main/java/com/cosain/trilo/auth/presentation/dto/AuthResponse.java
@@ -1,0 +1,19 @@
+package com.cosain.trilo.auth.presentation.dto;
+
+import lombok.Getter;
+
+@Getter
+public class AuthResponse {
+
+    private String authType;
+    private String accessToken;
+
+    public static AuthResponse from(String accessToken) {
+        return new AuthResponse(accessToken);
+    }
+
+    private AuthResponse(String accessToken){
+        this.authType = "Bearer";
+        this.accessToken = accessToken;
+    }
+}

--- a/src/main/java/com/cosain/trilo/common/exception/NotExistRefreshTokenException.java
+++ b/src/main/java/com/cosain/trilo/common/exception/NotExistRefreshTokenException.java
@@ -1,0 +1,9 @@
+package com.cosain.trilo.common.exception;
+
+public class NotExistRefreshTokenException extends RuntimeException{
+
+    private final static String MESSAGE = "토큰이 존재하지 않습니다.";
+    public NotExistRefreshTokenException(){
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/com/cosain/trilo/common/exception/NotValidTokenException.java
+++ b/src/main/java/com/cosain/trilo/common/exception/NotValidTokenException.java
@@ -1,0 +1,8 @@
+package com.cosain.trilo.common.exception;
+
+public class NotValidTokenException extends RuntimeException{
+    private final static String MESSAGE = "토큰이 유효하지 않습니다";
+    public NotValidTokenException(){
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/com/cosain/trilo/config/security/SecurityConfig.java
+++ b/src/main/java/com/cosain/trilo/config/security/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests(request -> request
                         .requestMatchers(HttpMethod.GET, "/deploy/**").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/auth/reissue").permitAll()
                         .anyRequest().authenticated()
                 )
                 .csrf().disable()

--- a/src/test/java/com/cosain/trilo/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/cosain/trilo/auth/application/AuthServiceTest.java
@@ -1,0 +1,54 @@
+package com.cosain.trilo.auth.application;
+
+import com.cosain.trilo.auth.domain.TokenRepository;
+import com.cosain.trilo.auth.infra.TokenAnalyzer;
+import com.cosain.trilo.auth.infra.TokenProvider;
+import com.cosain.trilo.common.exception.NotExistRefreshTokenException;
+import com.cosain.trilo.common.exception.NotValidTokenException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+    @InjectMocks
+    private AuthService authService;
+    @Mock
+    private TokenRepository tokenRepository;
+    @Mock
+    private TokenAnalyzer tokenAnalyzer;
+    @Mock
+    private TokenProvider tokenProvider;
+
+
+    @Test
+    void ACCESS_토큰_재발급(){
+        given(tokenAnalyzer.validateToken(any())).willReturn(true);
+        given(tokenProvider.createAccessToken(any())).willReturn("accessToken");
+        given(tokenRepository.existsById(any())).willReturn(true);
+
+        String accessToken = authService.reissueAccessToken(any());
+        System.out.println(accessToken);
+    }
+
+    @Test
+    void 접근토큰_재발급시_재발급_토큰이_유효하지_않다면_에러를_발생시킨다(){
+        given(tokenAnalyzer.validateToken(any())).willReturn(false);
+
+        Assertions.assertThatThrownBy(() -> authService.reissueAccessToken(any())).isInstanceOf(NotValidTokenException.class);
+    }
+
+    @Test
+    void 접근토큰_재발급시_REDIS에_재발급_토큰이_존재하지_않는다면_에러를_발생시킨다(){
+        given(tokenAnalyzer.validateToken(any())).willReturn(true);
+        given(tokenRepository.existsById(any())).willReturn(false);
+
+        Assertions.assertThatThrownBy(() -> authService.reissueAccessToken(any())).isInstanceOf(NotExistRefreshTokenException.class);
+    }
+}

--- a/src/test/java/com/cosain/trilo/auth/presentation/AuthRestControllerTest.java
+++ b/src/test/java/com/cosain/trilo/auth/presentation/AuthRestControllerTest.java
@@ -1,0 +1,47 @@
+package com.cosain.trilo.auth.presentation;
+
+import com.cosain.trilo.auth.application.AuthService;
+import com.cosain.trilo.support.RestDocsTestSupport;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AuthRestControllerTest extends RestDocsTestSupport {
+
+    @MockBean
+    private AuthService authService;
+
+    @Test
+    void 접근토큰_재발급_요청() throws Exception{
+
+        given(authService.reissueAccessToken(any())).willReturn("accessToken");
+
+        mockMvc.perform(RestDocumentationRequestBuilders.post("/api/auth/reissue")
+                        .cookie(new Cookie("refreshToken", "refreshToken")))
+                .andExpect(status().isOk())
+                .andDo(restDocs.document(
+                        responseFields(
+                                fieldWithPath("authType").type(STRING).description("인증 타입 (Bearer)"),
+                                fieldWithPath("accessToken").type(STRING).description("재발급한 접근 토큰")
+                        )
+                ));
+    }
+
+    @Test
+    void 접근토큰_재발급_요청시_쿠키가_존재하지_않으면_400_BadRequest_에러를_발생시킨다() throws Exception{
+        mockMvc.perform(RestDocumentationRequestBuilders.post("/api/auth/reissue"))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
# JIRA 티켓
[TRL-119]

# 작업 내역
- 토큰 재발급 요청 URI 모두 허용 ( Spring Security에 `/api/auth/reissue`  경로 permitall 설정 추가 )
- API 및 응용 서비스 계층 테스트 단위 작성 (Mockito 활용)

[TRL-119]: https://cosain.atlassian.net/browse/TRL-119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ