### PR TITLE
[TRL-162] fix: 인증 데이터를 JSON 형식으로 보내도록 수정

### DIFF
--- a/src/main/java/com/cosain/trilo/config/security/SecurityConfig.java
+++ b/src/main/java/com/cosain/trilo/config/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.cosain.trilo.config.security;
 
 import com.cosain.trilo.auth.infra.TokenAnalyzer;
+import com.cosain.trilo.config.security.dto.AuthUriResponse;
 import com.cosain.trilo.config.security.filter.ExceptionHandlerFilter;
 import com.cosain.trilo.config.security.filter.TokenAuthenticationFilter;
 import com.cosain.trilo.config.security.handler.CustomAccessDeniedHandler;
@@ -83,10 +84,10 @@ public class SecurityConfig {
         return http.build();
     }
 
-    private static class CustomRedirectStrategy implements RedirectStrategy {
+    private class CustomRedirectStrategy implements RedirectStrategy {
         @Override
         public void sendRedirect(HttpServletRequest request, HttpServletResponse response, String url) throws IOException {
-            response.setHeader("Auth-Url" ,url);
+            objectMapper.writeValue(response.getWriter(), AuthUriResponse.from(url));
         }
     }
 

--- a/src/main/java/com/cosain/trilo/config/security/dto/AuthUriResponse.java
+++ b/src/main/java/com/cosain/trilo/config/security/dto/AuthUriResponse.java
@@ -1,0 +1,17 @@
+package com.cosain.trilo.config.security.dto;
+
+import lombok.Getter;
+
+@Getter
+public class AuthUriResponse {
+
+    private String uri;
+
+    public static AuthUriResponse from(String uri){
+        return new AuthUriResponse(uri);
+    }
+
+    private AuthUriResponse(String uri){
+        this.uri = uri;
+    }
+}

--- a/src/main/java/com/cosain/trilo/config/security/handler/OAuthSuccessHandler.java
+++ b/src/main/java/com/cosain/trilo/config/security/handler/OAuthSuccessHandler.java
@@ -4,7 +4,9 @@ import com.cosain.trilo.auth.domain.Token;
 import com.cosain.trilo.auth.domain.TokenRepository;
 import com.cosain.trilo.auth.infra.TokenAnalyzer;
 import com.cosain.trilo.auth.infra.TokenProvider;
+import com.cosain.trilo.auth.presentation.dto.AuthResponse;
 import com.cosain.trilo.config.security.util.CookieUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -25,6 +27,7 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     private final TokenProvider tokenProvider;
     private final TokenAnalyzer tokenAnalyzer;
     private final TokenRepository tokenRepository;
+    private final ObjectMapper objectMapper;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
@@ -37,7 +40,7 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
         CookieUtil.addAuthCookie(response, refreshToken, tokenExpiry);
         response.setStatus(HttpStatus.OK.value());
-        response.setHeader("Access-Token",accessToken);
+        objectMapper.writeValue(response.getWriter(), AuthResponse.from(accessToken));
     }
 
 }

--- a/src/test/java/com/cosain/trilo/security/OAuth2LoginTest.java
+++ b/src/test/java/com/cosain/trilo/security/OAuth2LoginTest.java
@@ -5,10 +5,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
@@ -16,17 +16,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class OAuth2LoginTest extends RestDocsTestSupport{
 
     private static final String AUTH_URL_REQUEST_URL = "/api/auth/login/";
-    private static final String AUTH_URL_HEADER_NAME = "Auth-Url";
 
     @Test
     void 카카오_인증_URL_요청() throws Exception {
         mockMvc.perform(get(AUTH_URL_REQUEST_URL+"kakao"))
                 .andExpect(status().isOk())
-                .andExpect(header().exists(AUTH_URL_HEADER_NAME))
                 .andDo(restDocs.document(
-                        responseHeaders(
-                                headerWithName(AUTH_URL_HEADER_NAME).description("인증 URL")
-                        )
+                        responseFields(fieldWithPath("uri").type(STRING).description("카카오 인증 URI"))
                 ));
     }
 
@@ -34,11 +30,8 @@ public class OAuth2LoginTest extends RestDocsTestSupport{
     void 구글_인증_URL_요청() throws Exception{
         mockMvc.perform(get(AUTH_URL_REQUEST_URL+"google"))
                 .andExpect(status().isOk())
-                .andExpect(header().exists(AUTH_URL_HEADER_NAME))
                 .andDo(restDocs.document(
-                        responseHeaders(
-                                headerWithName(AUTH_URL_HEADER_NAME).description("인증 URL")
-                        )
+                        responseFields(fieldWithPath("uri").type(STRING).description("구글 인증 URI"))
                 ));
     }
 
@@ -46,11 +39,8 @@ public class OAuth2LoginTest extends RestDocsTestSupport{
     void 네이버_인증_URL_요청() throws Exception{
         mockMvc.perform(get(AUTH_URL_REQUEST_URL+"naver"))
                 .andExpect(status().isOk())
-                .andExpect(header().exists(AUTH_URL_HEADER_NAME))
                 .andDo(restDocs.document(
-                        responseHeaders(
-                                headerWithName(AUTH_URL_HEADER_NAME).description("인증 URL")
-                        )
+                        responseFields(fieldWithPath("uri").type(STRING).description("네이버 인증 URI"))
                 ));
     }
 


### PR DESCRIPTION
# JIRA 티켓
[TRL-162]

# 작업 내역
- [x] 인증 URI를 JSON으로 반환하도록 수정
- [x] 로그인 성공시 AccessToken을 JSON으로 반환하도록 수정

[TRL-162]: https://cosain.atlassian.net/browse/TRL-162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ