### PR TITLE
[TRL-165] feat: @AuthenticationPrincipal 커스터마이징 

### DIFF
--- a/src/main/java/com/cosain/trilo/common/LoginUser.java
+++ b/src/main/java/com/cosain/trilo/common/LoginUser.java
@@ -1,0 +1,15 @@
+package com.cosain.trilo.common;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : user")
+public @interface LoginUser {
+
+}

--- a/src/main/java/com/cosain/trilo/config/security/dto/UserPrincipal.java
+++ b/src/main/java/com/cosain/trilo/config/security/dto/UserPrincipal.java
@@ -1,13 +1,14 @@
 package com.cosain.trilo.config.security.dto;
 
 import com.cosain.trilo.user.domain.User;
+import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
-
+@Getter
 public class UserPrincipal implements OAuth2User {
 
     private User user;


### PR DESCRIPTION
# JIRA 티켓
[TRL-165]

# 작업 내역

- LoginUser 어노테이션은 컨트롤러에서 UserPrincipal 객체를 파라미터로 받아와서 사용할 수 있도록 해줍니다.
- 이를 통해 컨트롤러 코드의 가독성을 높이고, 보안적인 이슈도 예방할 수 있습니다.

[TRL-165]: https://cosain.atlassian.net/browse/TRL-165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ