### PR TITLE
[TRL-175] chore: 여행 관련 조회 컨트롤러 패키지를 레이어드 아키텍처에 맞게 이동

### DIFF
--- a/src/main/java/com/cosain/trilo/trip/query/presentation/schedule/SingleScheduleQueryController.java
+++ b/src/main/java/com/cosain/trilo/trip/query/presentation/schedule/SingleScheduleQueryController.java
@@ -1,4 +1,4 @@
-package com.cosain.trilo.trip.query.adapter.in.api.schedule;
+package com.cosain.trilo.trip.query.presentation.schedule;
 
 import com.cosain.trilo.common.exception.NotImplementedException;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/cosain/trilo/trip/query/presentation/schedule/TripScheduleListQueryController.java
+++ b/src/main/java/com/cosain/trilo/trip/query/presentation/schedule/TripScheduleListQueryController.java
@@ -1,4 +1,4 @@
-package com.cosain.trilo.trip.query.adapter.in.api.schedule;
+package com.cosain.trilo.trip.query.presentation.schedule;
 
 import com.cosain.trilo.common.exception.NotImplementedException;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/cosain/trilo/trip/query/presentation/scheduleplace/SingleSchedulePlaceQueryController.java
+++ b/src/main/java/com/cosain/trilo/trip/query/presentation/scheduleplace/SingleSchedulePlaceQueryController.java
@@ -1,4 +1,4 @@
-package com.cosain.trilo.trip.query.adapter.in.api.scheduleplace;
+package com.cosain.trilo.trip.query.presentation.scheduleplace;
 
 import com.cosain.trilo.common.exception.NotImplementedException;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/cosain/trilo/trip/query/presentation/trip/SingleTripQueryController.java
+++ b/src/main/java/com/cosain/trilo/trip/query/presentation/trip/SingleTripQueryController.java
@@ -1,4 +1,4 @@
-package com.cosain.trilo.trip.query.adapter.in.api.trip;
+package com.cosain.trilo.trip.query.presentation.trip;
 
 import com.cosain.trilo.common.exception.NotImplementedException;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/cosain/trilo/trip/query/presentation/trip/TripTemporaryStorageQueryController.java
+++ b/src/main/java/com/cosain/trilo/trip/query/presentation/trip/TripTemporaryStorageQueryController.java
@@ -1,4 +1,4 @@
-package com.cosain.trilo.trip.query.adapter.in.api.trip;
+package com.cosain.trilo.trip.query.presentation.trip;
 
 import com.cosain.trilo.common.exception.NotImplementedException;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/cosain/trilo/trip/query/presentation/trip/TripperTripListQueryController.java
+++ b/src/main/java/com/cosain/trilo/trip/query/presentation/trip/TripperTripListQueryController.java
@@ -1,4 +1,4 @@
-package com.cosain.trilo.trip.query.adapter.in.api.trip;
+package com.cosain.trilo.trip.query.presentation.trip;
 
 import com.cosain.trilo.common.exception.NotImplementedException;
 import lombok.extern.slf4j.Slf4j;

--- a/src/test/java/com/cosain/trilo/unit/trip/query/presentation/schedule/SingleScheduleQueryControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/query/presentation/schedule/SingleScheduleQueryControllerTest.java
@@ -1,5 +1,4 @@
-package com.cosain.trilo.unit.trip.query.adapter.in.api.trip;
-
+package com.cosain.trilo.unit.trip.query.presentation.schedule;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,8 +19,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@DisplayName("특정 사용자 여행 목록 API 테스트")
-class TripperTripListQueryControllerTest {
+@DisplayName("일정 단건 조회 API 테스트")
+class SingleScheduleQueryControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -36,8 +35,8 @@ class TripperTripListQueryControllerTest {
     @Test
     @DisplayName("인증된 사용자 요청 -> 미구현 500")
     @WithMockUser
-    public void findTripperTripList_with_authorizedUser() throws Exception {
-        mockMvc.perform(get("/api/trips?tripper-id=1"))
+    public void findSingleSchedule_with_authorizedUser() throws Exception {
+        mockMvc.perform(get("/api/schedule-places/1"))
                 .andDo(print())
                 .andExpect(status().isInternalServerError())
                 .andExpect(jsonPath("$.errorCode").exists())
@@ -47,8 +46,8 @@ class TripperTripListQueryControllerTest {
     @Test
     @DisplayName("미인증 사용자 요청 -> 인증 실패 401")
     @WithAnonymousUser
-    public void findTripperTripList_with_unauthorizedUser() throws Exception {
-        mockMvc.perform(get("/api/trips?tripper-id=1"))
+    public void findSingleSchedule_with_unauthorizedUser() throws Exception {
+        mockMvc.perform(get("/api/schedule-places/1"))
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorCode").exists())

--- a/src/test/java/com/cosain/trilo/unit/trip/query/presentation/schedule/TripScheduleListQueryControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/query/presentation/schedule/TripScheduleListQueryControllerTest.java
@@ -1,4 +1,4 @@
-package com.cosain.trilo.unit.trip.query.adapter.in.api.scheduleplace;
+package com.cosain.trilo.unit.trip.query.presentation.schedule;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -19,8 +19,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@DisplayName("일정장소 단건 조회 API 테스트")
-class SingleSchedulePlaceQueryControllerTest {
+@DisplayName("여행의 일정 목록 조회 API 테스트")
+class TripScheduleListQueryControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -35,8 +35,8 @@ class SingleSchedulePlaceQueryControllerTest {
     @Test
     @DisplayName("인증된 사용자 요청 -> 미구현 500")
     @WithMockUser
-    public void findSingleSchedulePlace_with_authorizedUser() throws Exception {
-        mockMvc.perform(get("/api/schedule-places/1"))
+    public void findTripScheduleList_with_authorizedUser() throws Exception {
+        mockMvc.perform(get("/api/trips/1/schedules"))
                 .andDo(print())
                 .andExpect(status().isInternalServerError())
                 .andExpect(jsonPath("$.errorCode").exists())
@@ -46,8 +46,8 @@ class SingleSchedulePlaceQueryControllerTest {
     @Test
     @DisplayName("미인증 사용자 요청 -> 인증 실패 401")
     @WithAnonymousUser
-    public void findSingleSchedulePlace_with_unauthorizedUser() throws Exception {
-        mockMvc.perform(get("/api/schedule-places/1"))
+    public void findTripScheduleList_with_unauthorizedUser() throws Exception {
+        mockMvc.perform(get("/api/trips/1/schedules"))
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorCode").exists())

--- a/src/test/java/com/cosain/trilo/unit/trip/query/presentation/scheduleplace/SingleSchedulePlaceQueryControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/query/presentation/scheduleplace/SingleSchedulePlaceQueryControllerTest.java
@@ -1,4 +1,4 @@
-package com.cosain.trilo.unit.trip.query.adapter.in.api.trip;
+package com.cosain.trilo.unit.trip.query.presentation.scheduleplace;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -19,8 +19,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@DisplayName("여행 단건 조회 API 테스트")
-class SingleTripQueryControllerTest {
+@DisplayName("일정장소 단건 조회 API 테스트")
+class SingleSchedulePlaceQueryControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -35,8 +35,8 @@ class SingleTripQueryControllerTest {
     @Test
     @DisplayName("인증된 사용자 요청 -> 미구현 500")
     @WithMockUser
-    public void findSingleTrip_with_authorizedUser() throws Exception {
-        mockMvc.perform(get("/api/trips/1"))
+    public void findSingleSchedulePlace_with_authorizedUser() throws Exception {
+        mockMvc.perform(get("/api/schedule-places/1"))
                 .andDo(print())
                 .andExpect(status().isInternalServerError())
                 .andExpect(jsonPath("$.errorCode").exists())
@@ -46,12 +46,11 @@ class SingleTripQueryControllerTest {
     @Test
     @DisplayName("미인증 사용자 요청 -> 인증 실패 401")
     @WithAnonymousUser
-    public void findSingleTrip_with_unauthorizedUser() throws Exception {
-        mockMvc.perform(get("/api/trips/1"))
+    public void findSingleSchedulePlace_with_unauthorizedUser() throws Exception {
+        mockMvc.perform(get("/api/schedule-places/1"))
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorCode").exists())
                 .andExpect(jsonPath("$.errorMessage").exists());
     }
-
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/query/presentation/trip/SingleTripQueryControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/query/presentation/trip/SingleTripQueryControllerTest.java
@@ -1,4 +1,4 @@
-package com.cosain.trilo.unit.trip.query.adapter.in.api.trip;
+package com.cosain.trilo.unit.trip.query.presentation.trip;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -19,8 +19,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@DisplayName("여행의 임시보관함 조회 API 테스트")
-class TripTemporaryStorageQueryControllerTest {
+@DisplayName("여행 단건 조회 API 테스트")
+class SingleTripQueryControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -35,8 +35,8 @@ class TripTemporaryStorageQueryControllerTest {
     @Test
     @DisplayName("인증된 사용자 요청 -> 미구현 500")
     @WithMockUser
-    public void findTripTemporaryStorage_with_authorizedUser() throws Exception {
-        mockMvc.perform(get("/api/trips/1/temporary-storage"))
+    public void findSingleTrip_with_authorizedUser() throws Exception {
+        mockMvc.perform(get("/api/trips/1"))
                 .andDo(print())
                 .andExpect(status().isInternalServerError())
                 .andExpect(jsonPath("$.errorCode").exists())
@@ -46,11 +46,12 @@ class TripTemporaryStorageQueryControllerTest {
     @Test
     @DisplayName("미인증 사용자 요청 -> 인증 실패 401")
     @WithAnonymousUser
-    public void findTripTemporaryStorage_with_unauthorizedUser() throws Exception {
-        mockMvc.perform(get("/api/trips/1/temporary-storage"))
+    public void findSingleTrip_with_unauthorizedUser() throws Exception {
+        mockMvc.perform(get("/api/trips/1"))
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorCode").exists())
                 .andExpect(jsonPath("$.errorMessage").exists());
     }
+
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/query/presentation/trip/TripTemporaryStorageQueryControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/query/presentation/trip/TripTemporaryStorageQueryControllerTest.java
@@ -1,4 +1,4 @@
-package com.cosain.trilo.unit.trip.query.adapter.in.api.schedule;
+package com.cosain.trilo.unit.trip.query.presentation.trip;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -19,8 +19,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@DisplayName("여행의 일정 목록 조회 API 테스트")
-class TripScheduleListQueryControllerTest {
+@DisplayName("여행의 임시보관함 조회 API 테스트")
+class TripTemporaryStorageQueryControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -35,8 +35,8 @@ class TripScheduleListQueryControllerTest {
     @Test
     @DisplayName("인증된 사용자 요청 -> 미구현 500")
     @WithMockUser
-    public void findTripScheduleList_with_authorizedUser() throws Exception {
-        mockMvc.perform(get("/api/trips/1/schedules"))
+    public void findTripTemporaryStorage_with_authorizedUser() throws Exception {
+        mockMvc.perform(get("/api/trips/1/temporary-storage"))
                 .andDo(print())
                 .andExpect(status().isInternalServerError())
                 .andExpect(jsonPath("$.errorCode").exists())
@@ -46,8 +46,8 @@ class TripScheduleListQueryControllerTest {
     @Test
     @DisplayName("미인증 사용자 요청 -> 인증 실패 401")
     @WithAnonymousUser
-    public void findTripScheduleList_with_unauthorizedUser() throws Exception {
-        mockMvc.perform(get("/api/trips/1/schedules"))
+    public void findTripTemporaryStorage_with_unauthorizedUser() throws Exception {
+        mockMvc.perform(get("/api/trips/1/temporary-storage"))
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorCode").exists())

--- a/src/test/java/com/cosain/trilo/unit/trip/query/presentation/trip/TripperTripListQueryControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/query/presentation/trip/TripperTripListQueryControllerTest.java
@@ -1,4 +1,5 @@
-package com.cosain.trilo.unit.trip.query.adapter.in.api.schedule;
+package com.cosain.trilo.unit.trip.query.presentation.trip;
+
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -19,8 +20,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@DisplayName("일정 단건 조회 API 테스트")
-class SingleScheduleQueryControllerTest {
+@DisplayName("특정 사용자 여행 목록 API 테스트")
+class TripperTripListQueryControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -35,8 +36,8 @@ class SingleScheduleQueryControllerTest {
     @Test
     @DisplayName("인증된 사용자 요청 -> 미구현 500")
     @WithMockUser
-    public void findSingleSchedule_with_authorizedUser() throws Exception {
-        mockMvc.perform(get("/api/schedule-places/1"))
+    public void findTripperTripList_with_authorizedUser() throws Exception {
+        mockMvc.perform(get("/api/trips?tripper-id=1"))
                 .andDo(print())
                 .andExpect(status().isInternalServerError())
                 .andExpect(jsonPath("$.errorCode").exists())
@@ -46,8 +47,8 @@ class SingleScheduleQueryControllerTest {
     @Test
     @DisplayName("미인증 사용자 요청 -> 인증 실패 401")
     @WithAnonymousUser
-    public void findSingleSchedule_with_unauthorizedUser() throws Exception {
-        mockMvc.perform(get("/api/schedule-places/1"))
+    public void findTripperTripList_with_unauthorizedUser() throws Exception {
+        mockMvc.perform(get("/api/trips?tripper-id=1"))
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorCode").exists())


### PR DESCRIPTION
# JIRA 티켓
- [TRL-175]

---

# 작업 내역
- 아키텍처 패턴을, 프로젝트 초기단계의 편의성을 위해 레이어드 아키텍처 패턴을 사용하기로 하였습니다.
- 따라서 패키지 구조를 이에 맞게 변경하였습니다. 이번 PR은 여행 관련 조회 컨트롤러 패키지를 이동하는 것 관련 PR입니다.

[TRL-175]: https://cosain.atlassian.net/browse/TRL-175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ