### PR TITLE
[TRL-120] feat: 여행 생성 API 구현

### DIFF
--- a/src/main/java/com/cosain/trilo/trip/command/application/command/TripCreateCommand.java
+++ b/src/main/java/com/cosain/trilo/trip/command/application/command/TripCreateCommand.java
@@ -1,0 +1,12 @@
+package com.cosain.trilo.trip.command.application.command;
+
+import lombok.Getter;
+
+@Getter
+public class TripCreateCommand {
+
+    private String title;
+    public TripCreateCommand(String title) {
+        this.title = title;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/command/application/service/TripCreateService.java
+++ b/src/main/java/com/cosain/trilo/trip/command/application/service/TripCreateService.java
@@ -1,0 +1,30 @@
+package com.cosain.trilo.trip.command.application.service;
+
+import com.cosain.trilo.trip.command.application.command.TripCreateCommand;
+import com.cosain.trilo.trip.command.application.usecase.TripCreateUseCase;
+import com.cosain.trilo.trip.command.domain.entity.Trip;
+import com.cosain.trilo.trip.command.domain.repository.TripRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TripCreateService implements TripCreateUseCase {
+
+    private final TripRepository tripRepository;
+
+    /**
+     * Trip을 생성하여 등록하고, 식별자를 반환합니다.
+     * @param tripperId : 여행자 식별자
+     * @param createDto : 여행 생성에 필요한 정보들
+     * @return 생성된 여행의 식별자
+     */
+    @Override
+    @Transactional
+    public Long createTrip(Long tripperId, TripCreateCommand createDto) {
+        Trip trip = Trip.create(createDto.getTitle(), tripperId);
+        Trip savedTrip = tripRepository.save(trip);
+        return savedTrip.getId();
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/command/application/usecase/TripCreateUseCase.java
+++ b/src/main/java/com/cosain/trilo/trip/command/application/usecase/TripCreateUseCase.java
@@ -1,0 +1,8 @@
+package com.cosain.trilo.trip.command.application.usecase;
+
+import com.cosain.trilo.trip.command.application.command.TripCreateCommand;
+
+public interface TripCreateUseCase {
+
+    Long createTrip(Long tripperId, TripCreateCommand createDto);
+}

--- a/src/main/java/com/cosain/trilo/trip/command/domain/entity/Trip.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/entity/Trip.java
@@ -1,0 +1,51 @@
+package com.cosain.trilo.trip.command.domain.entity;
+
+import com.cosain.trilo.trip.command.domain.vo.TripPeriod;
+import com.cosain.trilo.trip.command.domain.vo.TripStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Entity
+@Table(name = "trip")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString(of = {"id", "tripperId", "title", "status", "tripPeriod"})
+public class Trip {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "trip_id")
+    private Long id;
+
+    @Column(name = "tripper_id")
+    private Long tripperId;
+
+    @Column(name = "title")
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    private TripStatus status;
+
+    @Embedded
+    private TripPeriod tripPeriod;
+
+    /**
+     * 여행(Trip)을 최초로 생성합니다. 최초 생성된 Trip은 UNDECIDED 상태입니다.
+     * @param title: 여행의 제목
+     * @param tripperId : 여행자의 식별자
+     * @return 생성된 Trip
+     */
+    public static Trip create(String title, Long tripperId) {
+        return new Trip(tripperId, title, TripStatus.UNDECIDED, null);
+    }
+
+    private Trip(Long tripperId, String title, TripStatus status, TripPeriod tripPeriod) {
+        this.tripperId = tripperId;
+        this.title = title;
+        this.status = status;
+        this.tripPeriod = tripPeriod;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/command/domain/repository/TripRepository.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/repository/TripRepository.java
@@ -1,0 +1,7 @@
+package com.cosain.trilo.trip.command.domain.repository;
+
+import com.cosain.trilo.trip.command.domain.entity.Trip;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TripRepository extends JpaRepository<Trip, Long> {
+}

--- a/src/main/java/com/cosain/trilo/trip/command/domain/vo/TripPeriod.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/vo/TripPeriod.java
@@ -1,0 +1,28 @@
+package com.cosain.trilo.trip.command.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDate;
+
+@Getter
+@ToString(of = {"startDate", "endDate"})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class TripPeriod {
+
+    @Column(name = "start_date")
+    private LocalDate startDate;
+
+    @Column(name = "end_date")
+    private LocalDate endDate;
+
+    public TripPeriod(LocalDate startDate, LocalDate endDate) {
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/command/domain/vo/TripStatus.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/vo/TripStatus.java
@@ -1,0 +1,8 @@
+package com.cosain.trilo.trip.command.domain.vo;
+
+public enum TripStatus {
+
+    UNDECIDED,
+    TRIPPING,
+    FINISHED
+}

--- a/src/main/java/com/cosain/trilo/trip/command/presentation/trip/TripCreateController.java
+++ b/src/main/java/com/cosain/trilo/trip/command/presentation/trip/TripCreateController.java
@@ -1,22 +1,35 @@
 package com.cosain.trilo.trip.command.presentation.trip;
 
-import com.cosain.trilo.common.exception.NotImplementedException;
-import com.cosain.trilo.config.security.dto.UserPrincipal;
+import com.cosain.trilo.common.LoginUser;
+import com.cosain.trilo.trip.command.application.command.TripCreateCommand;
+import com.cosain.trilo.trip.command.application.usecase.TripCreateUseCase;
+import com.cosain.trilo.trip.command.presentation.trip.dto.TripCreateRequest;
+import com.cosain.trilo.trip.command.presentation.trip.dto.TripCreateResponse;
+import com.cosain.trilo.user.domain.User;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * TODO: 여행 생성
- */
 @Slf4j
+@RequiredArgsConstructor
 @RestController
 public class TripCreateController {
 
+    private final TripCreateUseCase tripCreateUseCase;
+
     @PostMapping("/api/trips")
-    public String createTrip(@AuthenticationPrincipal UserPrincipal principal) {
-        throw new NotImplementedException("여행 생성 미구현");
+    public ResponseEntity<TripCreateResponse> createTrip(@LoginUser User user, @RequestBody TripCreateRequest request) {
+        Long tripperId = user.getId();
+        TripCreateCommand createCommand = request.toCommand();
+
+        Long tripId = tripCreateUseCase.createTrip(tripperId, createCommand);
+
+        var response = TripCreateResponse.from(tripId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
 }

--- a/src/main/java/com/cosain/trilo/trip/command/presentation/trip/dto/TripCreateRequest.java
+++ b/src/main/java/com/cosain/trilo/trip/command/presentation/trip/dto/TripCreateRequest.java
@@ -1,0 +1,20 @@
+package com.cosain.trilo.trip.command.presentation.trip.dto;
+
+import com.cosain.trilo.trip.command.application.command.TripCreateCommand;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TripCreateRequest {
+
+    private String title;
+
+    public TripCreateRequest(String title) {
+        this.title = title;
+    }
+    public TripCreateCommand toCommand() {
+        return new TripCreateCommand(title);
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/command/presentation/trip/dto/TripCreateResponse.java
+++ b/src/main/java/com/cosain/trilo/trip/command/presentation/trip/dto/TripCreateResponse.java
@@ -1,0 +1,16 @@
+package com.cosain.trilo.trip.command.presentation.trip.dto;
+
+import lombok.Getter;
+
+@Getter
+public class TripCreateResponse {
+
+    private Long tripId;
+    public static TripCreateResponse from(Long tripId) {
+        return new TripCreateResponse(tripId);
+    }
+    private TripCreateResponse(Long tripId) {
+        this.tripId = tripId;
+    }
+
+}

--- a/src/test/java/com/cosain/trilo/support/RestControllerTest.java
+++ b/src/test/java/com/cosain/trilo/support/RestControllerTest.java
@@ -6,6 +6,8 @@ import com.cosain.trilo.auth.infra.TokenProvider;
 import com.cosain.trilo.config.MessageSourceTestConfig;
 import com.cosain.trilo.config.SecurityTestConfig;
 import com.cosain.trilo.user.domain.UserRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -14,7 +16,14 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import java.util.Optional;
+
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+
+import static com.cosain.trilo.fixture.UserFixture.KAKAO_MEMBER;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 @Import({SecurityTestConfig.class, MessageSourceTestConfig.class})
 public class RestControllerTest {
@@ -24,8 +33,12 @@ public class RestControllerTest {
     @Autowired
     protected WebApplicationContext context;
 
+    @Autowired
+    protected ObjectMapper objectMapper;
+
     @BeforeEach
     void setUp() {
+
         mockMvc = MockMvcBuilders
                 .webAppContextSetup(context)
                 .apply(springSecurity())
@@ -40,5 +53,16 @@ public class RestControllerTest {
     protected TokenRepository tokenRepository;
     @MockBean
     protected UserRepository userRepository;
+
+    protected String createJson(Object dto) throws JsonProcessingException{
+        return objectMapper.writeValueAsString(dto);
+    }
+
+    protected void mockingForLoginUserAnnotation(){
+        given(tokenAnalyzer.validateToken(any())).willReturn(true);
+        given(tokenRepository.existsLogoutAccessTokenById(any())).willReturn(false);
+        given(userRepository.findByEmail(any())).willReturn(Optional.ofNullable(KAKAO_MEMBER.create()));
+    }
+
 
 }

--- a/src/test/java/com/cosain/trilo/support/RestControllerTest.java
+++ b/src/test/java/com/cosain/trilo/support/RestControllerTest.java
@@ -38,7 +38,6 @@ public class RestControllerTest {
 
     @BeforeEach
     void setUp() {
-
         mockMvc = MockMvcBuilders
                 .webAppContextSetup(context)
                 .apply(springSecurity())

--- a/src/test/java/com/cosain/trilo/unit/trip/command/application/service/TripCreateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/application/service/TripCreateServiceTest.java
@@ -1,0 +1,59 @@
+package com.cosain.trilo.unit.trip.command.application.service;
+
+import com.cosain.trilo.trip.command.application.command.TripCreateCommand;
+import com.cosain.trilo.trip.command.application.service.TripCreateService;
+import com.cosain.trilo.trip.command.domain.entity.Trip;
+import com.cosain.trilo.trip.command.domain.repository.TripRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Field;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+@DisplayName("[TripCommand] TripCreateService에서")
+public class TripCreateServiceTest {
+
+    @InjectMocks
+    private TripCreateService tripCreateService;
+
+    @Mock
+    private TripRepository tripRepository;
+
+    @Test
+    @DisplayName("create 하면, 내부적으로 repository가 호출된다.")
+    public void create_and_repository_called() throws Exception {
+        // given
+        TripCreateCommand createCommand = new TripCreateCommand("제목");
+        Long tripperId = 1L;
+
+        // mocking
+        Trip trip = Trip.create("제목", tripperId);
+        injectFakeTripId(trip, 1L);
+
+        given(tripRepository.save(any(Trip.class))).willReturn(trip);
+
+        // when
+        tripCreateService.createTrip(tripperId, createCommand);
+
+        // then
+        verify(tripRepository).save(any(Trip.class));
+    }
+
+    private void injectFakeTripId(Trip trip, Long fakeTripId) {
+        Field field = ReflectionUtils.findField(Trip.class, "id");
+        ReflectionUtils.makeAccessible(field);
+        ReflectionUtils.setField(field, trip, fakeTripId);
+    }
+
+}

--- a/src/test/java/com/cosain/trilo/unit/trip/command/domain/entity/TripTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/domain/entity/TripTest.java
@@ -1,0 +1,43 @@
+package com.cosain.trilo.unit.trip.command.domain.entity;
+
+import com.cosain.trilo.trip.command.domain.entity.Trip;
+import com.cosain.trilo.trip.command.domain.vo.TripStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("[TripCommand] Trip 테스트")
+public class TripTest {
+
+    @Nested
+    @DisplayName("여행을 create로 생성하면")
+    class When_Create {
+
+        // given
+        private final String title = "제목";
+        private final Long tripperId = 1L;
+
+        @Test
+        @DisplayName("지정한 이름을 가진 여행이 생성된다.")
+        public void createdTrip_has_same_title() {
+            // when
+            Trip trip = Trip.create(title, tripperId);
+
+            // then
+            assertThat(trip.getTitle()).isEqualTo("제목");
+        }
+
+        @Test
+        @DisplayName("UNDECIEDE 상태를 가진 여행이 생성된다.")
+        public void createdTrip_status_is_undecided() {
+            // when
+            Trip trip = Trip.create(title, tripperId);
+
+            // then
+            assertThat(trip.getStatus()).isSameAs(TripStatus.UNDECIDED);
+        }
+    }
+
+}

--- a/src/test/java/com/cosain/trilo/unit/trip/command/domain/repository/TripRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/domain/repository/TripRepositoryTest.java
@@ -1,0 +1,38 @@
+package com.cosain.trilo.unit.trip.command.domain.repository;
+
+import com.cosain.trilo.trip.command.domain.entity.Trip;
+import com.cosain.trilo.trip.command.domain.repository.TripRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DisplayName("[TripCommand] TripRepository 테스트")
+public class TripRepositoryTest {
+
+    @Autowired
+    private TripRepository tripRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Test
+    @DisplayName("Trip을 저장하고 같은 식별자로 찾으면 같은 Trip이 찾아진다.")
+    void saveTest() {
+        Trip trip = Trip.create("제목", 1L);
+        tripRepository.save(trip);
+
+        em.clear();
+
+        Trip findTrip = tripRepository.findById(trip.getId()).get();
+        assertThat(findTrip.getId()).isEqualTo(trip.getId());
+        assertThat(findTrip.getTripperId()).isEqualTo(trip.getTripperId());
+        assertThat(findTrip.getTripPeriod()).isEqualTo(trip.getTripPeriod());
+    }
+}


### PR DESCRIPTION
# JIRA 티켓
- [TRL-120]

---

# 작업 내역
- [x] Trip 생성 관련 도메인 기능 추가 및 테스트
- [x] TripRepository 작성 및 저장 기능 테스트
- [x] TripCreateService 구현 및 단위 테스트
- [x] TripCreateController 구현 및 단위 테스트

---

# 참고 사항

- 이상적인 계층 분리는 Trip 도메인과 JPA 엔티티 계층을 분리하는 것이지만 기능 개발의 속도를 위해 도메인 클래스에 JPA 관련 코드를 삽입하고 이를 사용하기로 하였습니다.
- 이 기능은 인텔리제이의 Code With Me 기능을 이용하여 @pia2011 와 함께 페어 프로그래밍을 통해 개발됐습니다.

---

[TRL-120]: https://cosain.atlassian.net/browse/TRL-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ