### PR TITLE
[TRL-157] feat: 일정 삭제 API 구현

### DIFF
--- a/src/main/java/com/cosain/trilo/trip/command/application/exception/NoScheduleDeleteAuthorityException.java
+++ b/src/main/java/com/cosain/trilo/trip/command/application/exception/NoScheduleDeleteAuthorityException.java
@@ -1,0 +1,35 @@
+package com.cosain.trilo.trip.command.application.exception;
+
+import com.cosain.trilo.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class NoScheduleDeleteAuthorityException extends CustomException {
+
+    private static final String ERROR_NAME = "NoScheduleDeleteAuthority";
+    private static final HttpStatus HTTP_STATUS = HttpStatus.FORBIDDEN;
+
+    public NoScheduleDeleteAuthorityException() {
+    }
+
+    public NoScheduleDeleteAuthorityException(String debugMessage) {
+        super(debugMessage);
+    }
+
+    public NoScheduleDeleteAuthorityException(Throwable cause) {
+        super(cause);
+    }
+
+    public NoScheduleDeleteAuthorityException(String debugMessage, Throwable cause) {
+        super(debugMessage, cause);
+    }
+
+    @Override
+    public String getErrorName() {
+        return ERROR_NAME;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HTTP_STATUS;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/command/application/exception/ScheduleNotFoundException.java
+++ b/src/main/java/com/cosain/trilo/trip/command/application/exception/ScheduleNotFoundException.java
@@ -5,11 +5,22 @@ import org.springframework.http.HttpStatus;
 
 public class ScheduleNotFoundException extends CustomException {
 
-    private static final String ERROR_NAME = "ScheduleNotFoundException";
+    private static final String ERROR_NAME = "ScheduleNotFound";
     private static final HttpStatus HTTP_STATUS = HttpStatus.NOT_FOUND;
+
+    public ScheduleNotFoundException() {
+    }
 
     public ScheduleNotFoundException(String debugMessage) {
         super(debugMessage);
+    }
+
+    public ScheduleNotFoundException(Throwable cause) {
+        super(cause);
+    }
+
+    public ScheduleNotFoundException(String debugMessage, Throwable cause) {
+        super(debugMessage, cause);
     }
 
     @Override

--- a/src/main/java/com/cosain/trilo/trip/command/application/service/ScheduleDeleteService.java
+++ b/src/main/java/com/cosain/trilo/trip/command/application/service/ScheduleDeleteService.java
@@ -1,0 +1,12 @@
+package com.cosain.trilo.trip.command.application.service;
+
+import com.cosain.trilo.trip.command.application.usecase.ScheduleDeleteUseCase;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ScheduleDeleteService implements ScheduleDeleteUseCase {
+
+    @Override
+    public void deleteSchedule(Long scheduleId, Long deleteTripperId) {
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/command/application/service/ScheduleDeleteService.java
+++ b/src/main/java/com/cosain/trilo/trip/command/application/service/ScheduleDeleteService.java
@@ -1,12 +1,38 @@
 package com.cosain.trilo.trip.command.application.service;
 
+import com.cosain.trilo.trip.command.application.exception.NoScheduleDeleteAuthorityException;
+import com.cosain.trilo.trip.command.application.exception.ScheduleNotFoundException;
 import com.cosain.trilo.trip.command.application.usecase.ScheduleDeleteUseCase;
+import com.cosain.trilo.trip.command.domain.entity.Schedule;
+import com.cosain.trilo.trip.command.domain.repository.ScheduleRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@RequiredArgsConstructor
 @Service
 public class ScheduleDeleteService implements ScheduleDeleteUseCase {
 
+    private final ScheduleRepository scheduleRepository;
+
     @Override
+    @Transactional
     public void deleteSchedule(Long scheduleId, Long deleteTripperId) {
+        Schedule schedule = findSchedule(scheduleId);
+        validateDeleteAuthority(schedule, deleteTripperId);
+        scheduleRepository.delete(schedule);
+    }
+
+    private Schedule findSchedule(Long scheduleId) {
+        return scheduleRepository.findByIdWithTrip(scheduleId)
+                .orElseThrow(() -> new ScheduleNotFoundException("일치하는 식별자의 일정을 찾을 수 없음"));
+    }
+
+    private void validateDeleteAuthority(Schedule schedule, Long deleteTripperId) {
+        Long tripperId = schedule.getTrip().getTripperId();
+
+        if (!tripperId.equals(deleteTripperId)) {
+            throw new NoScheduleDeleteAuthorityException("여행의 소유주가 아닌 사람이 일정을 삭제하려고 시도함");
+        }
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/command/application/usecase/ScheduleDeleteUseCase.java
+++ b/src/main/java/com/cosain/trilo/trip/command/application/usecase/ScheduleDeleteUseCase.java
@@ -1,0 +1,6 @@
+package com.cosain.trilo.trip.command.application.usecase;
+
+public interface ScheduleDeleteUseCase {
+
+    void deleteSchedule(Long scheduleId, Long deleteTripperId);
+}

--- a/src/main/java/com/cosain/trilo/trip/command/domain/repository/ScheduleRepository.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/repository/ScheduleRepository.java
@@ -1,11 +1,8 @@
 package com.cosain.trilo.trip.command.domain.repository;
 
 import com.cosain.trilo.trip.command.domain.entity.Schedule;
-import com.cosain.trilo.trip.command.domain.entity.Trip;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -13,12 +10,13 @@ import java.util.Optional;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
+    @Query("SELECT s" +
+            " FROM Schedule as s JOIN FETCH s.trip" +
+            " WHERE s.id = :scheduleId")
+    Optional<Schedule> findByIdWithTrip(@Param("scheduleId") Long scheduleId);
+
     @Modifying
     @Query("DELETE FROM Schedule as s where s.trip.id = :tripId")
     void deleteAllByTripId(@Param("tripId") Long tripId);
 
-    @Query("SELECT s" +
-            " FROM Schedule as s JOIN FETCH s.trip" +
-            " WHERE s.id = :id")
-    Optional<Schedule> findByIdWithTrip(@Param("id") Long scheduleId);
 }

--- a/src/main/java/com/cosain/trilo/trip/command/presentation/schedule/ScheduleDeleteController.java
+++ b/src/main/java/com/cosain/trilo/trip/command/presentation/schedule/ScheduleDeleteController.java
@@ -1,20 +1,27 @@
 package com.cosain.trilo.trip.command.presentation.schedule;
 
-import com.cosain.trilo.common.exception.NotImplementedException;
+import com.cosain.trilo.common.LoginUser;
+import com.cosain.trilo.trip.command.application.usecase.ScheduleDeleteUseCase;
+import com.cosain.trilo.user.domain.User;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * TODO: 일정장소 삭제
- */
 @Slf4j
+@RequiredArgsConstructor
 @RestController
 public class ScheduleDeleteController {
 
+    private final ScheduleDeleteUseCase scheduleDeleteUseCase;
+
     @DeleteMapping("/api/schedules/{scheduleId}")
-    public String deleteSchedule(@PathVariable Long scheduleId) {
-        throw new NotImplementedException("일정 삭제 미구현");
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteSchedule(@LoginUser User user, @PathVariable Long scheduleId) {
+        Long deleteTripperId = user.getId();
+        scheduleDeleteUseCase.deleteSchedule(scheduleId, deleteTripperId);
     }
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/command/application/service/schedule/ScheduleDeleteServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/application/service/schedule/ScheduleDeleteServiceTest.java
@@ -1,0 +1,121 @@
+package com.cosain.trilo.unit.trip.command.application.service.schedule;
+
+import com.cosain.trilo.trip.command.application.exception.NoScheduleDeleteAuthorityException;
+import com.cosain.trilo.trip.command.application.exception.ScheduleNotFoundException;
+import com.cosain.trilo.trip.command.application.service.ScheduleDeleteService;
+import com.cosain.trilo.trip.command.domain.entity.Day;
+import com.cosain.trilo.trip.command.domain.entity.Schedule;
+import com.cosain.trilo.trip.command.domain.entity.Trip;
+import com.cosain.trilo.trip.command.domain.repository.ScheduleRepository;
+import com.cosain.trilo.trip.command.domain.vo.Coordinate;
+import com.cosain.trilo.trip.command.domain.vo.Place;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static com.cosain.trilo.fixture.TripFixture.DECIDED_TRIP;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.verify;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+@DisplayName("[TripCommand] ScheduleDeleteService 테스트")
+public class ScheduleDeleteServiceTest {
+
+    @InjectMocks
+    private ScheduleDeleteService scheduleDeleteService;
+
+    @Mock
+    private ScheduleRepository scheduleRepository;
+
+    @Test
+    @DisplayName("존재하지 않는 일정을 삭제하려 하면, ScheduleNotFoundException 발생")
+    public void if_delete_not_exist_schedule_then_it_throws_ScheduleNotFoundException() {
+        // given
+        Long scheduleId = 1L;
+        Long deleteTripperId = 1L;
+        given(scheduleRepository.findByIdWithTrip(eq(scheduleId))).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> scheduleDeleteService.deleteSchedule(scheduleId, deleteTripperId))
+                .isInstanceOf(ScheduleNotFoundException.class);
+        verify(scheduleRepository).findByIdWithTrip(eq(scheduleId));
+    }
+
+    @Nested
+    @DisplayName("일정의 소유자가 아닌 사람이 일정을 삭제하려 하면")
+    class When_delete_tripper_not_equals_trip_owner {
+
+        @Test
+        @DisplayName("NoScheduleDeleteAuthorityException 이 발생한다.")
+        void it_throws_NoScheduleDeleteAuthorityException() {
+            // given
+            Long tripId = 1L;
+            Long tripOwnerId = 2L;
+            Long invalidTripperId = 3L;
+            Long scheduleId = 4L;
+
+            Trip trip = DECIDED_TRIP.createDecided(tripId, tripOwnerId, "여행 제목", LocalDate.of(2023,3,1), LocalDate.of(2023,3,1));
+            Day day = Day.of(LocalDate.of(2023,3,1),trip);
+            Schedule schedule = Schedule.builder()
+                            .id(scheduleId)
+                            .title("일정")
+                            .day(day)
+                            .trip(trip)
+                            .place(Place.of("place-id", "광안리 해수욕장", Coordinate.of(35.1551, 129.1220)))
+                            .build();
+
+            given(scheduleRepository.findByIdWithTrip(eq(scheduleId))).willReturn(Optional.of(schedule));
+
+            // when & then
+            assertThatThrownBy(() -> scheduleDeleteService.deleteSchedule(scheduleId, invalidTripperId))
+                    .isInstanceOf(NoScheduleDeleteAuthorityException.class);
+
+            verify(scheduleRepository).findByIdWithTrip(eq(scheduleId));
+        }
+    }
+
+    @Test
+    @DisplayName("정상 삭제 요청이 들어왔을 때, 리포지토리가 정상적으로 호출되는 지 여부 테스트")
+    public void deleteSuccess_and_Repository_Called_Test() {
+        // given
+        Long tripId = 1L;
+        Long tripOwnerId = 2L;
+        Long deleteTripperId = 2L;
+        Long scheduleId = 3L;
+
+        Trip trip = DECIDED_TRIP.createDecided(tripId, tripOwnerId, "여행 제목", LocalDate.of(2023,3,1), LocalDate.of(2023,3,1));
+        Day day = Day.of(LocalDate.of(2023,3,1),trip);
+        Schedule schedule = Schedule.builder()
+                .id(scheduleId)
+                .title("일정")
+                .day(day)
+                .trip(trip)
+                .place(Place.of("place-id", "광안리 해수욕장", Coordinate.of(35.1551, 129.1220)))
+                .build();
+
+        given(scheduleRepository.findByIdWithTrip(eq(scheduleId))).willReturn(Optional.of(schedule));
+        willDoNothing().given(scheduleRepository).delete(any(Schedule.class));
+
+
+        // when
+        scheduleDeleteService.deleteSchedule(scheduleId, deleteTripperId);
+
+        // then
+        verify(scheduleRepository).findByIdWithTrip(eq(scheduleId));
+        verify(scheduleRepository).delete(any(Schedule.class));
+    }
+
+}

--- a/src/test/java/com/cosain/trilo/unit/trip/command/domain/repository/ScheduleRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/domain/repository/ScheduleRepositoryTest.java
@@ -32,31 +32,6 @@ public class ScheduleRepositoryTest {
     @Autowired
     private TestEntityManager em;
 
-    @Test
-    @DirtiesContext
-    @DisplayName("Schedule 조회 시 Trip과 함께 조회")
-    void findByIdWithTripTest(){
-        // given
-        Trip trip = Trip.create("제목", 1L);
-        em.persist(trip);
-
-        Day day = Day.of(LocalDate.of(2023, 5, 4), trip);
-        em.persist(day);
-
-        Schedule schedule = Schedule.create(day, trip, "제목", Place.of("google-map-dkjfse", "장소 이름", Coordinate.of(23.23, 23.23)));
-        em.persist(schedule);
-
-        em.flush();
-        em.clear();
-
-        // when
-        Schedule findSchedule = scheduleRepository.findByIdWithTrip(schedule.getId()).get();
-
-        // then
-        assertThat(findSchedule.getTrip().getTripperId()).isEqualTo(trip.getTripperId());
-
-    }
-
 
     @Test
     @DirtiesContext
@@ -164,6 +139,43 @@ public class ScheduleRepositoryTest {
         // then
         List<Schedule> findSchedules = scheduleRepository.findAllById(List.of(schedule1.getId(), schedule2.getId(), schedule3.getId()));
         assertThat(findSchedules).isEmpty();
+    }
+
+
+    @Test
+    @DirtiesContext
+    @DisplayName("findByIdWithTrip으로 일정을 조회하면 해당 일정만 조회된다.(여행도 같이 묶여서 조회됨)")
+    void findByIdWithTripTest() {
+        // given
+        Trip trip = Trip.builder()
+                .tripperId(1L)
+                .title("여행 제목")
+                .status(TripStatus.DECIDED)
+                .tripPeriod(TripPeriod.of(LocalDate.of(2023,3,1), LocalDate.of(2023,3,1)))
+                .build();
+        em.persist(trip);
+
+        Day day = Day.of(LocalDate.of(2023,3,1), trip);
+        em.persist(day);
+
+        Schedule schedule1 = Schedule.create(day, trip, "일정1", Place.of("place-id1", "광안리 해수욕장1", Coordinate.of(35.1551, 129.1220)));
+        Schedule schedule2 = Schedule.create(day, trip, "일정2", Place.of("place-id2", "광안리 해수욕장2", Coordinate.of(35.1551, 129.1220)));
+        Schedule schedule3 = Schedule.create(day, trip, "일정3", Place.of("place-id3", "광안리 해수욕장3", Coordinate.of(35.1551, 129.1220)));
+
+        em.persist(schedule1);
+        em.persist(schedule2);
+        em.persist(schedule3);
+        em.flush();
+        em.clear();
+
+        // when
+        Schedule findSchedule = scheduleRepository.findByIdWithTrip(schedule2.getId()).get();
+
+        // then
+        assertThat(findSchedule.getId()).isEqualTo(schedule2.getId());
+        assertThat(findSchedule.getTrip().getId()).isEqualTo(trip.getId());
+        assertThat(findSchedule.getTitle()).isEqualTo(schedule2.getTitle());
+        assertThat(findSchedule.getPlace()).isEqualTo(schedule2.getPlace());
     }
 
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/command/domain/repository/ScheduleRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/domain/repository/ScheduleRepositoryTest.java
@@ -95,6 +95,38 @@ public class ScheduleRepositoryTest {
         assertThat(findSchedule.getPlace()).isEqualTo(schedule.getPlace());
     }
 
+
+    @Test
+    @DirtiesContext
+    @DisplayName("delete로 일정을 삭제하면, 해당 일정이 삭제된다.")
+    void deleteTest() {
+        // given
+        Trip trip = Trip.builder()
+                .tripperId(1L)
+                .title("여행 제목")
+                .status(TripStatus.DECIDED)
+                .tripPeriod(TripPeriod.of(LocalDate.of(2023,3,1), LocalDate.of(2023,3,1)))
+                .build();
+
+        em.persist(trip);
+
+        Day day = Day.of(LocalDate.of(2023,3,1), trip);
+        em.persist(day);
+
+        Schedule schedule = Schedule.create(day, trip, "일정1", Place.of("place-id1", "광안리 해수욕장", Coordinate.of(35.1551, 129.1220)));
+        em.persist(schedule);
+
+        // when
+        scheduleRepository.delete(schedule);
+        em.flush();
+        em.clear();
+
+        // then
+        Schedule findSchedule = scheduleRepository.findById(schedule.getId()).orElse(null);
+        assertThat(findSchedule).isNull();
+    }
+
+
     @Test
     @DirtiesContext
     @DisplayName("deleteAllByTripId로 일정을 삭제하면, 해당 여행의 모든 일정들이 삭제된다.")

--- a/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/schedule/ScheduleDeleteControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/schedule/ScheduleDeleteControllerTest.java
@@ -1,38 +1,64 @@
 package com.cosain.trilo.unit.trip.command.preesentation.api.schedule;
 
 import com.cosain.trilo.support.RestControllerTest;
+import com.cosain.trilo.trip.command.application.usecase.ScheduleDeleteUseCase;
+import com.cosain.trilo.trip.command.application.usecase.TripDeleteUseCase;
 import com.cosain.trilo.trip.command.presentation.schedule.ScheduleDeleteController;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.security.test.context.support.WithMockUser;
 
+import java.nio.charset.StandardCharsets;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@DisplayName("일정 삭제 API 테스트")
+@DisplayName("[TripCommand] 일정 삭제 API 테스트")
 @WebMvcTest(ScheduleDeleteController.class)
 class ScheduleDeleteControllerTest extends RestControllerTest {
+
+    @MockBean
+    private ScheduleDeleteUseCase scheduleDeleteUseCase;
+
+    private final static String ACCESS_TOKEN = "Bearer accessToken";
 
     @Test
     @DisplayName("인증된 사용자 요청 -> 미구현 500")
     @WithMockUser
     public void deleteSchedule_with_authorizedUser() throws Exception {
-        mockMvc.perform(delete("/api/schedules/1"))
+        mockingForLoginUserAnnotation();
+        willDoNothing().given(scheduleDeleteUseCase).deleteSchedule(eq(1L), any());
+
+        mockMvc.perform(delete("/api/schedules/1")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
                 .andDo(print())
-                .andExpect(status().isInternalServerError())
-                .andExpect(jsonPath("$.errorCode").exists())
-                .andExpect(jsonPath("$.errorMessage").exists());
+                .andExpect(status().isNoContent())
+                .andExpect(jsonPath("$").doesNotExist());
+        verify(scheduleDeleteUseCase).deleteSchedule(eq(1L), any());
     }
 
     @Test
     @DisplayName("미인증 사용자 요청 -> 인증 실패 401")
     @WithAnonymousUser
     public void deleteSchedule_with_unauthorizedUser() throws Exception {
-        mockMvc.perform(delete("/api/schedules/1"))
+        mockMvc.perform(delete("/api/schedules/1")
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorCode").exists())


### PR DESCRIPTION
# JIRA 티켓
- [TRL-157]

---

# 작업 내역
- [x] 일정 삭제 관련 리포지토리 메서드 구현 및 테스트
- [x] 일정 삭제 관련 애플리케이션 계층 구현 및 테스트
- [x] 일정 삭제 관련 표현 계층 구현 및 테스트

---

# 비고
- (#50)의 내역을 기존 작업물에 리베이스해서 다시 올림

---


[TRL-157]: https://cosain.atlassian.net/browse/TRL-157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ