### PR TITLE
[TRL-229] feat: 일정 순서 필드 추가 및 임시보관함 설계

### DIFF
--- a/src/main/java/com/cosain/trilo/trip/command/application/service/ScheduleCreateService.java
+++ b/src/main/java/com/cosain/trilo/trip/command/application/service/ScheduleCreateService.java
@@ -11,9 +11,13 @@ import com.cosain.trilo.trip.command.domain.entity.Trip;
 import com.cosain.trilo.trip.command.domain.repository.DayRepository;
 import com.cosain.trilo.trip.command.domain.repository.ScheduleRepository;
 import com.cosain.trilo.trip.command.domain.repository.TripRepository;
+import com.cosain.trilo.trip.command.domain.vo.ScheduleIndex;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 
 @RequiredArgsConstructor
 @Service
@@ -33,7 +37,10 @@ public class ScheduleCreateService implements ScheduleCreateUseCase {
         Trip trip = findTrip(createCommand.getTripId());
         validateCreateAuthority(trip, tripperId);
 
-        Schedule schedule = Schedule.create(day, trip, createCommand.getTitle(), createCommand.getPlace());
+        // TODO: Schedule 생성의 책임을 Trip 및 Day에게 위임
+        // Schedule 생성 시 create를 통해 생성하는데, 컴파일 에러를 막기 위해 임시방편으로 현재 시각의 EpochSecond를 이용해 랜덤 순서값을 부여하도록 했다.
+        Schedule schedule = Schedule.create(day, trip, createCommand.getTitle(), createCommand.getPlace(), ScheduleIndex.of(LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)%1_000_000_000));
+
         scheduleRepository.save(schedule);
 
         return schedule.getId();

--- a/src/main/java/com/cosain/trilo/trip/command/domain/entity/Day.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/entity/Day.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @ToString(of = {"id", "tripDate"})
@@ -27,6 +29,10 @@ public class Day {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "trip_id")
     private Trip trip;
+
+    @OneToMany(mappedBy = "day")
+    @OrderBy("scheduleIndex.value asc")
+    private List<Schedule> schedules = new ArrayList<>();
 
     /**
      * 비즈니스 코드에서 Day 생성은 Trip 에서만 할 수 있다.

--- a/src/main/java/com/cosain/trilo/trip/command/domain/entity/Schedule.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/entity/Schedule.java
@@ -1,13 +1,15 @@
 package com.cosain.trilo.trip.command.domain.entity;
 
 import com.cosain.trilo.trip.command.domain.vo.Place;
+import com.cosain.trilo.trip.command.domain.vo.ScheduleIndex;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 
+
 @Slf4j
 @Getter
-@ToString(of = {"id", "title", "content", "place"})
+@ToString(of = {"id", "title", "content", "place", "scheduleIndex"})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "schedules")
 @Entity
@@ -35,23 +37,28 @@ public class Schedule {
     @Embedded
     private Place place;
 
-    public static Schedule create(Day day, Trip trip, String title, Place place) {
+    @Embedded
+    private ScheduleIndex scheduleIndex;
+
+    public static Schedule create(Day day, Trip trip, String title, Place place, ScheduleIndex scheduleIndex) {
         return Schedule.builder()
                 .day(day)
                 .trip(trip)
                 .title(title)
                 .place(place)
+                .scheduleIndex(scheduleIndex)
                 .build();
     }
 
     @Builder(access = AccessLevel.PUBLIC)
-    private Schedule(Long id, Day day, Trip trip, String title, String content, Place place) {
+    private Schedule(Long id, Day day, Trip trip, String title, String content, Place place, ScheduleIndex scheduleIndex) {
         this.id = id;
         this.day = day;
         this.trip = trip;
         this.title = title;
         this.content = content;
         this.place = place;
+        this.scheduleIndex = scheduleIndex;
     }
 
     public void changeTitle(String title){

--- a/src/main/java/com/cosain/trilo/trip/command/domain/entity/Trip.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/entity/Trip.java
@@ -10,6 +10,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.annotations.Where;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -43,6 +44,11 @@ public class Trip {
     @OneToMany(mappedBy = "trip")
     private final List<Day> days = new ArrayList<>();
 
+    @OneToMany(mappedBy = "trip")
+    @Where(clause = "day_id is NULL")
+    @OrderBy("scheduleIndex.value asc")
+    private final List<Schedule> temporaryStorage = new ArrayList<>();
+
     /**
      * 여행(Trip)을 최초로 생성합니다. 최초 생성된 Trip은 UNDECIDED 상태입니다.
      *
@@ -63,7 +69,7 @@ public class Trip {
      * 테스트의 편의성을 위해 Builder accessLevel = PUBLIC 으로 설정
      */
     @Builder(access = AccessLevel.PUBLIC)
-    private Trip(Long id, Long tripperId, String title, TripStatus status, TripPeriod tripPeriod, List<Day> days) {
+    private Trip(Long id, Long tripperId, String title, TripStatus status, TripPeriod tripPeriod, List<Day> days, List<Schedule> temporaryStorage) {
         this.id = id;
         this.tripperId = tripperId;
         this.title = title;
@@ -72,6 +78,10 @@ public class Trip {
 
         if (days != null) {
             this.days.addAll(days);
+        }
+
+        if (temporaryStorage != null) {
+            this.temporaryStorage.addAll(temporaryStorage);
         }
     }
 

--- a/src/main/java/com/cosain/trilo/trip/command/domain/exception/ScheduleIndexRangeException.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/exception/ScheduleIndexRangeException.java
@@ -1,0 +1,15 @@
+package com.cosain.trilo.trip.command.domain.exception;
+
+public class ScheduleIndexRangeException extends RuntimeException {
+
+    public ScheduleIndexRangeException() {
+    }
+
+    public ScheduleIndexRangeException(String message) {
+        super(message);
+    }
+
+    public ScheduleIndexRangeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/command/domain/vo/ScheduleIndex.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/vo/ScheduleIndex.java
@@ -12,9 +12,9 @@ import lombok.*;
 @Embeddable
 public class ScheduleIndex {
 
-    private static final long DEFAULT_SEQUENCE_GAP = 10_000_000;
-    private static final long MAX_INDEX = 5_000_000_000_000_000_000L;
-    private static final long MIN_INDEX = -5_000_000_000_000_000_000L;
+    public static final long DEFAULT_SEQUENCE_GAP = 10_000_000;
+    public static final long MAX_INDEX_VALUE = 5_000_000_000_000_000_000L;
+    public static final long MIN_INDEX_VALUE = -5_000_000_000_000_000_000L;
 
     @Column(name = "schedule_index")
     private long value;
@@ -22,7 +22,7 @@ public class ScheduleIndex {
     public static final ScheduleIndex ZERO_INDEX = ScheduleIndex.of(0);
 
     public static ScheduleIndex of(long value) {
-        if (value > MAX_INDEX || value < MIN_INDEX) {
+        if (value > MAX_INDEX_VALUE || value < MIN_INDEX_VALUE) {
             throw new ScheduleIndexRangeException("[처리 필요] 유효한 인덱스 범위를 벗어난 인덱스를 생성하려 함.");
         }
         return new ScheduleIndex(value);
@@ -30,6 +30,10 @@ public class ScheduleIndex {
 
     private ScheduleIndex(long value) {
         this.value = value;
+    }
+
+    public ScheduleIndex generateNextIndex() {
+        return ScheduleIndex.of(value + DEFAULT_SEQUENCE_GAP);
     }
 
 }

--- a/src/main/java/com/cosain/trilo/trip/command/domain/vo/ScheduleIndex.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/vo/ScheduleIndex.java
@@ -1,0 +1,35 @@
+package com.cosain.trilo.trip.command.domain.vo;
+
+import com.cosain.trilo.trip.command.domain.exception.ScheduleIndexRangeException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+@Getter
+@ToString(of = {"value"})
+@EqualsAndHashCode(of = {"value"})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class ScheduleIndex {
+
+    private static final long DEFAULT_SEQUENCE_GAP = 10_000_000;
+    private static final long MAX_INDEX = 5_000_000_000_000_000_000L;
+    private static final long MIN_INDEX = -5_000_000_000_000_000_000L;
+
+    @Column(name = "schedule_index")
+    private long value;
+
+    public static final ScheduleIndex ZERO_INDEX = ScheduleIndex.of(0);
+
+    public static ScheduleIndex of(long value) {
+        if (value > MAX_INDEX || value < MIN_INDEX) {
+            throw new ScheduleIndexRangeException("[처리 필요] 유효한 인덱스 범위를 벗어난 인덱스를 생성하려 함.");
+        }
+        return new ScheduleIndex(value);
+    }
+
+    private ScheduleIndex(long value) {
+        this.value = value;
+    }
+
+}

--- a/src/test/java/com/cosain/trilo/unit/trip/command/application/service/schedule/ScheduleCreateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/application/service/schedule/ScheduleCreateServiceTest.java
@@ -11,6 +11,7 @@ import com.cosain.trilo.trip.command.domain.repository.ScheduleRepository;
 import com.cosain.trilo.trip.command.domain.repository.TripRepository;
 import com.cosain.trilo.trip.command.domain.vo.Coordinate;
 import com.cosain.trilo.trip.command.domain.vo.Place;
+import com.cosain.trilo.trip.command.domain.vo.ScheduleIndex;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -49,7 +50,7 @@ public class ScheduleCreateServiceTest {
         Long tripperId = 1L;
         Trip trip = Trip.create("제목", tripperId);
         Day day = Day.of(LocalDate.of(2023, 4, 5), trip);
-        Schedule schedule = Schedule.create(day, trip, "제목", Place.of("장소 식별자", "장소 이름", Coordinate.of(23.21, 23.24)));
+        Schedule schedule = Schedule.create(day, trip, "제목", Place.of("장소 식별자", "장소 이름", Coordinate.of(23.21, 23.24)), ScheduleIndex.of(1000));
 
         ScheduleCreateCommand scheduleCreateCommand = ScheduleCreateCommand.of(1L, 1L, "제목", "내용", "장소 식별자", 23.21, 23.24);
         given(scheduleRepository.save(any(Schedule.class))).willReturn(schedule);

--- a/src/test/java/com/cosain/trilo/unit/trip/command/domain/repository/ScheduleRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/domain/repository/ScheduleRepositoryTest.java
@@ -4,10 +4,7 @@ import com.cosain.trilo.trip.command.domain.entity.Day;
 import com.cosain.trilo.trip.command.domain.entity.Schedule;
 import com.cosain.trilo.trip.command.domain.entity.Trip;
 import com.cosain.trilo.trip.command.domain.repository.ScheduleRepository;
-import com.cosain.trilo.trip.command.domain.vo.Coordinate;
-import com.cosain.trilo.trip.command.domain.vo.Place;
-import com.cosain.trilo.trip.command.domain.vo.TripPeriod;
-import com.cosain.trilo.trip.command.domain.vo.TripStatus;
+import com.cosain.trilo.trip.command.domain.vo.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -88,7 +85,7 @@ public class ScheduleRepositoryTest {
         Day day = Day.of(LocalDate.of(2023,3,1), trip);
         em.persist(day);
 
-        Schedule schedule = Schedule.create(day, trip, "일정1", Place.of("place-id1", "광안리 해수욕장", Coordinate.of(35.1551, 129.1220)));
+        Schedule schedule = Schedule.create(day, trip, "일정1", Place.of("place-id1", "광안리 해수욕장", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(1000));
         em.persist(schedule);
 
         // when
@@ -124,9 +121,9 @@ public class ScheduleRepositoryTest {
         em.persist(day2);
         em.persist(day3);
 
-        Schedule schedule1 = Schedule.create(day1, trip, "일정1", Place.of("place-id1", "광안리 해수욕장", Coordinate.of(35.1551, 129.1220)));
-        Schedule schedule2 = Schedule.create(day2, trip, "일정2", Place.of("place-id2", "광화문 광장", Coordinate.of(37.5748, 126.9767)));
-        Schedule schedule3 = Schedule.create(day3, trip, "일정3", Place.of("place-id3", "도쿄 타워", Coordinate.of(35.3931, 139.4443)));
+        Schedule schedule1 = Schedule.create(day1, trip, "일정1", Place.of("place-id1", "광안리 해수욕장", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(1000));
+        Schedule schedule2 = Schedule.create(day2, trip, "일정2", Place.of("place-id2", "광화문 광장", Coordinate.of(37.5748, 126.9767)), ScheduleIndex.of(1000));
+        Schedule schedule3 = Schedule.create(day3, trip, "일정3", Place.of("place-id3", "도쿄 타워", Coordinate.of(35.3931, 139.4443)), ScheduleIndex.of(1000));
 
         em.persist(schedule1);
         em.persist(schedule2);
@@ -158,9 +155,9 @@ public class ScheduleRepositoryTest {
         Day day = Day.of(LocalDate.of(2023,3,1), trip);
         em.persist(day);
 
-        Schedule schedule1 = Schedule.create(day, trip, "일정1", Place.of("place-id1", "광안리 해수욕장1", Coordinate.of(35.1551, 129.1220)));
-        Schedule schedule2 = Schedule.create(day, trip, "일정2", Place.of("place-id2", "광안리 해수욕장2", Coordinate.of(35.1551, 129.1220)));
-        Schedule schedule3 = Schedule.create(day, trip, "일정3", Place.of("place-id3", "광안리 해수욕장3", Coordinate.of(35.1551, 129.1220)));
+        Schedule schedule1 = Schedule.create(day, trip, "일정1", Place.of("place-id1", "광안리 해수욕장1", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(1000));
+        Schedule schedule2 = Schedule.create(day, trip, "일정2", Place.of("place-id2", "광안리 해수욕장2", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(2000));
+        Schedule schedule3 = Schedule.create(day, trip, "일정3", Place.of("place-id3", "광안리 해수욕장3", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(3000));
 
         em.persist(schedule1);
         em.persist(schedule2);

--- a/src/test/java/com/cosain/trilo/unit/trip/command/domain/vo/ScheduleIndexTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/domain/vo/ScheduleIndexTest.java
@@ -4,9 +4,11 @@ import com.cosain.trilo.trip.command.domain.exception.ScheduleIndexRangeExceptio
 import com.cosain.trilo.trip.command.domain.vo.ScheduleIndex;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("[TripCommand] ScheduleIndexTest")
@@ -42,6 +44,31 @@ public class ScheduleIndexTest {
         public void when_create_with_too_small_index_then_it_throws_ScheduleIndexRangeException(long indexValue) {
             assertThatThrownBy(() -> ScheduleIndex.of(indexValue))
                     .isInstanceOf(ScheduleIndexRangeException.class);
+        }
+
+    }
+
+    @Nested
+    @DisplayName("generateNextIndex 테스트")
+    class generateNextIndexTest {
+
+        @Test
+        @DisplayName("다음에 오는 순서가 범위를 벗어나는 경우 예외 발생")
+        public void when_nextIndex_is_too_big_index_then_it_throws_ScheduleIndexRangeException() {
+            ScheduleIndex index = ScheduleIndex.of(ScheduleIndex.MAX_INDEX_VALUE);
+
+            assertThatThrownBy(index::generateNextIndex)
+                    .isInstanceOf(ScheduleIndexRangeException.class);
+        }
+
+
+        @Test
+        @DisplayName("최댓값을 넘지않는 인덱스의 다음 인덱스 생성 시 정상적으로 인덱스 생성")
+        public void successfully_generate_nextIndex() {
+            ScheduleIndex index = ScheduleIndex.ZERO_INDEX;
+
+            ScheduleIndex nextIndex = index.generateNextIndex();
+            assertThat(nextIndex.getValue()).isEqualTo(index.getValue() + ScheduleIndex.DEFAULT_SEQUENCE_GAP);
         }
 
     }

--- a/src/test/java/com/cosain/trilo/unit/trip/command/domain/vo/ScheduleIndexTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/domain/vo/ScheduleIndexTest.java
@@ -1,0 +1,49 @@
+package com.cosain.trilo.unit.trip.command.domain.vo;
+
+import com.cosain.trilo.trip.command.domain.exception.ScheduleIndexRangeException;
+import com.cosain.trilo.trip.command.domain.vo.ScheduleIndex;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("[TripCommand] ScheduleIndexTest")
+public class ScheduleIndexTest {
+
+    @Nested
+    @DisplayName("생성 테스트")
+    class createTest {
+
+        @ParameterizedTest
+        @DisplayName("최댓값보다 큰 인덱스 생성 -> ScheduleIndexRangeException")
+        @ValueSource(longs = {
+                5_000_000_000_000_000_001L,
+                5_000_000_000_000_000_002L,
+                6_000_000_000_000_000_000L,
+                7_000_000_000_000_000_000L,
+                8_888_888_888_888_888_888L,
+                Long.MAX_VALUE})
+        public void when_create_with_too_big_index_then_it_throws_ScheduleIndexRangeException(long indexValue) {
+            assertThatThrownBy(() -> ScheduleIndex.of(indexValue))
+                    .isInstanceOf(ScheduleIndexRangeException.class);
+        }
+
+        @ParameterizedTest
+        @DisplayName("최솟값보다 작은 인덱스 생성 -> ScheduleIndexRangeException")
+        @ValueSource(longs = {
+                -5_000_000_000_000_000_001L,
+                -5_000_000_000_000_000_002L,
+                -6_000_000_000_000_000_000L,
+                -7_000_000_000_000_000_000L,
+                -8_888_888_888_888_888_888L,
+                Long.MIN_VALUE})
+        public void when_create_with_too_small_index_then_it_throws_ScheduleIndexRangeException(long indexValue) {
+            assertThatThrownBy(() -> ScheduleIndex.of(indexValue))
+                    .isInstanceOf(ScheduleIndexRangeException.class);
+        }
+
+    }
+
+}


### PR DESCRIPTION
# JIRA 티켓
- [TRL-229]

---

# 작업 내역
- [x] Schedule에 순서 부여를 위한 값 타입 정의 -> `ScheduleIndex`
- [x] ScheduleIndex를 통해 다음에 새로 생성될 Index를 새로 생성하는 기능 추가
- [x] ScheduleIndex 필드 추가
- [x] 임시보관함 필드 추가

---

# 비고
- 일정 순서를 부여함에 따라 기존 기능들을 수정하기에는 PR의 덩어리가 너무 커짐
  - 일정 생성
  - 여행 기간 변경
- 실제로 일정의 순서를 각 기능별로 알맞게 부여하고, 이동시키는 부분은 이후 PR에서 기능별로 리팩터링하면서 보강함

[TRL-229]: https://cosain.atlassian.net/browse/TRL-229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ