### PR TITLE
[TRL-233] feat: 일정 생성 기능 확장(임시보관함 적용, 순서 부여)

### DIFF
--- a/src/main/java/com/cosain/trilo/trip/command/application/service/ScheduleCreateService.java
+++ b/src/main/java/com/cosain/trilo/trip/command/application/service/ScheduleCreateService.java
@@ -39,7 +39,9 @@ public class ScheduleCreateService implements ScheduleCreateUseCase {
     }
 
     private Day findDay(Long dayId){
-        return dayRepository.findById(dayId).orElseThrow(() -> new DayNotFoundException("Schedule을 Day에 넣으려고 했는데, 해당하는 Day가 존재하지 않음."));
+        return (dayId == null)
+                ? null
+                : dayRepository.findById(dayId).orElseThrow(() -> new DayNotFoundException("Schedule을 Day에 넣으려고 했는데, 해당하는 Day가 존재하지 않음."));
     }
 
     private Trip findTrip(Long tripId){

--- a/src/main/java/com/cosain/trilo/trip/command/domain/entity/Day.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/entity/Day.java
@@ -4,10 +4,7 @@ import com.cosain.trilo.trip.command.domain.vo.Place;
 import com.cosain.trilo.trip.command.domain.vo.ScheduleIndex;
 import com.cosain.trilo.trip.command.domain.vo.TripPeriod;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -34,18 +31,26 @@ public class Day {
 
     @OneToMany(mappedBy = "day")
     @OrderBy("scheduleIndex.value asc")
-    private List<Schedule> schedules = new ArrayList<>();
+    private final List<Schedule> schedules = new ArrayList<>();
 
     /**
      * 비즈니스 코드에서 Day 생성은 Trip 에서만 할 수 있다.
      */
-    public static Day of(LocalDate date, Trip trip){
-        return new Day(date, trip);
+    public static Day of(LocalDate tripDate, Trip trip){
+        return Day.builder()
+                .tripDate(tripDate)
+                .trip(trip)
+                .build();
     }
 
-    private Day(LocalDate date, Trip trip) {
-        this.tripDate = date;
+    @Builder(access = AccessLevel.PUBLIC)
+    private Day(Long id, LocalDate tripDate, Trip trip, List<Schedule> schedules) {
+        this.id = id;
+        this.tripDate = tripDate;
         this.trip = trip;
+        if (schedules != null) {
+            this.schedules.addAll(schedules);
+        }
     }
 
     /**

--- a/src/main/java/com/cosain/trilo/trip/command/domain/entity/Day.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/entity/Day.java
@@ -1,5 +1,7 @@
 package com.cosain.trilo.trip.command.domain.entity;
 
+import com.cosain.trilo.trip.command.domain.vo.Place;
+import com.cosain.trilo.trip.command.domain.vo.ScheduleIndex;
 import com.cosain.trilo.trip.command.domain.vo.TripPeriod;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -53,5 +55,17 @@ public class Day {
      */
     public boolean isIn(TripPeriod tripPeriod) {
         return tripPeriod.contains(tripDate);
+    }
+
+    public Schedule createSchedule(String title, Place place) {
+        Schedule schedule = Schedule.create(this, trip, title, place, generateNextScheduleIndex());
+        schedules.add(schedule);
+        return schedule;
+    }
+
+    private ScheduleIndex generateNextScheduleIndex() {
+        return (schedules.isEmpty())
+                ? ScheduleIndex.ZERO_INDEX
+                : schedules.get(schedules.size() - 1).getScheduleIndex().generateNextIndex();
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/command/domain/entity/Day.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/entity/Day.java
@@ -57,7 +57,7 @@ public class Day {
         return tripPeriod.contains(tripDate);
     }
 
-    public Schedule createSchedule(String title, Place place) {
+    Schedule createSchedule(String title, Place place) {
         Schedule schedule = Schedule.create(this, trip, title, place, generateNextScheduleIndex());
         schedules.add(schedule);
         return schedule;

--- a/src/main/java/com/cosain/trilo/trip/command/domain/entity/Schedule.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/entity/Schedule.java
@@ -40,7 +40,7 @@ public class Schedule {
     @Embedded
     private ScheduleIndex scheduleIndex;
 
-    public static Schedule create(Day day, Trip trip, String title, Place place, ScheduleIndex scheduleIndex) {
+    static Schedule create(Day day, Trip trip, String title, Place place, ScheduleIndex scheduleIndex) {
         return Schedule.builder()
                 .day(day)
                 .trip(trip)

--- a/src/main/java/com/cosain/trilo/trip/command/domain/entity/Trip.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/entity/Trip.java
@@ -2,6 +2,7 @@ package com.cosain.trilo.trip.command.domain.entity;
 
 import com.cosain.trilo.trip.command.domain.dto.ChangeTripPeriodResult;
 import com.cosain.trilo.trip.command.domain.exception.EmptyPeriodUpdateException;
+import com.cosain.trilo.trip.command.domain.exception.InvalidTripDayException;
 import com.cosain.trilo.trip.command.domain.vo.Place;
 import com.cosain.trilo.trip.command.domain.vo.ScheduleIndex;
 import com.cosain.trilo.trip.command.domain.vo.TripPeriod;
@@ -162,6 +163,10 @@ public class Trip {
     }
 
     private Schedule makeDaySchedule(Day day, String title, Place place) {
+        if (!this.id.equals(day.getTrip().id)) {
+            throw new InvalidTripDayException("해당 day는 Trip의 Day가 아님");
+        }
+
         return day.createSchedule(title, place);
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/command/domain/entity/Trip.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/entity/Trip.java
@@ -14,8 +14,6 @@ import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.Where;
 
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -147,6 +145,23 @@ public class Trip {
     }
 
     public Schedule createSchedule(Day day, String title, Place place) {
-        return Schedule.create(day, this, title, place, ScheduleIndex.of(LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)%1_000_000_000));
+        return (day == null)
+                ? makeTemporaryStorageSchedule(title, place)
+                : makeDaySchedule(day, title, place);
+    }
+    private Schedule makeTemporaryStorageSchedule(String title, Place place) {
+        Schedule schedule = Schedule.create(null, this, title, place, generateNextTemporaryStorageScheduleIndex());
+        temporaryStorage.add(schedule);
+        return schedule;
+    }
+
+    private ScheduleIndex generateNextTemporaryStorageScheduleIndex() {
+        return (temporaryStorage.isEmpty())
+                ? ScheduleIndex.ZERO_INDEX
+                : temporaryStorage.get(temporaryStorage.size() - 1).getScheduleIndex().generateNextIndex();
+    }
+
+    private Schedule makeDaySchedule(Day day, String title, Place place) {
+        return day.createSchedule(title, place);
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/command/domain/entity/Trip.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/entity/Trip.java
@@ -2,6 +2,8 @@ package com.cosain.trilo.trip.command.domain.entity;
 
 import com.cosain.trilo.trip.command.domain.dto.ChangeTripPeriodResult;
 import com.cosain.trilo.trip.command.domain.exception.EmptyPeriodUpdateException;
+import com.cosain.trilo.trip.command.domain.vo.Place;
+import com.cosain.trilo.trip.command.domain.vo.ScheduleIndex;
 import com.cosain.trilo.trip.command.domain.vo.TripPeriod;
 import com.cosain.trilo.trip.command.domain.vo.TripStatus;
 import jakarta.persistence.*;
@@ -12,6 +14,8 @@ import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.Where;
 
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -142,4 +146,7 @@ public class Trip {
         return newDays;
     }
 
+    public Schedule createSchedule(Day day, String title, Place place) {
+        return Schedule.create(day, this, title, place, ScheduleIndex.of(LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)%1_000_000_000));
+    }
 }

--- a/src/main/java/com/cosain/trilo/trip/command/domain/exception/InvalidTripDayException.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/exception/InvalidTripDayException.java
@@ -1,0 +1,35 @@
+package com.cosain.trilo.trip.command.domain.exception;
+
+import com.cosain.trilo.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidTripDayException extends CustomException {
+
+    private static final String ERROR_NAME = "InvalidTripDay";
+    private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+    public InvalidTripDayException() {
+    }
+
+    public InvalidTripDayException(String debugMessage) {
+        super(debugMessage);
+    }
+
+    public InvalidTripDayException(Throwable cause) {
+        super(cause);
+    }
+
+    public InvalidTripDayException(String debugMessage, Throwable cause) {
+        super(debugMessage, cause);
+    }
+
+    @Override
+    public String getErrorName() {
+        return ERROR_NAME;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HTTP_STATUS;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/command/domain/repository/ScheduleRepository.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/repository/ScheduleRepository.java
@@ -19,4 +19,15 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     @Query("DELETE FROM Schedule as s where s.trip.id = :tripId")
     void deleteAllByTripId(@Param("tripId") Long tripId);
 
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Schedule s " +
+            "SET s.scheduleIndex.value = (" +
+            "  SELECT COUNT(s2) " +
+            "  FROM Schedule s2 " +
+            "  WHERE (:dayId is not null AND s2.day.id = :dayId AND s2.scheduleIndex.value < s.scheduleIndex.value) " +
+            "        OR (:dayId is null AND s2.day is null AND s2.trip.id = :tripId AND s2.scheduleIndex.value < s.scheduleIndex.value) " +
+            ") * 10000000 " +
+            "WHERE s.trip.id = :tripId " +
+            "  AND ((:dayId is not null AND s.day.id = :dayId) OR (:dayId is null AND s.day is null))")
+    int relocateDaySchedules(@Param("tripId") Long tripId, @Param("dayId") Long dayId);
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/command/application/service/schedule/ScheduleCreateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/application/service/schedule/ScheduleCreateServiceTest.java
@@ -50,7 +50,7 @@ public class ScheduleCreateServiceTest {
         Long tripperId = 1L;
         Trip trip = Trip.create("제목", tripperId);
         Day day = Day.of(LocalDate.of(2023, 4, 5), trip);
-        Schedule schedule = Schedule.create(day, trip, "제목", Place.of("장소 식별자", "장소 이름", Coordinate.of(23.21, 23.24)), ScheduleIndex.of(1000));
+        Schedule schedule = trip.createSchedule(day, "제목", Place.of("장소 식별자", "장소 이름", Coordinate.of(23.21, 23.24)));
 
         ScheduleCreateCommand scheduleCreateCommand = ScheduleCreateCommand.of(1L, 1L, "제목", "내용", "장소 식별자", 23.21, 23.24);
         given(scheduleRepository.save(any(Schedule.class))).willReturn(schedule);

--- a/src/test/java/com/cosain/trilo/unit/trip/command/domain/entity/TripTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/domain/entity/TripTest.java
@@ -1,10 +1,11 @@
 package com.cosain.trilo.unit.trip.command.domain.entity;
 
 import com.cosain.trilo.trip.command.domain.entity.Day;
+import com.cosain.trilo.trip.command.domain.entity.Schedule;
 import com.cosain.trilo.trip.command.domain.entity.Trip;
 import com.cosain.trilo.trip.command.domain.exception.EmptyPeriodUpdateException;
-import com.cosain.trilo.trip.command.domain.vo.TripPeriod;
-import com.cosain.trilo.trip.command.domain.vo.TripStatus;
+import com.cosain.trilo.trip.command.domain.exception.ScheduleIndexRangeException;
+import com.cosain.trilo.trip.command.domain.vo.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -548,4 +549,92 @@ public class TripTest {
             }
         }
     }
+
+    @Nested
+    @DisplayName("CreateSchedule 테스트")
+    class CreateScheduleTest {
+
+        @DisplayName("임시보관함에 일정을 새로 추가할 경우")
+        @Nested
+        class Case_TemporaryStorage {
+
+            @DisplayName("인덱스가 최대 범위를 벗어나면, ScheduleIndexRangeException 발생")
+            @Test
+            public void when_new_index_range_is_over_max_index_value_then_it_throws_ScheduleIndexRangeException() {
+                Trip trip = Trip.create("여행 제목", 1L);
+
+                Schedule schedule1 = Schedule.builder()
+                        .day(null)
+                        .trip(trip)
+                        .title("일정 제목1")
+                        .place(Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)))
+                        .scheduleIndex(ScheduleIndex.of(ScheduleIndex.MAX_INDEX_VALUE))
+                        .build();
+
+                trip.getTemporaryStorage().add(schedule1); // 원래 이 방식을 통해 추가하는 것은 도메인 규칙에 어긋나지만 범위를 벗어나는 테스트를 하기 위함.
+
+                // when & then
+                assertThatThrownBy(() ->
+                        trip.createSchedule(null, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523))))
+                        .isInstanceOf(ScheduleIndexRangeException.class);
+            }
+
+            @DisplayName("인덱스가 최대 범위를 벗어나지 않으면, 정상적으로 다음 순서의 Schedule 생성됨")
+            @Test
+            public void successTest() {
+                Trip trip = Trip.create("여행 제목", 1L);
+
+                Schedule schedule1 = trip.createSchedule(null, "일정 제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(null, "일정 제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+
+                assertThat(schedule1.getScheduleIndex()).isEqualTo(ScheduleIndex.ZERO_INDEX);
+                assertThat(schedule2.getScheduleIndex()).isEqualTo(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP));
+            }
+        }
+
+        @DisplayName("특정 Day에 일정을 새로 추가할 경우")
+        @Nested
+        class Case_DaySchedule {
+
+            @DisplayName("인덱스가 최대 범위를 벗어나면, ScheduleIndexRangeException 발생")
+            @Test
+            public void when_new_index_range_is_over_max_index_value_then_it_throws_ScheduleIndexRangeException() {
+                Trip trip = Trip.create("여행 제목", 1L);
+                trip.changePeriod(TripPeriod.of(LocalDate.of(2023,3,1), LocalDate.of(2023, 3, 1)));
+
+                Day day = trip.getDays().get(0);
+
+                Schedule schedule1 = Schedule.builder()
+                        .day(day)
+                        .trip(trip)
+                        .title("일정 제목1")
+                        .place(Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)))
+                        .scheduleIndex(ScheduleIndex.of(ScheduleIndex.MAX_INDEX_VALUE))
+                        .build();
+
+                day.getSchedules().add(schedule1); // 원래 이 방식을 통해 추가하는 것은 도메인 규칙에 어긋나지만 범위를 벗어나는 테스트를 하기 위함.
+
+                // when & then
+                assertThatThrownBy(() ->
+                        trip.createSchedule(day, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523))))
+                        .isInstanceOf(ScheduleIndexRangeException.class);
+            }
+
+            @DisplayName("인덱스가 최대 범위를 벗어나지 않으면, 정상적으로 다음 순서의 Schedule 생성됨")
+            @Test
+            public void successTest() {
+                Trip trip = Trip.create("여행 제목", 1L);
+                trip.changePeriod(TripPeriod.of(LocalDate.of(2023,3,1), LocalDate.of(2023, 3, 1)));
+
+                Day day = trip.getDays().get(0);
+
+                Schedule schedule1 = trip.createSchedule(day, "일정 제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(day, "일정 제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+
+                assertThat(schedule1.getScheduleIndex()).isEqualTo(ScheduleIndex.ZERO_INDEX);
+                assertThat(schedule2.getScheduleIndex()).isEqualTo(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP));
+            }
+        }
+    }
+
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/command/domain/repository/ScheduleRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/domain/repository/ScheduleRepositoryTest.java
@@ -39,7 +39,7 @@ public class ScheduleRepositoryTest {
                 .tripperId(1L)
                 .title("여행 제목")
                 .status(TripStatus.DECIDED)
-                .tripPeriod(TripPeriod.of(LocalDate.of(2023,3,1), LocalDate.of(2023,3,1)))
+                .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
                 .build();
 
         em.persist(trip);
@@ -77,15 +77,15 @@ public class ScheduleRepositoryTest {
                 .tripperId(1L)
                 .title("여행 제목")
                 .status(TripStatus.DECIDED)
-                .tripPeriod(TripPeriod.of(LocalDate.of(2023,3,1), LocalDate.of(2023,3,1)))
+                .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
                 .build();
 
         em.persist(trip);
 
-        Day day = Day.of(LocalDate.of(2023,3,1), trip);
+        Day day = Day.of(LocalDate.of(2023, 3, 1), trip);
         em.persist(day);
 
-        Schedule schedule = Schedule.create(day, trip, "일정1", Place.of("place-id1", "광안리 해수욕장", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(1000));
+        Schedule schedule = trip.createSchedule(day, "일정1", Place.of("place-id1", "광안리 해수욕장", Coordinate.of(35.1551, 129.1220)));
         em.persist(schedule);
 
         // when
@@ -108,22 +108,22 @@ public class ScheduleRepositoryTest {
                 .tripperId(1L)
                 .title("여행 제목")
                 .status(TripStatus.DECIDED)
-                .tripPeriod(TripPeriod.of(LocalDate.of(2023,3,1), LocalDate.of(2023,3,3)))
+                .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 3)))
                 .build();
 
         em.persist(trip);
 
-        Day day1 = Day.of(LocalDate.of(2023,3,1), trip);
-        Day day2 = Day.of(LocalDate.of(2023,3,2), trip);
-        Day day3 = Day.of(LocalDate.of(2023,3,3), trip);
+        Day day1 = Day.of(LocalDate.of(2023, 3, 1), trip);
+        Day day2 = Day.of(LocalDate.of(2023, 3, 2), trip);
+        Day day3 = Day.of(LocalDate.of(2023, 3, 3), trip);
 
         em.persist(day1);
         em.persist(day2);
         em.persist(day3);
 
-        Schedule schedule1 = Schedule.create(day1, trip, "일정1", Place.of("place-id1", "광안리 해수욕장", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(1000));
-        Schedule schedule2 = Schedule.create(day2, trip, "일정2", Place.of("place-id2", "광화문 광장", Coordinate.of(37.5748, 126.9767)), ScheduleIndex.of(1000));
-        Schedule schedule3 = Schedule.create(day3, trip, "일정3", Place.of("place-id3", "도쿄 타워", Coordinate.of(35.3931, 139.4443)), ScheduleIndex.of(1000));
+        Schedule schedule1 = trip.createSchedule(day1, "일정1", Place.of("place-id1", "광안리 해수욕장", Coordinate.of(35.1551, 129.1220)));
+        Schedule schedule2 = trip.createSchedule(day2, "일정2", Place.of("place-id2", "광화문 광장", Coordinate.of(37.5748, 126.9767)));
+        Schedule schedule3 = trip.createSchedule(day3, "일정3", Place.of("place-id3", "도쿄 타워", Coordinate.of(35.3931, 139.4443)));
 
         em.persist(schedule1);
         em.persist(schedule2);
@@ -148,16 +148,16 @@ public class ScheduleRepositoryTest {
                 .tripperId(1L)
                 .title("여행 제목")
                 .status(TripStatus.DECIDED)
-                .tripPeriod(TripPeriod.of(LocalDate.of(2023,3,1), LocalDate.of(2023,3,1)))
+                .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
                 .build();
         em.persist(trip);
 
-        Day day = Day.of(LocalDate.of(2023,3,1), trip);
+        Day day = Day.of(LocalDate.of(2023, 3, 1), trip);
         em.persist(day);
 
-        Schedule schedule1 = Schedule.create(day, trip, "일정1", Place.of("place-id1", "광안리 해수욕장1", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(1000));
-        Schedule schedule2 = Schedule.create(day, trip, "일정2", Place.of("place-id2", "광안리 해수욕장2", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(2000));
-        Schedule schedule3 = Schedule.create(day, trip, "일정3", Place.of("place-id3", "광안리 해수욕장3", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(3000));
+        Schedule schedule1 = trip.createSchedule(day,  "일정1", Place.of("place-id1", "광안리 해수욕장1", Coordinate.of(35.1551, 129.1220)));
+        Schedule schedule2 = trip.createSchedule(day,  "일정2", Place.of("place-id2", "광안리 해수욕장2", Coordinate.of(35.1551, 129.1220)));
+        Schedule schedule3 = trip.createSchedule(day, "일정3", Place.of("place-id3", "광안리 해수욕장3", Coordinate.of(35.1551, 129.1220)));
 
         em.persist(schedule1);
         em.persist(schedule2);

--- a/src/test/java/com/cosain/trilo/unit/trip/command/domain/repository/ScheduleRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/domain/repository/ScheduleRepositoryTest.java
@@ -6,6 +6,7 @@ import com.cosain.trilo.trip.command.domain.entity.Trip;
 import com.cosain.trilo.trip.command.domain.repository.ScheduleRepository;
 import com.cosain.trilo.trip.command.domain.vo.*;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -155,8 +156,8 @@ public class ScheduleRepositoryTest {
         Day day = Day.of(LocalDate.of(2023, 3, 1), trip);
         em.persist(day);
 
-        Schedule schedule1 = trip.createSchedule(day,  "일정1", Place.of("place-id1", "광안리 해수욕장1", Coordinate.of(35.1551, 129.1220)));
-        Schedule schedule2 = trip.createSchedule(day,  "일정2", Place.of("place-id2", "광안리 해수욕장2", Coordinate.of(35.1551, 129.1220)));
+        Schedule schedule1 = trip.createSchedule(day, "일정1", Place.of("place-id1", "광안리 해수욕장1", Coordinate.of(35.1551, 129.1220)));
+        Schedule schedule2 = trip.createSchedule(day, "일정2", Place.of("place-id2", "광안리 해수욕장2", Coordinate.of(35.1551, 129.1220)));
         Schedule schedule3 = trip.createSchedule(day, "일정3", Place.of("place-id3", "광안리 해수욕장3", Coordinate.of(35.1551, 129.1220)));
 
         em.persist(schedule1);
@@ -175,4 +176,133 @@ public class ScheduleRepositoryTest {
         assertThat(findSchedule.getPlace()).isEqualTo(schedule2.getPlace());
     }
 
+
+    @Nested
+    @DisplayName("relocateSchedules 테스트")
+    class RelocateSchedulesTest {
+
+        @DisplayName("임시보관함의 일정 재갱신 -> 임시보관함만 재갱신됨")
+        @Test
+        void relocateTemporaryStorage() {
+            // given
+            Trip trip = Trip.builder()
+                    .tripperId(1L)
+                    .title("여행 제목")
+                    .status(TripStatus.DECIDED)
+                    .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
+                    .build();
+
+            em.persist(trip);
+
+            Day day1 = Day.of(LocalDate.of(2023, 3, 1), trip);
+            Day day2 = Day.of(LocalDate.of(2023, 3, 1), trip);
+
+            em.persist(day1);
+            em.persist(day2);
+
+            Schedule schedule1 = buildDummySchedule(trip, null, "일정제목1", Place.of("place-id1", "광안리 해수욕장1", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(7));
+            Schedule schedule2 = buildDummySchedule(trip, null, "일정제목2", Place.of("place-id2", "광안리 해수욕장2", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(-1));
+            Schedule schedule3 = buildDummySchedule(trip, null, "일정제목3", Place.of("place-id3", "광안리 해수욕장3", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(5));
+            Schedule schedule4 = buildDummySchedule(trip, day1, "일정제목4", Place.of("place-id4", "광안리 해수욕장4", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(7));
+            Schedule schedule5 = buildDummySchedule(trip, day1, "일정제목5", Place.of("place-id5", "광안리 해수욕장5", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(-1));
+            Schedule schedule6 = buildDummySchedule(trip, day1, "일정제목6", Place.of("place-id6", "광안리 해수욕장6", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(5));
+            Schedule schedule7 = buildDummySchedule(trip, day2, "일정제목7", Place.of("place-id7", "광안리 해수욕장7", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(7));
+            Schedule schedule8 = buildDummySchedule(trip, day2, "일정제목8", Place.of("place-id8", "광안리 해수욕장8", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(-1));
+            Schedule schedule9 = buildDummySchedule(trip, day2, "일정제목9", Place.of("place-id9", "광안리 해수욕장9", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(5));
+
+            em.persist(schedule1);
+            em.persist(schedule2);
+            em.persist(schedule3);
+            em.persist(schedule4);
+            em.persist(schedule5);
+            em.persist(schedule6);
+            em.persist(schedule7);
+            em.persist(schedule8);
+            em.persist(schedule9);
+
+
+            // when
+            int affectedRowCount = scheduleRepository.relocateDaySchedules(trip.getId(), null);
+
+            // then
+            List<Schedule> schedules = scheduleRepository.findAllById(
+                    List.of(schedule1.getId(), schedule2.getId(), schedule3.getId(),
+                            schedule4.getId(), schedule5.getId(), schedule6.getId(),
+                            schedule7.getId(), schedule8.getId(), schedule9.getId()));
+
+            assertThat(affectedRowCount).isEqualTo(3);
+            assertThat(schedules).map(Schedule::getScheduleIndex)
+                    .containsExactly(
+                            ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP * 2), ScheduleIndex.ZERO_INDEX, ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP),
+                            ScheduleIndex.of(7), ScheduleIndex.of(-1), ScheduleIndex.of(5),
+                            ScheduleIndex.of(7), ScheduleIndex.of(-1), ScheduleIndex.of(5)
+                    );
+        }
+
+        @DisplayName("day의 일정 재갱신 -> 해당 day만 재갱신됨")
+        @Test
+        void relocateDaySchedules() {
+            // given
+            Trip trip = Trip.builder()
+                    .tripperId(1L)
+                    .title("여행 제목")
+                    .status(TripStatus.DECIDED)
+                    .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)))
+                    .build();
+
+            em.persist(trip);
+
+            Day day1 = Day.of(LocalDate.of(2023, 3, 1), trip);
+            Day day2 = Day.of(LocalDate.of(2023, 3, 2), trip);
+
+            em.persist(day1);
+            em.persist(day2);
+
+            Schedule schedule1 = buildDummySchedule(trip, null, "일정제목1", Place.of("place-id1", "광안리 해수욕장1", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(7));
+            Schedule schedule2 = buildDummySchedule(trip, null, "일정제목2", Place.of("place-id2", "광안리 해수욕장2", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(-1));
+            Schedule schedule3 = buildDummySchedule(trip, null, "일정제목3", Place.of("place-id3", "광안리 해수욕장3", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(5));
+            Schedule schedule4 = buildDummySchedule(trip, day1, "일정제목4", Place.of("place-id4", "광안리 해수욕장4", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(7));
+            Schedule schedule5 = buildDummySchedule(trip, day1, "일정제목5", Place.of("place-id5", "광안리 해수욕장5", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(-1));
+            Schedule schedule6 = buildDummySchedule(trip, day1, "일정제목6", Place.of("place-id6", "광안리 해수욕장6", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(5));
+            Schedule schedule7 = buildDummySchedule(trip, day2, "일정제목7", Place.of("place-id7", "광안리 해수욕장7", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(7));
+            Schedule schedule8 = buildDummySchedule(trip, day2, "일정제목8", Place.of("place-id8", "광안리 해수욕장8", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(-1));
+            Schedule schedule9 = buildDummySchedule(trip, day2, "일정제목9", Place.of("place-id9", "광안리 해수욕장9", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(5));
+
+            em.persist(schedule1);
+            em.persist(schedule2);
+            em.persist(schedule3);
+            em.persist(schedule4);
+            em.persist(schedule5);
+            em.persist(schedule6);
+            em.persist(schedule7);
+            em.persist(schedule8);
+            em.persist(schedule9);
+
+            // when
+            int affectedRowCount = scheduleRepository.relocateDaySchedules(trip.getId(), day1.getId());
+
+            // then
+            List<Schedule> schedules = scheduleRepository.findAllById(
+                    List.of(schedule1.getId(), schedule2.getId(), schedule3.getId(),
+                            schedule4.getId(), schedule5.getId(), schedule6.getId(),
+                            schedule7.getId(), schedule8.getId(), schedule9.getId()));
+
+            assertThat(affectedRowCount).isEqualTo(3);
+            assertThat(schedules).map(Schedule::getScheduleIndex)
+                    .containsExactly(
+                            ScheduleIndex.of(7), ScheduleIndex.of(-1), ScheduleIndex.of(5),
+                            ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP * 2), ScheduleIndex.ZERO_INDEX, ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP),
+                            ScheduleIndex.of(7), ScheduleIndex.of(-1), ScheduleIndex.of(5)
+                    );
+        }
+        private Schedule buildDummySchedule(Trip trip, Day day, String title, Place place, ScheduleIndex scheduleIndex) {
+            return Schedule.builder()
+                    .day(day)
+                    .trip(trip)
+                    .title(title)
+                    .place(place)
+                    .scheduleIndex(scheduleIndex)
+                    .build();
+        }
+    }
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/command/domain/repository/TripRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/domain/repository/TripRepositoryTest.java
@@ -55,9 +55,30 @@ public class TripRepositoryTest {
             Trip trip = Trip.create("제목", 1L);
             tripRepository.save(trip);
 
-            Schedule schedule1 = Schedule.create(null, trip, "일정1", Place.of("place-id1", "광안리 해수욕장111", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(3000L));
-            Schedule schedule2 = Schedule.create(null, trip, "일정2", Place.of("place-id2", "광안리 해수욕장222", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(5000L));
-            Schedule schedule3 = Schedule.create(null, trip, "일정3", Place.of("place-id3", "광안리 해수욕장333", Coordinate.of(35.1551, 129.1220)), ScheduleIndex.of(-1000L));
+            Schedule schedule1 = Schedule.builder()
+                    .day(null)
+                    .trip(trip)
+                    .title("일정1")
+                    .place(Place.of("place-id1", "광안리 해수욕장111", Coordinate.of(35.1551, 129.1220)))
+                    .scheduleIndex(ScheduleIndex.of(30_000_000L))
+                    .build();
+
+            Schedule schedule2 = Schedule.builder()
+                    .day(null)
+                    .trip(trip)
+                    .title("일정2")
+                    .place(Place.of("place-id2", "광안리 해수욕장222", Coordinate.of(35.1551, 129.1220)))
+                    .scheduleIndex(ScheduleIndex.of(50_000_000L))
+                    .build();
+
+
+            Schedule schedule3 = Schedule.builder()
+                    .day(null)
+                    .trip(trip)
+                    .title("일정3")
+                    .place(Place.of("place-id3", "광안리 해수욕장333", Coordinate.of(35.1551, 129.1220)))
+                    .scheduleIndex(ScheduleIndex.of(-10_000_000L))
+                    .build();
 
             em.persist(schedule1);
             em.persist(schedule2);
@@ -71,7 +92,7 @@ public class TripRepositoryTest {
 
             // then
             assertThat(temporaryStorage).map(Schedule::getScheduleIndex)
-                    .containsExactly(ScheduleIndex.of(-1000L), ScheduleIndex.of(3000L), ScheduleIndex.of(5000L));
+                    .containsExactly(ScheduleIndex.of(-10_000_000L), ScheduleIndex.of(30_000_000L), ScheduleIndex.of(50_000_000L));
         }
     }
 


### PR DESCRIPTION
# JIRA 티켓
- [TRL-233]

---

# 작업 내역
- [x] Schedule 생성의 책임을 Trip에게 위임
  - [x] day가 null일 경우, Trip의 임시보관함에 추가하도록 하기
  - [x] day가 null이 아닐 경우 해당 Day에 위임하여 Schedule을 생성하도록 하기
- [x] 생성된 Schedule에 순서 부여하기(기존의 인덱스 뒤에 일정 간격을 두면서 추가하기)
- [x] Day 또는 Trip의 임시보관함이 가진 일정들의 인덱스 재배치 쿼리 작성
- [x] Schedule 추가 시 최대 범위를 벗어날 경우, 해당 Day 또는 임시보관함에 속한 Schedule들의 인덱스를 전체 재배치 시키고 다시 작업하도록 하기
- [x] (추가) 기존에 day가 Trip에 속해있는 경우를 가정했는데, 만약 사용자가 엉뚱한 DayId를 보내서 Schedule을 생성하려고하면 방어가 안 되어있는 부분 방어로직 추가

---


[TRL-233]: https://cosain.atlassian.net/browse/TRL-233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ