### PR TITLE
[TRL-118] feat: 특정 사용자 여행 목록 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ out/
 
 ### HTML 문서 ###
 src/main/resources/static/docs/*.html
+
+# Ignore generated files
+src/main/generated/

--- a/src/main/java/com/cosain/trilo/trip/query/application/exception/TripperNotFoundException.java
+++ b/src/main/java/com/cosain/trilo/trip/query/application/exception/TripperNotFoundException.java
@@ -1,0 +1,34 @@
+package com.cosain.trilo.trip.query.application.exception;
+
+import com.cosain.trilo.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class TripperNotFoundException extends CustomException {
+
+    private static final String ERROR_NAME = "TripperNotFound";
+    private static final HttpStatus HTTP_STATUS = HttpStatus.NOT_FOUND;
+
+    public TripperNotFoundException() {}
+
+    public TripperNotFoundException(String debugMessage) {
+        super(debugMessage);
+    }
+
+    public TripperNotFoundException(Throwable cause) {
+        super(cause);
+    }
+
+    public TripperNotFoundException(String debugMessage, Throwable cause) {
+        super(debugMessage, cause);
+    }
+
+    @Override
+    public String getErrorName() {
+        return ERROR_NAME;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HTTP_STATUS;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/query/application/service/TripListSearchService.java
+++ b/src/main/java/com/cosain/trilo/trip/query/application/service/TripListSearchService.java
@@ -1,0 +1,51 @@
+package com.cosain.trilo.trip.query.application.service;
+
+import com.cosain.trilo.trip.query.application.exception.TripperNotFoundException;
+import com.cosain.trilo.trip.query.application.usecase.TripListSearchUseCase;
+import com.cosain.trilo.trip.query.domain.repository.TripQueryRepository;
+import com.cosain.trilo.trip.query.infra.dto.TripDetail;
+import com.cosain.trilo.trip.query.presentation.trip.dto.TripDetailResponse;
+import com.cosain.trilo.trip.query.presentation.trip.dto.TripPageResponse;
+import com.cosain.trilo.user.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class TripListSearchService implements TripListSearchUseCase {
+
+    private final TripQueryRepository tripQueryRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public TripPageResponse searchTripDetails(Long tripperId, Pageable pageable) {
+
+        verifyTripperExists(tripperId);
+        Slice<TripDetail> tripDetailList = findTripDetailList(tripperId, pageable);
+        return TripPageResponse.of(mapToTripDetailResponse(tripDetailList), tripDetailList.hasNext());
+    }
+
+    private void verifyTripperExists(Long tripperId){
+        userRepository.findById(tripperId).orElseThrow(TripperNotFoundException::new);
+    }
+
+    private Slice<TripDetail> findTripDetailList(Long tripperId, Pageable pageable){
+        return tripQueryRepository.findTripDetailListByTripperId(tripperId, pageable);
+    }
+
+    private List<TripDetailResponse> mapToTripDetailResponse(Slice<TripDetail> tripDetailList){
+        return tripDetailList.getContent()
+                .stream()
+                .map(tripDetail -> TripDetailResponse.of(tripDetail.getId(), tripDetail.getTitle(), tripDetail.getStatus(), tripDetail.getStartDate(), tripDetail.getEndDate()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/query/application/usecase/TripListSearchUseCase.java
+++ b/src/main/java/com/cosain/trilo/trip/query/application/usecase/TripListSearchUseCase.java
@@ -1,0 +1,8 @@
+package com.cosain.trilo.trip.query.application.usecase;
+
+import com.cosain.trilo.trip.query.presentation.trip.dto.TripPageResponse;
+import org.springframework.data.domain.Pageable;
+
+public interface TripListSearchUseCase {
+    TripPageResponse searchTripDetails(Long tripperId, Pageable pageable);
+}

--- a/src/main/java/com/cosain/trilo/trip/query/domain/repository/TripQueryRepository.java
+++ b/src/main/java/com/cosain/trilo/trip/query/domain/repository/TripQueryRepository.java
@@ -1,9 +1,13 @@
 package com.cosain.trilo.trip.query.domain.repository;
 
 import com.cosain.trilo.trip.query.infra.dto.TripDetail;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 import java.util.Optional;
 
 public interface TripQueryRepository {
     Optional<TripDetail> findTripDetailByTripId(Long tripId);
+
+    Slice<TripDetail> findTripDetailListByTripperId(Long tripperId, Pageable pageable);
 }

--- a/src/main/java/com/cosain/trilo/trip/query/infra/repository/trip/TripQueryRepositoryImpl.java
+++ b/src/main/java/com/cosain/trilo/trip/query/infra/repository/trip/TripQueryRepositoryImpl.java
@@ -4,6 +4,8 @@ import com.cosain.trilo.trip.query.domain.repository.TripQueryRepository;
 import com.cosain.trilo.trip.query.infra.dto.TripDetail;
 import com.cosain.trilo.trip.query.infra.repository.trip.jpa.TripQueryJpaRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -17,5 +19,10 @@ public class TripQueryRepositoryImpl implements TripQueryRepository {
     @Override
     public Optional<TripDetail> findTripDetailByTripId(Long tripId) {
         return tripQueryJpaRepository.findTripDetailById(tripId);
+    }
+
+    @Override
+    public Slice<TripDetail> findTripDetailListByTripperId(Long tripperId, Pageable pageable) {
+        return tripQueryJpaRepository.findTripDetailListByTripperId(tripperId, pageable);
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/query/infra/repository/trip/jpa/TripQueryJpaRepositoryCustom.java
+++ b/src/main/java/com/cosain/trilo/trip/query/infra/repository/trip/jpa/TripQueryJpaRepositoryCustom.java
@@ -1,9 +1,13 @@
 package com.cosain.trilo.trip.query.infra.repository.trip.jpa;
 
 import com.cosain.trilo.trip.query.infra.dto.TripDetail;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 import java.util.Optional;
 
 public interface TripQueryJpaRepositoryCustom {
     Optional<TripDetail> findTripDetailById(Long tripId);
+
+    Slice<TripDetail> findTripDetailListByTripperId(Long tripperId, Pageable pageable);
 }

--- a/src/main/java/com/cosain/trilo/trip/query/infra/repository/trip/jpa/TripQueryJpaRepositoryImpl.java
+++ b/src/main/java/com/cosain/trilo/trip/query/infra/repository/trip/jpa/TripQueryJpaRepositoryImpl.java
@@ -2,8 +2,12 @@ package com.cosain.trilo.trip.query.infra.repository.trip.jpa;
 
 import com.cosain.trilo.trip.query.infra.dto.QTripDetail;
 import com.cosain.trilo.trip.query.infra.dto.TripDetail;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 import java.util.Optional;
 
@@ -30,5 +34,21 @@ public class TripQueryJpaRepositoryImpl implements TripQueryJpaRepositoryCustom{
                 .from(trip)
                 .where(trip.id.eq(tripId))
                 .fetchOne());
+    }
+
+    @Override
+    public Slice<TripDetail> findTripDetailListByTripperId(Long tripperId, Pageable pageable) {
+        JPAQuery<TripDetail> jpaQuery = query.select(new QTripDetail(trip.id, trip.tripperId, trip.title, trip.status, trip.tripPeriod.startDate, trip.tripPeriod.endDate))
+                .from(trip)
+                .where(trip.tripperId.eq(tripperId))
+                .orderBy(trip.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+
+        long totalCount = query.from(trip)
+                .where(trip.tripperId.eq(tripperId))
+                .fetchCount();
+
+        return new PageImpl<>(jpaQuery.fetch(), pageable, totalCount);
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/query/presentation/trip/TripperTripListQueryController.java
+++ b/src/main/java/com/cosain/trilo/trip/query/presentation/trip/TripperTripListQueryController.java
@@ -1,23 +1,25 @@
 package com.cosain.trilo.trip.query.presentation.trip;
 
-import com.cosain.trilo.common.exception.NotImplementedException;
+import com.cosain.trilo.trip.query.application.usecase.TripListSearchUseCase;
+import com.cosain.trilo.trip.query.presentation.trip.dto.TripPageResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * TODO: 특정 사용자 여행 목록
- */
 @Slf4j
 @RestController
+@RequiredArgsConstructor
 public class TripperTripListQueryController {
 
+    private final TripListSearchUseCase tripListSearchUseCase;
     @GetMapping("/api/trips")
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-    public String findTripperTripList(@RequestParam("tripper-id") Long tripperId) {
-        throw new NotImplementedException("특정 사용자 여행 목록 미구현");
+    @ResponseStatus(HttpStatus.OK)
+    public TripPageResponse findTripperTripList(@RequestParam("tripper-id") Long tripperId, Pageable pageable) {
+        return tripListSearchUseCase.searchTripDetails(tripperId, pageable);
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/query/presentation/trip/dto/TripPageResponse.java
+++ b/src/main/java/com/cosain/trilo/trip/query/presentation/trip/dto/TripPageResponse.java
@@ -1,0 +1,23 @@
+package com.cosain.trilo.trip.query.presentation.trip.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class TripPageResponse {
+
+    private final boolean hasNext;
+    private final List<TripDetailResponse> trips;
+
+    public static TripPageResponse of(final List<TripDetailResponse> trips, final boolean hasNext){
+        return new TripPageResponse(trips, hasNext);
+    }
+
+    private TripPageResponse(final List<TripDetailResponse> trips, final boolean hasNext){
+        this.hasNext = hasNext;
+        this.trips = trips;
+    }
+
+
+}

--- a/src/test/java/com/cosain/trilo/unit/trip/query/application/TripListSearchServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/query/application/TripListSearchServiceTest.java
@@ -1,0 +1,80 @@
+package com.cosain.trilo.unit.trip.query.application;
+
+import com.cosain.trilo.trip.command.domain.vo.TripStatus;
+import com.cosain.trilo.trip.query.application.exception.TripperNotFoundException;
+import com.cosain.trilo.trip.query.application.service.TripListSearchService;
+import com.cosain.trilo.trip.query.domain.repository.TripQueryRepository;
+import com.cosain.trilo.trip.query.infra.dto.TripDetail;
+import com.cosain.trilo.trip.query.presentation.trip.dto.TripPageResponse;
+import com.cosain.trilo.user.domain.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static com.cosain.trilo.fixture.UserFixture.KAKAO_MEMBER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class TripListSearchServiceTest {
+    @InjectMocks
+    private TripListSearchService tripListSearchService;
+
+    @Mock
+    private TripQueryRepository tripQueryRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("정상 호출 시에 호출 및 반환 테스트")
+    void searchTripDetailsTest(){
+        // given
+        Long tripperId = 1L;
+        Pageable pageable = PageRequest.of(0, 10);
+        TripDetail tripDetail1 = new TripDetail(1L, tripperId, "여행 1", TripStatus.DECIDED, LocalDate.now(), LocalDate.now());
+        TripDetail tripDetail2 = new TripDetail(2L, tripperId, "여행 2", TripStatus.UNDECIDED, LocalDate.now(), LocalDate.now());
+        Slice<TripDetail> tripDetailSlice = new PageImpl<>(List.of(tripDetail1, tripDetail2), pageable, 2L);
+
+        given(userRepository.findById(eq(1L))).willReturn(Optional.of(KAKAO_MEMBER.create()));
+        given(tripQueryRepository.findTripDetailListByTripperId(tripperId, pageable)).willReturn(tripDetailSlice);
+
+        // when
+        TripPageResponse tripPageResponse = tripListSearchService.searchTripDetails(tripperId, pageable);
+
+        // then
+        assertThat(tripPageResponse).isNotNull();
+        assertThat(tripPageResponse.getTrips()).hasSize(2);
+        assertThat(tripPageResponse.getTrips().get(0).getTitle()).isEqualTo(tripDetail1.getTitle());
+        assertThat(tripPageResponse.getTrips().get(1).getTitle()).isEqualTo(tripDetail2.getTitle());
+        assertThat(tripPageResponse.isHasNext()).isFalse();
+
+    }
+
+    @Test
+    @DisplayName("tripperId에 해당하는 사용자가 존재하지 않으면 TripperNotFoundException 에러를 반환한다.")
+    void when_the_user_is_not_exist_that_coincide_with_tripper_id_it_will_throws_TripperNotFoundException(){
+        // given
+        Long tripperId = 1L;
+        Pageable pageable = PageRequest.of(0, 10);
+        given(userRepository.findById(tripperId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> tripListSearchService.searchTripDetails(tripperId, pageable)).isInstanceOf(TripperNotFoundException.class);
+
+    }
+
+}

--- a/src/test/java/com/cosain/trilo/unit/trip/query/infra/repository/TripQueryRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/query/infra/repository/TripQueryRepositoryTest.java
@@ -8,8 +8,11 @@ import com.cosain.trilo.trip.query.domain.repository.TripQueryRepository;
 import com.cosain.trilo.trip.query.infra.dto.TripDetail;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 
 import java.time.LocalDate;
 
@@ -47,4 +50,74 @@ public class TripQueryRepositoryTest {
         assertThat(tripDetail.getEndDate()).isEqualTo(trip.getTripPeriod().getEndDate());
         assertThat(tripDetail.getStatus()).isEqualTo(trip.getStatus().name());
     }
+
+    @Nested
+    @DisplayName("사용자의 여행 목록을 조회 하면")
+    class findTripDetailListByTripperIdTest{
+
+        @Test
+        @DisplayName("여행의 TipperId가 일치하는 여행들이 요청된 페이지의 크기만큼 조회된다")
+        void findTest(){
+            // given
+            Trip trip1 = Trip.builder()
+                    .tripperId(1L)
+                    .title("제목 1")
+                    .status(TripStatus.DECIDED)
+                    .tripPeriod(TripPeriod.of(LocalDate.of(2023, 5, 5), LocalDate.of(2023, 5, 10)))
+                    .build();
+
+            Trip trip2 = Trip.builder()
+                    .tripperId(1L)
+                    .title("제목 2")
+                    .status(TripStatus.DECIDED)
+                    .tripPeriod(TripPeriod.of(LocalDate.of(2023, 5, 5), LocalDate.of(2023, 5, 10)))
+                    .build();
+
+
+            em.persist(trip1);
+            em.persist(trip2);
+
+            // when
+            Slice<TripDetail> tripDetailSlice = tripQueryRepository.findTripDetailListByTripperId(1L, PageRequest.of(0, 2));
+
+            // then
+            assertThat(tripDetailSlice.getContent().size()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("가장 최근에 생성된 여행 순으로 조회된다")
+        void sortTest(){
+            // given
+            Trip trip1 = Trip.builder()
+                    .tripperId(1L)
+                    .title("제목 1")
+                    .status(TripStatus.DECIDED)
+                    .tripPeriod(TripPeriod.of(LocalDate.of(2023, 5, 5), LocalDate.of(2023, 5, 10)))
+                    .build();
+
+            Trip trip2 = Trip.builder()
+                    .tripperId(1L)
+                    .title("제목 2")
+                    .status(TripStatus.DECIDED)
+                    .tripPeriod(TripPeriod.of(LocalDate.of(2023, 5, 5), LocalDate.of(2023, 5, 10)))
+                    .build();
+
+
+            em.persist(trip1);
+            em.persist(trip2);
+
+            // when
+            Slice<TripDetail> tripDetailSlice = tripQueryRepository.findTripDetailListByTripperId(1L, PageRequest.of(0, 2));
+
+
+            // then
+            assertThat(tripDetailSlice.getContent().get(0).getTitle()).isEqualTo(trip2.getTitle());
+            assertThat(tripDetailSlice.getContent().get(1).getTitle()).isEqualTo(trip1.getTitle());
+
+        }
+
+
+    }
+
+
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/query/presentation/api/trip/TripperTripListQueryControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/query/presentation/api/trip/TripperTripListQueryControllerTest.java
@@ -2,13 +2,26 @@ package com.cosain.trilo.unit.trip.query.presentation.api.trip;
 
 
 import com.cosain.trilo.support.RestControllerTest;
+import com.cosain.trilo.trip.query.application.usecase.TripListSearchUseCase;
 import com.cosain.trilo.trip.query.presentation.trip.TripperTripListQueryController;
+import com.cosain.trilo.trip.query.presentation.trip.dto.TripDetailResponse;
+import com.cosain.trilo.trip.query.presentation.trip.dto.TripPageResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithAnonymousUser;
-import org.springframework.security.test.context.support.WithMockUser;
 
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -18,15 +31,29 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(TripperTripListQueryController.class)
 class TripperTripListQueryControllerTest extends RestControllerTest {
 
+    @MockBean
+    private TripListSearchUseCase tripListSearchUseCase;
+    private final String ACCESS_TOKEN = "Bearer accessToken";
+
+
     @Test
-    @DisplayName("인증된 사용자 요청 -> 미구현 500")
-    @WithMockUser
+    @DisplayName("인증된 사용자 요청 -> 회원 여행 목록 조회")
     public void findTripperTripList_with_authorizedUser() throws Exception {
-        mockMvc.perform(get("/api/trips?tripper-id=1"))
-                .andDo(print())
-                .andExpect(status().isInternalServerError())
-                .andExpect(jsonPath("$.errorCode").exists())
-                .andExpect(jsonPath("$.errorMessage").exists());
+
+        mockingForLoginUserAnnotation();
+        TripDetailResponse dto1 = TripDetailResponse.of(1L, "여행 제목 1", "DECIDED", LocalDate.of(2023, 5, 10), LocalDate.of(2023, 5, 15));
+        TripDetailResponse dto2 = TripDetailResponse.of(134L, "여행 제목 2", "DECIDED", LocalDate.of(2023, 5, 10), LocalDate.of(2023, 5, 15));
+        TripDetailResponse dto3 = TripDetailResponse.of(1423L, "여행 제목 3", "DECIDED", LocalDate.of(2023, 5, 10), LocalDate.of(2023, 5, 15));
+        TripPageResponse tripPageResponse = TripPageResponse.of(List.of(dto1, dto2, dto3), true);
+        given(tripListSearchUseCase.searchTripDetails(eq(1L), any(Pageable.class))).willReturn(tripPageResponse);
+
+        mockMvc.perform(get("/api/trips?tripper-id=1")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpectAll(status().isOk())
+                .andExpect(jsonPath("$.hasNext").value(true))
+                .andExpect(jsonPath("$.trips").isNotEmpty());
     }
 
     @Test


### PR DESCRIPTION
# JIRA 티켓
[TRL-118]

# 작업 내역
- [x] 여행 목록 조회 Repository 구현 및 테스트
- [x] 여행 목록 조회 응용 서비스 계층 구현 및 테스트
- [x] 여행 목록 조회 표현 계층 구현 및 테스트

# 추가사항

- nGrinder 를 활용해서 부하 테스트를 진행하여,, 필요 시 쿼리 튜닝 및 INDEX 적용하여 성능 개선할 계획입니다.
- 저장소 청결성 유지를 위해 Q class 이 위치한 디렉토리를 버전 관리에서 제외하였습니다.

[TRL-118]: https://cosain.atlassian.net/browse/TRL-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ