### PR TITLE
[TRL-213] feat: 일정 이동 API 구현

### DIFF
--- a/src/main/java/com/cosain/trilo/trip/command/application/command/ScheduleMoveCommand.java
+++ b/src/main/java/com/cosain/trilo/trip/command/application/command/ScheduleMoveCommand.java
@@ -1,0 +1,19 @@
+package com.cosain.trilo.trip.command.application.command;
+
+import lombok.Getter;
+
+@Getter
+public class ScheduleMoveCommand {
+
+    private Long targetDayId;
+    private int targetOrder;
+
+    public static ScheduleMoveCommand of(Long targetDayId, int targetOrder) {
+        return new ScheduleMoveCommand(targetDayId, targetOrder);
+    }
+
+    private ScheduleMoveCommand(Long targetDayId, int targetOrder) {
+        this.targetDayId = targetDayId;
+        this.targetOrder = targetOrder;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/command/application/exception/NoScheduleMoveAuthorityException.java
+++ b/src/main/java/com/cosain/trilo/trip/command/application/exception/NoScheduleMoveAuthorityException.java
@@ -1,0 +1,35 @@
+package com.cosain.trilo.trip.command.application.exception;
+
+import com.cosain.trilo.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class NoScheduleMoveAuthorityException extends CustomException {
+
+    private static final String ERROR_NAME = "NoScheduleUpdateAuthorityException";
+    private static final HttpStatus HTTP_STATUS = HttpStatus.FORBIDDEN;
+
+    public NoScheduleMoveAuthorityException() {
+    }
+
+    public NoScheduleMoveAuthorityException(String debugMessage) {
+        super(debugMessage);
+    }
+
+    public NoScheduleMoveAuthorityException(Throwable cause) {
+        super(cause);
+    }
+
+    public NoScheduleMoveAuthorityException(String debugMessage, Throwable cause) {
+        super(debugMessage, cause);
+    }
+
+    @Override
+    public String getErrorName() {
+        return ERROR_NAME;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HTTP_STATUS;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/command/application/result/ScheduleMoveResult.java
+++ b/src/main/java/com/cosain/trilo/trip/command/application/result/ScheduleMoveResult.java
@@ -1,0 +1,32 @@
+package com.cosain.trilo.trip.command.application.result;
+
+import com.cosain.trilo.trip.command.domain.dto.ScheduleMoveDto;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ScheduleMoveResult {
+
+    private Long scheduleId;
+    private Long beforeDayId;
+    private Long afterDayId;
+    private boolean positionChanged;
+
+    public static ScheduleMoveResult from(ScheduleMoveDto dto) {
+        return ScheduleMoveResult.builder()
+                .scheduleId(dto.getScheduleId())
+                .beforeDayId(dto.getBeforeDayId())
+                .afterDayId(dto.getAfterDayId())
+                .positionChanged(dto.isPositionChanged())
+                .build();
+    }
+
+    @Builder(access = AccessLevel.PUBLIC)
+    private ScheduleMoveResult(Long scheduleId, Long beforeDayId, Long afterDayId, boolean positionChanged) {
+        this.scheduleId = scheduleId;
+        this.beforeDayId = beforeDayId;
+        this.afterDayId = afterDayId;
+        this.positionChanged = positionChanged;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/command/application/result/ScheduleMoveResult.java
+++ b/src/main/java/com/cosain/trilo/trip/command/application/result/ScheduleMoveResult.java
@@ -22,6 +22,9 @@ public class ScheduleMoveResult {
                 .build();
     }
 
+    /**
+     * 테스트의 편의성을 위해 Builder accessLevel = PUBLIC 으로 설정
+     */
     @Builder(access = AccessLevel.PUBLIC)
     private ScheduleMoveResult(Long scheduleId, Long beforeDayId, Long afterDayId, boolean positionChanged) {
         this.scheduleId = scheduleId;

--- a/src/main/java/com/cosain/trilo/trip/command/application/service/ScheduleMoveService.java
+++ b/src/main/java/com/cosain/trilo/trip/command/application/service/ScheduleMoveService.java
@@ -1,0 +1,14 @@
+package com.cosain.trilo.trip.command.application.service;
+
+import com.cosain.trilo.trip.command.application.command.ScheduleMoveCommand;
+import com.cosain.trilo.trip.command.application.usecase.ScheduleMoveUseCase;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ScheduleMoveService implements ScheduleMoveUseCase {
+
+    @Override
+    public void moveSchedule(Long scheduleId, Long moveTripperId, ScheduleMoveCommand moveCommand) {
+    }
+
+}

--- a/src/main/java/com/cosain/trilo/trip/command/application/service/ScheduleMoveService.java
+++ b/src/main/java/com/cosain/trilo/trip/command/application/service/ScheduleMoveService.java
@@ -1,14 +1,67 @@
 package com.cosain.trilo.trip.command.application.service;
 
 import com.cosain.trilo.trip.command.application.command.ScheduleMoveCommand;
+import com.cosain.trilo.trip.command.application.exception.DayNotFoundException;
+import com.cosain.trilo.trip.command.application.exception.NoScheduleMoveAuthorityException;
+import com.cosain.trilo.trip.command.application.exception.ScheduleNotFoundException;
 import com.cosain.trilo.trip.command.application.usecase.ScheduleMoveUseCase;
+import com.cosain.trilo.trip.command.domain.entity.Day;
+import com.cosain.trilo.trip.command.domain.entity.Schedule;
+import com.cosain.trilo.trip.command.domain.entity.Trip;
+import com.cosain.trilo.trip.command.domain.exception.MidScheduleIndexConflictException;
+import com.cosain.trilo.trip.command.domain.exception.ScheduleIndexRangeException;
+import com.cosain.trilo.trip.command.domain.repository.DayRepository;
+import com.cosain.trilo.trip.command.domain.repository.ScheduleRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@RequiredArgsConstructor
 @Service
 public class ScheduleMoveService implements ScheduleMoveUseCase {
 
+    private final ScheduleRepository scheduleRepository;
+    private final DayRepository dayRepository;
+
     @Override
+    @Transactional
     public void moveSchedule(Long scheduleId, Long moveTripperId, ScheduleMoveCommand moveCommand) {
+        Schedule schedule = findSchedule(scheduleId);
+        Day targetDay = findDay(moveCommand.getTargetDayId());
+
+        Trip trip = schedule.getTrip();
+
+        validateScheduleMoveAuthority(trip, moveTripperId);
+
+        try {
+            trip.moveSchedule(schedule, targetDay, moveCommand.getTargetOrder());
+        } catch (MidScheduleIndexConflictException | ScheduleIndexRangeException e) {
+            scheduleRepository.relocateDaySchedules(trip.getId(), targetDay.getId());
+            schedule = findSchedule(scheduleId);
+            targetDay = findDay(moveCommand.getTargetDayId());
+
+            trip = schedule.getTrip();
+            trip.moveSchedule(schedule, targetDay, moveCommand.getTargetOrder());
+        }
     }
 
+
+    private Schedule findSchedule(Long scheduleId) {
+        return scheduleRepository.findByIdWithTrip(scheduleId)
+                .orElseThrow(() -> new ScheduleNotFoundException("일치하는 식별자의 일정을 찾을 수 없음"));
+    }
+
+    private Day findDay(Long targetDayId) {
+        if (targetDayId == null) {
+            return null;
+        }
+        return dayRepository.findByIdWithTrip(targetDayId)
+                .orElseThrow(() -> new DayNotFoundException("일치하는 식별자의 Day를 찾을 수 없음"));
+    }
+
+    private void validateScheduleMoveAuthority(Trip trip, Long moveTripperId) {
+        if (!trip.getTripperId().equals(moveTripperId)) {
+            throw new NoScheduleMoveAuthorityException("권한 없는 사람이 일정을 이동하려 함");
+        }
+    }
 }

--- a/src/main/java/com/cosain/trilo/trip/command/application/service/ScheduleMoveService.java
+++ b/src/main/java/com/cosain/trilo/trip/command/application/service/ScheduleMoveService.java
@@ -39,7 +39,7 @@ public class ScheduleMoveService implements ScheduleMoveUseCase {
         try {
             moveDto = trip.moveSchedule(schedule, targetDay, moveCommand.getTargetOrder());
         } catch (MidScheduleIndexConflictException | ScheduleIndexRangeException e) {
-            scheduleRepository.relocateDaySchedules(trip.getId(), targetDay.getId());
+            scheduleRepository.relocateDaySchedules(trip.getId(), moveCommand.getTargetDayId());
             schedule = findSchedule(scheduleId);
             targetDay = findDay(moveCommand.getTargetDayId());
 

--- a/src/main/java/com/cosain/trilo/trip/command/application/usecase/ScheduleMoveUseCase.java
+++ b/src/main/java/com/cosain/trilo/trip/command/application/usecase/ScheduleMoveUseCase.java
@@ -1,8 +1,9 @@
 package com.cosain.trilo.trip.command.application.usecase;
 
 import com.cosain.trilo.trip.command.application.command.ScheduleMoveCommand;
+import com.cosain.trilo.trip.command.application.result.ScheduleMoveResult;
 
 public interface ScheduleMoveUseCase {
 
-    void moveSchedule(Long scheduleId, Long moveTripperId, ScheduleMoveCommand moveCommand);
+    ScheduleMoveResult moveSchedule(Long scheduleId, Long moveTripperId, ScheduleMoveCommand moveCommand);
 }

--- a/src/main/java/com/cosain/trilo/trip/command/application/usecase/ScheduleMoveUseCase.java
+++ b/src/main/java/com/cosain/trilo/trip/command/application/usecase/ScheduleMoveUseCase.java
@@ -1,0 +1,8 @@
+package com.cosain.trilo.trip.command.application.usecase;
+
+import com.cosain.trilo.trip.command.application.command.ScheduleMoveCommand;
+
+public interface ScheduleMoveUseCase {
+
+    void moveSchedule(Long scheduleId, Long moveTripperId, ScheduleMoveCommand moveCommand);
+}

--- a/src/main/java/com/cosain/trilo/trip/command/domain/dto/ScheduleMoveDto.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/dto/ScheduleMoveDto.java
@@ -1,0 +1,46 @@
+package com.cosain.trilo.trip.command.domain.dto;
+
+import com.cosain.trilo.trip.command.domain.entity.Day;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ScheduleMoveDto {
+
+    private Long scheduleId;
+    private Long beforeDayId;
+    private Long afterDayId;
+    private boolean positionChanged;
+
+    public static ScheduleMoveDto ofPositionChanged(Long scheduleId, Day beforeDay, Day afterDay) {
+        Long beforeDayId = (beforeDay == null) ? null : beforeDay.getId();
+        Long afterDayId = (afterDay == null) ? null : afterDay.getId();
+
+        return ScheduleMoveDto.builder()
+                .scheduleId(scheduleId)
+                .beforeDayId(beforeDayId)
+                .afterDayId(afterDayId)
+                .positionChanged(true)
+                .build();
+    }
+
+    public static ScheduleMoveDto ofNotPositionChanged(Long scheduleId, Day day) {
+        Long dayId = (day == null) ? null : day.getId();
+
+        return ScheduleMoveDto.builder()
+                .scheduleId(scheduleId)
+                .beforeDayId(dayId)
+                .afterDayId(dayId)
+                .positionChanged(false)
+                .build();
+    }
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private ScheduleMoveDto(Long scheduleId, Long beforeDayId, Long afterDayId, boolean positionChanged) {
+        this.scheduleId = scheduleId;
+        this.beforeDayId = beforeDayId;
+        this.afterDayId = afterDayId;
+        this.positionChanged = positionChanged;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/command/domain/entity/Day.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/entity/Day.java
@@ -1,5 +1,6 @@
 package com.cosain.trilo.trip.command.domain.entity;
 
+import com.cosain.trilo.trip.command.domain.dto.ScheduleMoveDto;
 import com.cosain.trilo.trip.command.domain.exception.InvalidScheduleMoveTargetOrderException;
 import com.cosain.trilo.trip.command.domain.exception.MidScheduleIndexConflictException;
 import com.cosain.trilo.trip.command.domain.vo.Place;
@@ -92,24 +93,26 @@ public class Day {
      * @param schedule
      * @param targetOrder
      */
-    void moveSchedule(Schedule schedule, int targetOrder) {
+    ScheduleMoveDto moveSchedule(Schedule schedule, int targetOrder) {
         // 일단 앞에서 Schedule이 Trip과 관련된 Schedule이라는 것은 검증 됨
         // TODO: 임시보관함과 Day에서 동일한 로직이 중복됨 -> 리팩터링을 해야할 것인가
         if (targetOrder < 0 || targetOrder > this.schedules.size()) {
             throw new InvalidScheduleMoveTargetOrderException("일정을 지정 위치로 옮기려 시도했으나, 유효한 순서 범위를 벗어남");
         }
+        Day beforeDay = schedule.getDay();
         if (isSamePositionMove(schedule, targetOrder)) {
-            return;
+            return ScheduleMoveDto.ofNotPositionChanged(schedule.getId(), beforeDay);
         }
         if (targetOrder == this.schedules.size()) {
             moveScheduleToTail(schedule);
-            return;
+            return ScheduleMoveDto.ofPositionChanged(schedule.getId(), beforeDay, this);
         }
         if (targetOrder == 0) {
             moveScheduleToHead(schedule);
-            return;
+            return ScheduleMoveDto.ofPositionChanged(schedule.getId(), beforeDay, this);
         }
         moveScheduleToMiddle(schedule, targetOrder);
+        return ScheduleMoveDto.ofPositionChanged(schedule.getId(), beforeDay, this);
     }
 
     /**

--- a/src/main/java/com/cosain/trilo/trip/command/domain/entity/Day.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/entity/Day.java
@@ -11,6 +11,7 @@ import lombok.*;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Getter
 @ToString(of = {"id", "tripDate"})
@@ -119,7 +120,7 @@ public class Day {
      * @return
      */
     private boolean isSamePositionMove(Schedule schedule, int targetOrder) {
-        return schedule.getDay().equals(this) && (targetOrder == schedules.indexOf(schedule) || targetOrder == schedules.indexOf(schedule) + 1);
+        return Objects.equals(this, schedule.getDay()) && (targetOrder == schedules.indexOf(schedule) || targetOrder == schedules.indexOf(schedule) + 1);
     }
 
     /**

--- a/src/main/java/com/cosain/trilo/trip/command/domain/entity/Day.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/entity/Day.java
@@ -1,5 +1,7 @@
 package com.cosain.trilo.trip.command.domain.entity;
 
+import com.cosain.trilo.trip.command.domain.exception.InvalidScheduleMoveTargetOrderException;
+import com.cosain.trilo.trip.command.domain.exception.MidScheduleIndexConflictException;
 import com.cosain.trilo.trip.command.domain.vo.Place;
 import com.cosain.trilo.trip.command.domain.vo.ScheduleIndex;
 import com.cosain.trilo.trip.command.domain.vo.TripPeriod;
@@ -72,5 +74,89 @@ public class Day {
         return (schedules.isEmpty())
                 ? ScheduleIndex.ZERO_INDEX
                 : schedules.get(schedules.size() - 1).getScheduleIndex().generateNextIndex();
+    }
+
+    /**
+     * Schdeules의 제일 앞 index를 새로 만듭니다.
+     * @return 제일 앞 인덱스(기존 일정이 없으면 0번 인덱스, 있으면 제일 앞보다 한단계 낮은 인덱스)
+     */
+    private ScheduleIndex generateSchedulesHeadIndex() {
+        return (schedules.isEmpty())
+                ? ScheduleIndex.ZERO_INDEX
+                : schedules.get(0).getScheduleIndex().generateBeforeIndex();
+    }
+
+    /**
+     * 일정을 지정 위치로 옮깁니다.
+     * @param schedule
+     * @param targetOrder
+     */
+    void moveSchedule(Schedule schedule, int targetOrder) {
+        // 일단 앞에서 Schedule이 Trip과 관련된 Schedule이라는 것은 검증 됨
+        // TODO: 임시보관함과 Day에서 동일한 로직이 중복됨 -> 리팩터링을 해야할 것인가
+        if (targetOrder < 0 || targetOrder > this.schedules.size()) {
+            throw new InvalidScheduleMoveTargetOrderException("일정을 지정 위치로 옮기려 시도했으나, 유효한 순서 범위를 벗어남");
+        }
+        if (targetOrder == this.schedules.size()) {
+            moveScheduleToTail(schedule);
+            return;
+        }
+        if (this.schedules.get(targetOrder).equals(schedule)) {
+            return;
+        }
+        if (targetOrder == 0) {
+            moveScheduleToHead(schedule);
+            return;
+        }
+        moveScheduleToMiddle(schedule, targetOrder);
+    }
+
+    /**
+     * 일정을 Schedules의 맨 앞으로 옮깁니다.
+     * @param schedule
+     */
+    private void moveScheduleToHead(Schedule schedule) {
+        ScheduleIndex newScheduleIndex = generateSchedulesHeadIndex();
+
+        schedule.changePosition(this, newScheduleIndex);
+        schedules.add(schedule);
+    }
+
+    /**
+     * 일정을 Schedules의 맨 뒤로 옮깁니다.
+     * @param schedule
+     */
+    private void moveScheduleToTail(Schedule schedule) {
+        ScheduleIndex newScheduleIndex = generateNextScheduleIndex();
+
+        schedule.changePosition(this, newScheduleIndex);
+        schedules.add(schedule);
+    }
+
+    /**
+     * 지정 Schedule을 지정한 순서에 놓음
+     * @param schedule
+     * @param targetOrder
+     */
+    private void moveScheduleToMiddle(Schedule schedule, int targetOrder) {
+        ScheduleIndex destinationOrderScheduleIndex = schedules.get(targetOrder).getScheduleIndex();
+        ScheduleIndex previousOrderScheduleIndex = schedules.get(targetOrder - 1).getScheduleIndex();
+
+        ScheduleIndex newScheduleIndex = destinationOrderScheduleIndex.mid(previousOrderScheduleIndex);
+
+        if (newScheduleIndex.equals(destinationOrderScheduleIndex) || newScheduleIndex.equals(previousOrderScheduleIndex)) {
+            throw new MidScheduleIndexConflictException("중간 삽입 인덱스 충돌 발생 -> 인덱스 재정렬 필요");
+        }
+
+        schedule.changePosition(this, newScheduleIndex);
+        schedules.add(schedule);
+    }
+
+    /**
+     * 자기 자신이 가진 Schedules에서, 지정 Schedule을 분리함
+     * @param schedule : 끊어낼 Schedule
+     */
+    void detachSchedule(Schedule schedule) {
+        this.schedules.remove(schedule);
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/command/domain/entity/Day.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/entity/Day.java
@@ -97,11 +97,11 @@ public class Day {
         if (targetOrder < 0 || targetOrder > this.schedules.size()) {
             throw new InvalidScheduleMoveTargetOrderException("일정을 지정 위치로 옮기려 시도했으나, 유효한 순서 범위를 벗어남");
         }
-        if (targetOrder == this.schedules.size()) {
-            moveScheduleToTail(schedule);
+        if (isSamePositionMove(schedule, targetOrder)) {
             return;
         }
-        if (this.schedules.get(targetOrder).equals(schedule)) {
+        if (targetOrder == this.schedules.size()) {
+            moveScheduleToTail(schedule);
             return;
         }
         if (targetOrder == 0) {
@@ -109,6 +109,17 @@ public class Day {
             return;
         }
         moveScheduleToMiddle(schedule, targetOrder);
+    }
+
+    /**
+     * 스케쥴을 옮길 때 대상이 되는 순서로 옮길 경우, 기존과 상대적 순서가 똑같은 지 여부를 확인합니다. 예를 들어 Day의 Schedules 상에서 1번 위치에 있던 일정을
+     * 1번 위치에 옮기거나, 2번 위치로 옮기는 경우는 결국 기존과 상대적 순서가 같습니다.
+     * @param schedule
+     * @param targetOrder
+     * @return
+     */
+    private boolean isSamePositionMove(Schedule schedule, int targetOrder) {
+        return schedule.getDay().equals(this) && (targetOrder == schedules.indexOf(schedule) || targetOrder == schedules.indexOf(schedule) + 1);
     }
 
     /**

--- a/src/main/java/com/cosain/trilo/trip/command/domain/entity/Day.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/entity/Day.java
@@ -47,6 +47,9 @@ public class Day {
                 .build();
     }
 
+    /**
+     * 테스트의 편의성을 위해 Builder accessLevel = PUBLIC 으로 설정
+     */
     @Builder(access = AccessLevel.PUBLIC)
     private Day(Long id, LocalDate tripDate, Trip trip, List<Schedule> schedules) {
         this.id = id;

--- a/src/main/java/com/cosain/trilo/trip/command/domain/entity/Schedule.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/entity/Schedule.java
@@ -67,4 +67,27 @@ public class Schedule {
     public void changeContent(String content){
         this.content = content;
     }
+
+    /**
+     * 일정의 day와 ScheduleIndex를 변경합니다.
+     * 기존의 day 또는 임시보관함이 있으면 해당 Day와 관계를 끊고 새로운 day 또는 임시보관함과 관계를 맺습니다.
+     * @param changeDay
+     * @param changeScheduleIndex
+     */
+    void changePosition(Day changeDay, ScheduleIndex changeScheduleIndex) {
+        detachFromDayOrTemporaryStorage();
+        this.day = changeDay;
+        this.scheduleIndex = changeScheduleIndex;
+    }
+
+    /**
+     * 자신이 속했던 Day 또는, 임시보관함에서 Schedule 자신을 끊어냅니다.
+     */
+    private void detachFromDayOrTemporaryStorage() {
+        if (day == null) {
+            trip.detachScheduleFromTemporaryStorage(this);
+            return;
+        }
+        day.detachSchedule(this);
+    }
 }

--- a/src/main/java/com/cosain/trilo/trip/command/domain/entity/Schedule.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/entity/Schedule.java
@@ -50,6 +50,9 @@ public class Schedule {
                 .build();
     }
 
+    /**
+     * 테스트의 편의성을 위해 Builder accessLevel = PUBLIC 으로 설정
+     */
     @Builder(access = AccessLevel.PUBLIC)
     private Schedule(Long id, Day day, Trip trip, String title, String content, Place place, ScheduleIndex scheduleIndex) {
         this.id = id;

--- a/src/main/java/com/cosain/trilo/trip/command/domain/entity/Trip.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/entity/Trip.java
@@ -1,8 +1,7 @@
 package com.cosain.trilo.trip.command.domain.entity;
 
 import com.cosain.trilo.trip.command.domain.dto.ChangeTripPeriodResult;
-import com.cosain.trilo.trip.command.domain.exception.EmptyPeriodUpdateException;
-import com.cosain.trilo.trip.command.domain.exception.InvalidTripDayException;
+import com.cosain.trilo.trip.command.domain.exception.*;
 import com.cosain.trilo.trip.command.domain.vo.Place;
 import com.cosain.trilo.trip.command.domain.vo.ScheduleIndex;
 import com.cosain.trilo.trip.command.domain.vo.TripPeriod;
@@ -163,7 +162,7 @@ public class Trip {
     }
 
     private Schedule makeDaySchedule(Day day, String title, Place place) {
-        if (!this.id.equals(day.getTrip().id)) {
+        if (!day.getTrip().equals(this)) {
             throw new InvalidTripDayException("해당 day는 Trip의 Day가 아님");
         }
 

--- a/src/main/java/com/cosain/trilo/trip/command/domain/entity/Trip.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/entity/Trip.java
@@ -149,6 +149,7 @@ public class Trip {
                 ? makeTemporaryStorageSchedule(title, place)
                 : makeDaySchedule(day, title, place);
     }
+
     private Schedule makeTemporaryStorageSchedule(String title, Place place) {
         Schedule schedule = Schedule.create(null, this, title, place, generateNextTemporaryStorageScheduleIndex());
         temporaryStorage.add(schedule);
@@ -201,20 +202,19 @@ public class Trip {
 
     /**
      * Schedule을 임시보관함의 지정 순서로 이동시킵니다.
+     *
      * @param schedule
      * @param targetOrder
      */
     private void moveScheduleToTemporaryStorage(Schedule schedule, int targetOrder) {
-        // 일단 앞에서 Schedule이 Trip과 관련된 Schedule이라는 것은 검증 됨
-        // TODO: 임시보관함과 Day에서 동일한 로직이 중복됨 -> 리팩터링을 해야할 것인가
         if (targetOrder < 0 || targetOrder > this.temporaryStorage.size()) {
             throw new InvalidScheduleMoveTargetOrderException("일정을 지정 위치로 옮기려 시도했으나, 유효한 순서 범위를 벗어남");
         }
-        if (targetOrder == this.temporaryStorage.size()) {
-            moveScheduleToTemporaryStorageTail(schedule);
+        if (isSamePositionMove(schedule, targetOrder)) {
             return;
         }
-        if (this.temporaryStorage.get(targetOrder).equals(schedule)) {
+        if (targetOrder == this.temporaryStorage.size()) {
+            moveScheduleToTemporaryStorageTail(schedule);
             return;
         }
         if (targetOrder == 0) {
@@ -222,6 +222,17 @@ public class Trip {
             return;
         }
         moveScheduleToTemporaryStorageMiddle(schedule, targetOrder);
+    }
+
+    /**
+     * 스케쥴을 옮길 때 대상이 되는 순서로 옮길 경우, 기존과 상대적 순서가 똑같은 지 여부를 확인합니다. 예를 들어 임시보관함 1번 위치에 있던 일정을
+     * 1번 위치에 옮기거나, 2번 위치로 옮기는 경우는 결국 기존과 상대적 순서가 같습니다.
+     * @param schedule
+     * @param targetOrder
+     * @return
+     */
+    private boolean isSamePositionMove(Schedule schedule, int targetOrder) {
+        return schedule.getDay() == null && (targetOrder == temporaryStorage.indexOf(schedule) || targetOrder == temporaryStorage.indexOf(schedule) + 1);
     }
 
     /**

--- a/src/main/java/com/cosain/trilo/trip/command/domain/exception/InvalidScheduleMoveTargetOrderException.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/exception/InvalidScheduleMoveTargetOrderException.java
@@ -1,0 +1,35 @@
+package com.cosain.trilo.trip.command.domain.exception;
+
+import com.cosain.trilo.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidScheduleMoveTargetOrderException extends CustomException {
+
+    private static final String ERROR_NAME = "InvalidScheduleMoveTargetOrderException";
+    private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+    public InvalidScheduleMoveTargetOrderException() {
+    }
+
+    public InvalidScheduleMoveTargetOrderException(String debugMessage) {
+        super(debugMessage);
+    }
+
+    public InvalidScheduleMoveTargetOrderException(Throwable cause) {
+        super(cause);
+    }
+
+    public InvalidScheduleMoveTargetOrderException(String debugMessage, Throwable cause) {
+        super(debugMessage, cause);
+    }
+
+    @Override
+    public String getErrorName() {
+        return ERROR_NAME;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HTTP_STATUS;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/command/domain/exception/MidScheduleIndexConflictException.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/exception/MidScheduleIndexConflictException.java
@@ -1,0 +1,15 @@
+package com.cosain.trilo.trip.command.domain.exception;
+
+public class MidScheduleIndexConflictException extends RuntimeException {
+
+    public MidScheduleIndexConflictException() {
+    }
+
+    public MidScheduleIndexConflictException(String message) {
+        super(message);
+    }
+
+    public MidScheduleIndexConflictException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/command/domain/repository/DayRepository.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/repository/DayRepository.java
@@ -7,8 +7,14 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface DayRepository extends JpaRepository<Day, Long> {
+
+    @Query("SELECT d " +
+            "FROM Day as d JOIN FETCH d.trip " +
+            "WHERE d.id = :dayId")
+    Optional<Day> findByIdWithTrip(@Param("dayId") Long dayId);
 
     @Modifying
     @Query("delete from Day d where d in :days")

--- a/src/main/java/com/cosain/trilo/trip/command/domain/vo/ScheduleIndex.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/vo/ScheduleIndex.java
@@ -36,4 +36,13 @@ public class ScheduleIndex {
         return ScheduleIndex.of(value + DEFAULT_SEQUENCE_GAP);
     }
 
+
+    /**
+     * 자기 자신의 앞에 새로 인덱스를 생성합니다.
+     * @return 앞에 오는 인덱스
+     */
+    public ScheduleIndex generateBeforeIndex() {
+        return ScheduleIndex.of(value - DEFAULT_SEQUENCE_GAP);
+    }
+
 }

--- a/src/main/java/com/cosain/trilo/trip/command/domain/vo/ScheduleIndex.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/vo/ScheduleIndex.java
@@ -5,6 +5,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.*;
 
+import java.math.BigInteger;
+
 @Getter
 @ToString(of = {"value"})
 @EqualsAndHashCode(of = {"value"})
@@ -43,6 +45,20 @@ public class ScheduleIndex {
      */
     public ScheduleIndex generateBeforeIndex() {
         return ScheduleIndex.of(value - DEFAULT_SEQUENCE_GAP);
+    }
+
+
+    /**
+     * 중간 인덱스 생성
+     * @param other : 다른 대상 인덱스
+     * @return : 자기 자신과 다른 대상 인덱스의 중간 위치에 대응되는 인덱스
+     */
+    public ScheduleIndex mid(ScheduleIndex other) {
+        BigInteger value1 = BigInteger.valueOf(this.value);
+        BigInteger value2 = BigInteger.valueOf(other.value);
+
+        long midValue = value1.add(value2).divide(BigInteger.TWO).longValue();
+        return ScheduleIndex.of(midValue);
     }
 
 }

--- a/src/main/java/com/cosain/trilo/trip/command/presentation/schedule/ScheduleMoveController.java
+++ b/src/main/java/com/cosain/trilo/trip/command/presentation/schedule/ScheduleMoveController.java
@@ -1,0 +1,31 @@
+package com.cosain.trilo.trip.command.presentation.schedule;
+
+import com.cosain.trilo.common.LoginUser;
+import com.cosain.trilo.trip.command.application.command.ScheduleMoveCommand;
+import com.cosain.trilo.trip.command.application.usecase.ScheduleMoveUseCase;
+import com.cosain.trilo.trip.command.presentation.schedule.dto.ScheduleMoveRequest;
+import com.cosain.trilo.trip.command.presentation.schedule.dto.ScheduleMoveResponse;
+import com.cosain.trilo.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+public class ScheduleMoveController {
+
+    private final ScheduleMoveUseCase scheduleMoveUseCase;
+
+    @PatchMapping("/api/schedules/{scheduleId}")
+    @ResponseStatus(HttpStatus.OK)
+    public ScheduleMoveResponse moveSchedule(@LoginUser User user, @PathVariable Long scheduleId, @RequestBody ScheduleMoveRequest scheduleMoveRequest) {
+        Long moveTripperId = user.getId();
+
+        ScheduleMoveCommand scheduleMoveCommand = scheduleMoveRequest.toCommand();
+        scheduleMoveUseCase.moveSchedule(scheduleId, moveTripperId, scheduleMoveCommand);
+
+        return ScheduleMoveResponse.from(scheduleId);
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/command/presentation/schedule/ScheduleMoveController.java
+++ b/src/main/java/com/cosain/trilo/trip/command/presentation/schedule/ScheduleMoveController.java
@@ -2,6 +2,7 @@ package com.cosain.trilo.trip.command.presentation.schedule;
 
 import com.cosain.trilo.common.LoginUser;
 import com.cosain.trilo.trip.command.application.command.ScheduleMoveCommand;
+import com.cosain.trilo.trip.command.application.result.ScheduleMoveResult;
 import com.cosain.trilo.trip.command.application.usecase.ScheduleMoveUseCase;
 import com.cosain.trilo.trip.command.presentation.schedule.dto.ScheduleMoveRequest;
 import com.cosain.trilo.trip.command.presentation.schedule.dto.ScheduleMoveResponse;
@@ -24,8 +25,8 @@ public class ScheduleMoveController {
         Long moveTripperId = user.getId();
 
         ScheduleMoveCommand scheduleMoveCommand = scheduleMoveRequest.toCommand();
-        scheduleMoveUseCase.moveSchedule(scheduleId, moveTripperId, scheduleMoveCommand);
+        ScheduleMoveResult scheduleMoveResult = scheduleMoveUseCase.moveSchedule(scheduleId, moveTripperId, scheduleMoveCommand);
 
-        return ScheduleMoveResponse.from(scheduleId);
+        return ScheduleMoveResponse.from(scheduleMoveResult);
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/command/presentation/schedule/dto/ScheduleCreateRequest.java
+++ b/src/main/java/com/cosain/trilo/trip/command/presentation/schedule/dto/ScheduleCreateRequest.java
@@ -19,6 +19,9 @@ public class ScheduleCreateRequest {
     private double latitude;
     private double longitude;
 
+    /**
+     * 테스트의 편의성을 위해 Builder accessLevel = PUBLIC 으로 설정
+     */
     @Builder(access = AccessLevel.PUBLIC)
     private ScheduleCreateRequest(Long dayId, Long tripId, String title, String placeId, String placeName, double latitude, double longitude) {
         this.dayId = dayId;

--- a/src/main/java/com/cosain/trilo/trip/command/presentation/schedule/dto/ScheduleMoveRequest.java
+++ b/src/main/java/com/cosain/trilo/trip/command/presentation/schedule/dto/ScheduleMoveRequest.java
@@ -1,0 +1,23 @@
+package com.cosain.trilo.trip.command.presentation.schedule.dto;
+
+import com.cosain.trilo.trip.command.application.command.ScheduleMoveCommand;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ScheduleMoveRequest {
+
+    private Long targetDayId;
+    private int targetOrder;
+
+    public ScheduleMoveRequest(Long targetDayId, int targetOrder) {
+        this.targetDayId = targetDayId;
+        this.targetOrder = targetOrder;
+    }
+
+    public ScheduleMoveCommand toCommand() {
+        return ScheduleMoveCommand.of(targetDayId, targetOrder);
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/command/presentation/schedule/dto/ScheduleMoveResponse.java
+++ b/src/main/java/com/cosain/trilo/trip/command/presentation/schedule/dto/ScheduleMoveResponse.java
@@ -1,0 +1,17 @@
+package com.cosain.trilo.trip.command.presentation.schedule.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ScheduleMoveResponse {
+
+    private Long scheduleId;
+
+    public static ScheduleMoveResponse from(Long scheduleId) {
+        return new ScheduleMoveResponse(scheduleId);
+    }
+
+    private ScheduleMoveResponse(Long scheduleId) {
+        this.scheduleId = scheduleId;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/command/presentation/schedule/dto/ScheduleMoveResponse.java
+++ b/src/main/java/com/cosain/trilo/trip/command/presentation/schedule/dto/ScheduleMoveResponse.java
@@ -1,17 +1,32 @@
 package com.cosain.trilo.trip.command.presentation.schedule.dto;
 
+import com.cosain.trilo.trip.command.application.result.ScheduleMoveResult;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 public class ScheduleMoveResponse {
 
     private Long scheduleId;
+    private Long beforeDayId;
+    private Long afterDayId;
+    private boolean positionChanged;
 
-    public static ScheduleMoveResponse from(Long scheduleId) {
-        return new ScheduleMoveResponse(scheduleId);
+    public static ScheduleMoveResponse from(ScheduleMoveResult scheduleMoveResult) {
+        return ScheduleMoveResponse.builder()
+                .scheduleId(scheduleMoveResult.getScheduleId())
+                .beforeDayId(scheduleMoveResult.getBeforeDayId())
+                .afterDayId(scheduleMoveResult.getAfterDayId())
+                .positionChanged(scheduleMoveResult.isPositionChanged())
+                .build();
     }
 
-    private ScheduleMoveResponse(Long scheduleId) {
+    @Builder(access = AccessLevel.PRIVATE)
+    private ScheduleMoveResponse(Long scheduleId, Long beforeDayId, Long afterDayId, boolean positionChanged) {
         this.scheduleId = scheduleId;
+        this.beforeDayId = beforeDayId;
+        this.afterDayId = afterDayId;
+        this.positionChanged = positionChanged;
     }
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/command/application/service/schedule/ScheduleMoveServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/application/service/schedule/ScheduleMoveServiceTest.java
@@ -4,6 +4,7 @@ import com.cosain.trilo.trip.command.application.command.ScheduleMoveCommand;
 import com.cosain.trilo.trip.command.application.exception.DayNotFoundException;
 import com.cosain.trilo.trip.command.application.exception.NoScheduleMoveAuthorityException;
 import com.cosain.trilo.trip.command.application.exception.ScheduleNotFoundException;
+import com.cosain.trilo.trip.command.application.result.ScheduleMoveResult;
 import com.cosain.trilo.trip.command.application.service.ScheduleMoveService;
 import com.cosain.trilo.trip.command.domain.entity.Day;
 import com.cosain.trilo.trip.command.domain.entity.Schedule;
@@ -22,10 +23,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDate;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.*;
 
 @Slf4j
@@ -104,7 +105,7 @@ public class ScheduleMoveServiceTest {
         verify(dayRepository).findByIdWithTrip(eq(notExistTargetDayId));
     }
 
-    @DisplayName("권한이 없는 사람이 이동을 시도하면 NoTripMoveAotu 발생")
+    @DisplayName("권한이 없는 사람이 이동을 시도하면 NoScheduleMoveAuthorityException 발생")
     @Test
     public void noTripMoveMoveAuthorityTripperTest() {
         // given
@@ -196,10 +197,14 @@ public class ScheduleMoveServiceTest {
         given(scheduleRepository.findByIdWithTrip(eq(scheduleId))).willReturn(Optional.of(schedule));
         given(dayRepository.findByIdWithTrip(eq(targetDayId))).willReturn(Optional.of(day));
 
-        scheduleMoveService.moveSchedule(scheduleId, tripperId, moveCommand);
+        // when
+        ScheduleMoveResult scheduleMoveResult = scheduleMoveService.moveSchedule(scheduleId, tripperId, moveCommand);
 
 
-        // when & then
+        // then
+        assertThat(scheduleMoveResult.getBeforeDayId()).isEqualTo(null);
+        assertThat(scheduleMoveResult.getAfterDayId()).isEqualTo(targetDayId);
+        assertThat(scheduleMoveResult.isPositionChanged()).isEqualTo(true);
         verify(scheduleRepository, times(1)).findByIdWithTrip(eq(scheduleId));
         verify(dayRepository, times(1)).findByIdWithTrip(eq(targetDayId));
         verify(scheduleRepository, times(0)).relocateDaySchedules(eq(tripId), eq(targetDayId));
@@ -292,8 +297,13 @@ public class ScheduleMoveServiceTest {
 
         given(scheduleRepository.relocateDaySchedules(eq(tripId), eq(targetDayId))).willReturn(1);
 
-        scheduleMoveService.moveSchedule(scheduleId, tripperId, moveCommand);
+        // when
+        ScheduleMoveResult scheduleMoveResult = scheduleMoveService.moveSchedule(scheduleId, tripperId, moveCommand);
 
+        // then
+        assertThat(scheduleMoveResult.getBeforeDayId()).isEqualTo(null);
+        assertThat(scheduleMoveResult.getAfterDayId()).isEqualTo(targetDayId);
+        assertThat(scheduleMoveResult.isPositionChanged()).isEqualTo(true);
         verify(scheduleRepository, times(2)).findByIdWithTrip(eq(scheduleId));
         verify(dayRepository, times(2)).findByIdWithTrip(eq(targetDayId));
         verify(scheduleRepository, times(1)).relocateDaySchedules(eq(tripId), eq(targetDayId));
@@ -386,8 +396,13 @@ public class ScheduleMoveServiceTest {
 
         given(scheduleRepository.relocateDaySchedules(eq(tripId), eq(targetDayId))).willReturn(1);
 
-        scheduleMoveService.moveSchedule(scheduleId, tripperId, moveCommand);
+        // when
+        ScheduleMoveResult scheduleMoveResult = scheduleMoveService.moveSchedule(scheduleId, tripperId, moveCommand);
 
+        // then
+        assertThat(scheduleMoveResult.getBeforeDayId()).isEqualTo(null);
+        assertThat(scheduleMoveResult.getAfterDayId()).isEqualTo(targetDayId);
+        assertThat(scheduleMoveResult.isPositionChanged()).isEqualTo(true);
         verify(scheduleRepository, times(2)).findByIdWithTrip(eq(scheduleId));
         verify(dayRepository, times(2)).findByIdWithTrip(eq(targetDayId));
         verify(scheduleRepository, times(1)).relocateDaySchedules(eq(tripId), eq(targetDayId));
@@ -498,8 +513,13 @@ public class ScheduleMoveServiceTest {
 
         given(scheduleRepository.relocateDaySchedules(eq(tripId), eq(targetDayId))).willReturn(1);
 
-        scheduleMoveService.moveSchedule(scheduleId, tripperId, moveCommand);
+        // when
+        ScheduleMoveResult scheduleMoveResult = scheduleMoveService.moveSchedule(scheduleId, tripperId, moveCommand);
 
+        // then
+        assertThat(scheduleMoveResult.getBeforeDayId()).isEqualTo(null);
+        assertThat(scheduleMoveResult.getAfterDayId()).isEqualTo(targetDayId);
+        assertThat(scheduleMoveResult.isPositionChanged()).isEqualTo(true);
         verify(scheduleRepository, times(2)).findByIdWithTrip(eq(scheduleId));
         verify(dayRepository, times(2)).findByIdWithTrip(eq(targetDayId));
         verify(scheduleRepository, times(1)).relocateDaySchedules(eq(tripId), eq(targetDayId));

--- a/src/test/java/com/cosain/trilo/unit/trip/command/application/service/schedule/ScheduleMoveServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/application/service/schedule/ScheduleMoveServiceTest.java
@@ -1,0 +1,507 @@
+package com.cosain.trilo.unit.trip.command.application.service.schedule;
+
+import com.cosain.trilo.trip.command.application.command.ScheduleMoveCommand;
+import com.cosain.trilo.trip.command.application.exception.DayNotFoundException;
+import com.cosain.trilo.trip.command.application.exception.NoScheduleMoveAuthorityException;
+import com.cosain.trilo.trip.command.application.exception.ScheduleNotFoundException;
+import com.cosain.trilo.trip.command.application.service.ScheduleMoveService;
+import com.cosain.trilo.trip.command.domain.entity.Day;
+import com.cosain.trilo.trip.command.domain.entity.Schedule;
+import com.cosain.trilo.trip.command.domain.entity.Trip;
+import com.cosain.trilo.trip.command.domain.repository.DayRepository;
+import com.cosain.trilo.trip.command.domain.repository.ScheduleRepository;
+import com.cosain.trilo.trip.command.domain.vo.*;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.*;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+@DisplayName("[TripCommand] ScheduleMoveService 테스트")
+public class ScheduleMoveServiceTest {
+
+    @InjectMocks
+    private ScheduleMoveService scheduleMoveService;
+
+    @Mock
+    private ScheduleRepository scheduleRepository;
+
+    @Mock
+    private DayRepository dayRepository;
+
+    @DisplayName("존재하지 않는 일정을 이동시키려고 하면 ScheduleNotFoundException 발생")
+    @Test
+    public void testNotExistScheduleMove() {
+        // given
+        Long notExistScheduleId = 3L;
+        Long tripperId = 1L;
+        Long targetDayId = 2L;
+        int targetOrder = 3;
+
+        ScheduleMoveCommand moveCommand = ScheduleMoveCommand.of(targetDayId, targetOrder);
+        given(scheduleRepository.findByIdWithTrip(eq(notExistScheduleId))).willReturn(Optional.empty());
+
+
+        // when & then
+        assertThatThrownBy(() -> scheduleMoveService.moveSchedule(notExistScheduleId, tripperId, moveCommand))
+                .isInstanceOf(ScheduleNotFoundException.class);
+
+        verify(scheduleRepository).findByIdWithTrip(eq(notExistScheduleId));
+    }
+
+    @DisplayName("존재하지 않는 Day로 이동시키려고 하면, DayNotFoundException 발생")
+    @Test
+    public void testNotExistTargetDayMove() {
+        // given
+        Long scheduleId = 1L;
+        Long tripperId = 1L;
+        Long notExistTargetDayId = 2L;
+        int targetOrder = 3;
+        Long tripId = 1L;
+
+        Trip trip = Trip.builder()
+                .id(tripId)
+                .tripperId(tripperId)
+                .title("여행 제목")
+                .status(TripStatus.DECIDED)
+                .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
+                .build();
+
+        Schedule schedule = Schedule.builder()
+                .id(scheduleId)
+                .day(null)
+                .trip(trip)
+                .title("일정 제목")
+                .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
+                .scheduleIndex(ScheduleIndex.ZERO_INDEX)
+                .build();
+        trip.getTemporaryStorage().add(schedule);
+
+        ScheduleMoveCommand moveCommand = ScheduleMoveCommand.of(notExistTargetDayId, targetOrder);
+
+        given(scheduleRepository.findByIdWithTrip(eq(scheduleId))).willReturn(Optional.of(schedule));
+        given(dayRepository.findByIdWithTrip(eq(notExistTargetDayId))).willReturn(Optional.empty());
+
+
+        // when & then
+        assertThatThrownBy(() -> scheduleMoveService.moveSchedule(scheduleId, tripperId, moveCommand))
+                .isInstanceOf(DayNotFoundException.class);
+
+        verify(scheduleRepository).findByIdWithTrip(eq(scheduleId));
+        verify(dayRepository).findByIdWithTrip(eq(notExistTargetDayId));
+    }
+
+    @DisplayName("권한이 없는 사람이 이동을 시도하면 NoTripMoveAotu 발생")
+    @Test
+    public void noTripMoveMoveAuthorityTripperTest() {
+        // given
+        Long tripId = 1L;
+        Long scheduleId = 2L;
+        Long targetDayId = 3L;
+
+        Long tripperId = 4L;
+        Long noAuthorityTripperId = 5L;
+        int targetOrder = 0;
+
+        Trip trip = Trip.builder()
+                .id(tripId)
+                .tripperId(tripperId)
+                .title("여행 제목")
+                .status(TripStatus.DECIDED)
+                .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
+                .build();
+
+        Day day = Day.builder()
+                .id(targetDayId)
+                .tripDate(LocalDate.of(2023, 3, 1))
+                .trip(trip)
+                .build();
+        trip.getDays().add(day);
+
+        Schedule schedule = Schedule.builder()
+                .id(scheduleId)
+                .day(null)
+                .trip(trip)
+                .title("일정 제목")
+                .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
+                .scheduleIndex(ScheduleIndex.ZERO_INDEX)
+                .build();
+        trip.getTemporaryStorage().add(schedule);
+
+        ScheduleMoveCommand moveCommand = ScheduleMoveCommand.of(targetDayId, targetOrder);
+
+        given(scheduleRepository.findByIdWithTrip(eq(scheduleId))).willReturn(Optional.of(schedule));
+        given(dayRepository.findByIdWithTrip(eq(targetDayId))).willReturn(Optional.of(day));
+
+
+        // when & then
+        assertThatThrownBy(() -> scheduleMoveService.moveSchedule(scheduleId, noAuthorityTripperId, moveCommand))
+                .isInstanceOf(NoScheduleMoveAuthorityException.class);
+
+        verify(scheduleRepository).findByIdWithTrip(eq(scheduleId));
+        verify(dayRepository).findByIdWithTrip(eq(targetDayId));
+    }
+
+    @DisplayName("정상적인 이동 요청의 경우, 리포지토리 호출이 1회씩 발생한다.")
+    @Test
+    public void testSuccess() {
+        // given
+        Long tripId = 1L;
+        Long scheduleId = 2L;
+        Long tripperId = 3L;
+
+        Long targetDayId = 4L;
+        int targetOrder = 0;
+
+        Trip trip = Trip.builder()
+                .id(tripId)
+                .tripperId(tripperId)
+                .title("여행 제목")
+                .status(TripStatus.DECIDED)
+                .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
+                .build();
+
+        Day day = Day.builder()
+                .id(targetDayId)
+                .tripDate(LocalDate.of(2023, 3, 1))
+                .trip(trip)
+                .build();
+        trip.getDays().add(day);
+
+        Schedule schedule = Schedule.builder()
+                .id(scheduleId)
+                .day(null)
+                .trip(trip)
+                .title("일정 제목")
+                .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
+                .scheduleIndex(ScheduleIndex.ZERO_INDEX)
+                .build();
+        trip.getTemporaryStorage().add(schedule);
+
+        ScheduleMoveCommand moveCommand = ScheduleMoveCommand.of(targetDayId, targetOrder);
+
+        given(scheduleRepository.findByIdWithTrip(eq(scheduleId))).willReturn(Optional.of(schedule));
+        given(dayRepository.findByIdWithTrip(eq(targetDayId))).willReturn(Optional.of(day));
+
+        scheduleMoveService.moveSchedule(scheduleId, tripperId, moveCommand);
+
+
+        // when & then
+        verify(scheduleRepository, times(1)).findByIdWithTrip(eq(scheduleId));
+        verify(dayRepository, times(1)).findByIdWithTrip(eq(targetDayId));
+        verify(scheduleRepository, times(0)).relocateDaySchedules(eq(tripId), eq(targetDayId));
+    }
+
+    @DisplayName("맨 뒤에 이동 시 인덱스 범위 벗어나면 재배치 후 리포지토리 호출이 추가적으로 발생")
+    @Test
+    public void testRelocate_whenMoveToTail() {
+        // given
+        Long tripId = 1L;
+        Long scheduleId = 2L;
+        Long tripperId = 3L;
+
+        Long targetDayId = 4L;
+        int targetOrder = 1;
+
+        Trip beforeTrip = Trip.builder()
+                .id(tripId)
+                .tripperId(tripperId)
+                .title("여행 제목")
+                .status(TripStatus.DECIDED)
+                .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
+                .build();
+        Day beforeTargetDay = Day.builder()
+                .id(targetDayId)
+                .tripDate(LocalDate.of(2023, 3, 1))
+                .trip(beforeTrip)
+                .build();
+        Schedule beforeTargetDaySchedule = Schedule.builder()
+                .id(scheduleId)
+                .day(beforeTargetDay)
+                .trip(beforeTrip)
+                .title("일정 제목1")
+                .place(Place.of("장소 식별자1", "장소명2", Coordinate.of(23.21, 23.24)))
+                .scheduleIndex(ScheduleIndex.of(ScheduleIndex.MAX_INDEX_VALUE))
+                .build();
+        Schedule beforeMoveSchedule = Schedule.builder()
+                .id(scheduleId)
+                .day(null)
+                .trip(beforeTrip)
+                .title("일정 제목2")
+                .place(Place.of("장소 식별자2", "장소명2", Coordinate.of(23.21, 23.24)))
+                .scheduleIndex(ScheduleIndex.ZERO_INDEX)
+                .build();
+        beforeTrip.getDays().add(beforeTargetDay);
+        beforeTargetDay.getSchedules().add(beforeTargetDaySchedule);
+        beforeTrip.getTemporaryStorage().add(beforeMoveSchedule);
+
+        Trip rediscoveredTrip = Trip.builder()
+                .id(tripId)
+                .tripperId(tripperId)
+                .title("여행 제목")
+                .status(TripStatus.DECIDED)
+                .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
+                .build();
+        Day rediscoveredTargetDay = Day.builder()
+                .id(targetDayId)
+                .tripDate(LocalDate.of(2023, 3, 1))
+                .trip(rediscoveredTrip)
+                .build();
+        Schedule rediscoveredTargetDaySchedule = Schedule.builder()
+                .id(scheduleId)
+                .day(rediscoveredTargetDay)
+                .trip(rediscoveredTrip)
+                .title("일정 제목1")
+                .place(Place.of("장소 식별자1", "장소명2", Coordinate.of(23.21, 23.24)))
+                .scheduleIndex(ScheduleIndex.ZERO_INDEX)
+                .build();
+        Schedule rediscoveredMoveSchedule = Schedule.builder()
+                .id(scheduleId)
+                .day(null)
+                .trip(rediscoveredTrip)
+                .title("일정 제목")
+                .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
+                .scheduleIndex(ScheduleIndex.ZERO_INDEX)
+                .build();
+        rediscoveredTrip.getDays().add(rediscoveredTargetDay);
+        rediscoveredTargetDay.getSchedules().add(rediscoveredTargetDaySchedule);
+        rediscoveredTrip.getTemporaryStorage().add(rediscoveredMoveSchedule);
+
+        ScheduleMoveCommand moveCommand = ScheduleMoveCommand.of(targetDayId, targetOrder);
+
+        when(scheduleRepository.findByIdWithTrip(eq(scheduleId)))
+                .thenReturn(Optional.of(beforeMoveSchedule))
+                .thenReturn(Optional.of(rediscoveredMoveSchedule));
+
+        when(dayRepository.findByIdWithTrip(eq(targetDayId)))
+                .thenReturn(Optional.of(beforeTargetDay))
+                .thenReturn(Optional.of(rediscoveredTargetDay));
+
+        given(scheduleRepository.relocateDaySchedules(eq(tripId), eq(targetDayId))).willReturn(1);
+
+        scheduleMoveService.moveSchedule(scheduleId, tripperId, moveCommand);
+
+        verify(scheduleRepository, times(2)).findByIdWithTrip(eq(scheduleId));
+        verify(dayRepository, times(2)).findByIdWithTrip(eq(targetDayId));
+        verify(scheduleRepository, times(1)).relocateDaySchedules(eq(tripId), eq(targetDayId));
+    }
+
+    @DisplayName("맨 앞에 이동 시 인덱스 범위 벗어나면 재배치 후 리포지토리 호출이 추가적으로 발생")
+    @Test
+    public void testRelocate_whenMoveToHead() {
+        // given
+        Long tripId = 1L;
+        Long scheduleId = 2L;
+        Long tripperId = 3L;
+
+        Long targetDayId = 4L;
+        int targetOrder = 0;
+
+        Trip beforeTrip = Trip.builder()
+                .id(tripId)
+                .tripperId(tripperId)
+                .title("여행 제목")
+                .status(TripStatus.DECIDED)
+                .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
+                .build();
+        Day beforeTargetDay = Day.builder()
+                .id(targetDayId)
+                .tripDate(LocalDate.of(2023, 3, 1))
+                .trip(beforeTrip)
+                .build();
+        Schedule beforeTargetDaySchedule = Schedule.builder()
+                .id(scheduleId)
+                .day(beforeTargetDay)
+                .trip(beforeTrip)
+                .title("일정 제목1")
+                .place(Place.of("장소 식별자1", "장소명2", Coordinate.of(23.21, 23.24)))
+                .scheduleIndex(ScheduleIndex.of(ScheduleIndex.MIN_INDEX_VALUE))
+                .build();
+        Schedule beforeMoveSchedule = Schedule.builder()
+                .id(scheduleId)
+                .day(null)
+                .trip(beforeTrip)
+                .title("일정 제목2")
+                .place(Place.of("장소 식별자2", "장소명2", Coordinate.of(23.21, 23.24)))
+                .scheduleIndex(ScheduleIndex.ZERO_INDEX)
+                .build();
+        beforeTrip.getDays().add(beforeTargetDay);
+        beforeTargetDay.getSchedules().add(beforeTargetDaySchedule);
+        beforeTrip.getTemporaryStorage().add(beforeMoveSchedule);
+
+        Trip rediscoveredTrip = Trip.builder()
+                .id(tripId)
+                .tripperId(tripperId)
+                .title("여행 제목")
+                .status(TripStatus.DECIDED)
+                .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
+                .build();
+        Day rediscoveredTargetDay = Day.builder()
+                .id(targetDayId)
+                .tripDate(LocalDate.of(2023, 3, 1))
+                .trip(rediscoveredTrip)
+                .build();
+        Schedule rediscoveredTargetDaySchedule = Schedule.builder()
+                .id(scheduleId)
+                .day(rediscoveredTargetDay)
+                .trip(rediscoveredTrip)
+                .title("일정 제목1")
+                .place(Place.of("장소 식별자1", "장소명2", Coordinate.of(23.21, 23.24)))
+                .scheduleIndex(ScheduleIndex.ZERO_INDEX)
+                .build();
+        Schedule rediscoveredMoveSchedule = Schedule.builder()
+                .id(scheduleId)
+                .day(null)
+                .trip(rediscoveredTrip)
+                .title("일정 제목")
+                .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
+                .scheduleIndex(ScheduleIndex.ZERO_INDEX)
+                .build();
+        rediscoveredTrip.getDays().add(rediscoveredTargetDay);
+        rediscoveredTargetDay.getSchedules().add(rediscoveredTargetDaySchedule);
+        rediscoveredTrip.getTemporaryStorage().add(rediscoveredMoveSchedule);
+
+        ScheduleMoveCommand moveCommand = ScheduleMoveCommand.of(targetDayId, targetOrder);
+
+        when(scheduleRepository.findByIdWithTrip(eq(scheduleId)))
+                .thenReturn(Optional.of(beforeMoveSchedule))
+                .thenReturn(Optional.of(rediscoveredMoveSchedule));
+
+        when(dayRepository.findByIdWithTrip(eq(targetDayId)))
+                .thenReturn(Optional.of(beforeTargetDay))
+                .thenReturn(Optional.of(rediscoveredTargetDay));
+
+        given(scheduleRepository.relocateDaySchedules(eq(tripId), eq(targetDayId))).willReturn(1);
+
+        scheduleMoveService.moveSchedule(scheduleId, tripperId, moveCommand);
+
+        verify(scheduleRepository, times(2)).findByIdWithTrip(eq(scheduleId));
+        verify(dayRepository, times(2)).findByIdWithTrip(eq(targetDayId));
+        verify(scheduleRepository, times(1)).relocateDaySchedules(eq(tripId), eq(targetDayId));
+    }
+
+    @DisplayName("중간 이동 시 충돌나면 재배치 후 리포지토리 호출이 추가적으로 발생")
+    @Test
+    public void testRelocate_whenMoveToMiddle() {
+        // given
+        Long tripId = 1L;
+        Long scheduleId = 2L;
+        Long tripperId = 3L;
+
+        Long targetDayId = 4L;
+        int targetOrder = 1;
+
+        Trip beforeTrip = Trip.builder()
+                .id(tripId)
+                .tripperId(tripperId)
+                .title("여행 제목")
+                .status(TripStatus.DECIDED)
+                .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
+                .build();
+        Day beforeTargetDay = Day.builder()
+                .id(targetDayId)
+                .tripDate(LocalDate.of(2023, 3, 1))
+                .trip(beforeTrip)
+                .build();
+        Schedule beforeTargetDaySchedule1 = Schedule.builder()
+                .id(scheduleId)
+                .day(beforeTargetDay)
+                .trip(beforeTrip)
+                .title("일정 제목1")
+                .place(Place.of("장소 식별자1", "장소명1", Coordinate.of(23.21, 23.24)))
+                .scheduleIndex(ScheduleIndex.of(10))
+                .build();
+        Schedule beforeTargetDaySchedule2 = Schedule.builder()
+                .id(scheduleId)
+                .day(beforeTargetDay)
+                .trip(beforeTrip)
+                .title("일정 제목2")
+                .place(Place.of("장소 식별자2", "장소명2", Coordinate.of(23.21, 23.24)))
+                .scheduleIndex(ScheduleIndex.of(11))
+                .build();
+        Schedule beforeMoveSchedule = Schedule.builder()
+                .id(scheduleId)
+                .day(null)
+                .trip(beforeTrip)
+                .title("일정 제목3")
+                .place(Place.of("장소 식별자3", "장소명3", Coordinate.of(23.21, 23.24)))
+                .scheduleIndex(ScheduleIndex.ZERO_INDEX)
+                .build();
+        beforeTrip.getDays().add(beforeTargetDay);
+        beforeTargetDay.getSchedules().add(beforeTargetDaySchedule1);
+        beforeTargetDay.getSchedules().add(beforeTargetDaySchedule2);
+        beforeTrip.getTemporaryStorage().add(beforeMoveSchedule);
+
+        Trip rediscoveredTrip = Trip.builder()
+                .id(tripId)
+                .tripperId(tripperId)
+                .title("여행 제목")
+                .status(TripStatus.DECIDED)
+                .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
+                .build();
+        Day rediscoveredTargetDay = Day.builder()
+                .id(targetDayId)
+                .tripDate(LocalDate.of(2023, 3, 1))
+                .trip(rediscoveredTrip)
+                .build();
+        Schedule rediscoveredTargetDaySchedule1 = Schedule.builder()
+                .id(scheduleId)
+                .day(rediscoveredTargetDay)
+                .trip(rediscoveredTrip)
+                .title("일정 제목1")
+                .place(Place.of("장소 식별자1", "장소명1", Coordinate.of(23.21, 23.24)))
+                .scheduleIndex(ScheduleIndex.ZERO_INDEX)
+                .build();
+        Schedule rediscoveredTargetDaySchedule2 = Schedule.builder()
+                .id(scheduleId)
+                .day(rediscoveredTargetDay)
+                .trip(rediscoveredTrip)
+                .title("일정 제목2")
+                .place(Place.of("장소 식별자2", "장소명2", Coordinate.of(23.21, 23.24)))
+                .scheduleIndex(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP))
+                .build();
+        Schedule rediscoveredMoveSchedule = Schedule.builder()
+                .id(scheduleId)
+                .day(null)
+                .trip(rediscoveredTrip)
+                .title("일정 제목")
+                .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
+                .scheduleIndex(ScheduleIndex.ZERO_INDEX)
+                .build();
+        rediscoveredTrip.getDays().add(rediscoveredTargetDay);
+        rediscoveredTargetDay.getSchedules().add(rediscoveredTargetDaySchedule1);
+        rediscoveredTargetDay.getSchedules().add(rediscoveredTargetDaySchedule2);
+        rediscoveredTrip.getTemporaryStorage().add(rediscoveredMoveSchedule);
+
+        ScheduleMoveCommand moveCommand = ScheduleMoveCommand.of(targetDayId, targetOrder);
+
+        when(scheduleRepository.findByIdWithTrip(eq(scheduleId)))
+                .thenReturn(Optional.of(beforeMoveSchedule))
+                .thenReturn(Optional.of(rediscoveredMoveSchedule));
+
+        when(dayRepository.findByIdWithTrip(eq(targetDayId)))
+                .thenReturn(Optional.of(beforeTargetDay))
+                .thenReturn(Optional.of(rediscoveredTargetDay));
+
+        given(scheduleRepository.relocateDaySchedules(eq(tripId), eq(targetDayId))).willReturn(1);
+
+        scheduleMoveService.moveSchedule(scheduleId, tripperId, moveCommand);
+
+        verify(scheduleRepository, times(2)).findByIdWithTrip(eq(scheduleId));
+        verify(dayRepository, times(2)).findByIdWithTrip(eq(targetDayId));
+        verify(scheduleRepository, times(1)).relocateDaySchedules(eq(tripId), eq(targetDayId));
+    }
+}

--- a/src/test/java/com/cosain/trilo/unit/trip/command/domain/entity/TripTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/domain/entity/TripTest.java
@@ -11,6 +11,7 @@ import com.cosain.trilo.trip.command.domain.vo.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.cglib.core.Local;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -735,6 +736,20 @@ public class TripTest {
                         .isInstanceOf(InvalidScheduleMoveTargetOrderException.class);
             }
 
+            @DisplayName("targetOrder가 임시보관함 크기를 넘어가는 경우 InvalidScheduleMoveTargetOrderException 발생")
+            @Test
+            public void when_targetOrder_is_over_temporary_storage_max_size_then_it_throws_InvalidScheduleMoveTargetOrderException() {
+                Trip trip = Trip.create("여행제목", 1L);
+                Day day = null;
+
+                Schedule schedule1 = trip.createSchedule(day, "일정제목",Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(day, "일정제목",Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+
+                // when & then
+                assertThatThrownBy(()-> trip.moveSchedule(schedule1, day, 3))
+                        .isInstanceOf(InvalidScheduleMoveTargetOrderException.class);
+            }
+
         }
 
         @Nested
@@ -776,6 +791,23 @@ public class TripTest {
                 assertThatThrownBy(()-> trip.moveSchedule(schedule, targetDay, -1))
                         .isInstanceOf(InvalidScheduleMoveTargetOrderException.class);
             }
+
+            @DisplayName("targetOrder가 Schedules 크기를 넘어가는 경우 InvalidScheduleMoveTargetOrderException 발생")
+            @Test
+            public void when_targetOrder_is_over_day_schedules_max_size_then_it_throws_InvalidScheduleMoveTargetOrderException() {
+                Trip trip = Trip.create("여행제목", 1L);
+                trip.changePeriod(TripPeriod.of(LocalDate.of(2023,3,1), LocalDate.of(2023,3,1)));
+
+                Day beforeDay = null;
+                Schedule schedule1 = trip.createSchedule(beforeDay, "일정제목",Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+
+                Day targetDay = trip.getDays().get(0);
+                Schedule schedule2 = trip.createSchedule(targetDay, "일정제목2" ,Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+
+                // when & then
+                assertThatThrownBy(()-> trip.moveSchedule(schedule1, targetDay, 2))
+                        .isInstanceOf(InvalidScheduleMoveTargetOrderException.class);
+            }
         }
 
         @Nested
@@ -800,7 +832,6 @@ public class TripTest {
                         .isInstanceOf(InvalidTripDayException.class);
             }
 
-
             @DisplayName("targetOrder가 0보다 작으면 InvalidScheduleMoveTargetOrderException 발생")
             @Test
             public void when_targetOrder_is_under_zero_then_it_throws_InvalidScheduleMoveTargetOrderException() {
@@ -814,6 +845,24 @@ public class TripTest {
 
                 // when & then
                 assertThatThrownBy(()-> trip.moveSchedule(schedule, targetDay, -1))
+                        .isInstanceOf(InvalidScheduleMoveTargetOrderException.class);
+            }
+
+            @DisplayName("targetOrder가 Schedules 크기를 넘어가는 경우 InvalidScheduleMoveTargetOrderException 발생")
+            @Test
+            public void when_targetOrder_is_over_day_schedules_max_size_then_it_throws_InvalidScheduleMoveTargetOrderException() {
+                Trip trip = Trip.create("여행제목", 1L);
+                trip.changePeriod(TripPeriod.of(LocalDate.of(2023,3,1), LocalDate.of(2023,3,2)));
+
+                Day beforeDay = trip.getDays().get(0);
+                Schedule schedule1 = trip.createSchedule(beforeDay, "일정제목",Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+
+
+                Day targetDay = trip.getDays().get(1);
+                Schedule schedule2 = trip.createSchedule(targetDay, "일정제목2" ,Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+
+                // when & then
+                assertThatThrownBy(()-> trip.moveSchedule(schedule1, targetDay, 2))
                         .isInstanceOf(InvalidScheduleMoveTargetOrderException.class);
             }
         }
@@ -835,6 +884,22 @@ public class TripTest {
 
                 // when & then
                 assertThatThrownBy(()-> trip.moveSchedule(schedule, targetDay, -1))
+                        .isInstanceOf(InvalidScheduleMoveTargetOrderException.class);
+            }
+
+            @DisplayName("targetOrder가 임시보관함 크기를 넘어가는 경우 InvalidScheduleMoveTargetOrderException 발생")
+            @Test
+            public void when_targetOrder_is_over_temporary_storage_max_size_then_it_throws_InvalidScheduleMoveTargetOrderException() {
+                Trip trip = Trip.create("여행제목", 1L);
+                trip.changePeriod(TripPeriod.of(LocalDate.of(2023,3,1), LocalDate.of(2023,3,1)));
+                Day beforeDay = trip.getDays().get(0);
+                Day targetDay = null;
+
+                Schedule schedule1 = trip.createSchedule(beforeDay, "일정제목",Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(targetDay, "일정제목",Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+
+                // when & then
+                assertThatThrownBy(()-> trip.moveSchedule(schedule1, targetDay, 2))
                         .isInstanceOf(InvalidScheduleMoveTargetOrderException.class);
             }
         }

--- a/src/test/java/com/cosain/trilo/unit/trip/command/domain/entity/TripTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/domain/entity/TripTest.java
@@ -612,7 +612,7 @@ public class TripTest {
 
                 Day validDay = Day.builder()
                         .id(1L)
-                        .tripDate(LocalDate.of(2023, 3,1))
+                        .tripDate(LocalDate.of(2023, 3, 1))
                         .trip(trip)
                         .build();
 
@@ -623,11 +623,11 @@ public class TripTest {
                         .tripperId(2L)
                         .title("여행제목2")
                         .status(TripStatus.DECIDED)
-                        .tripPeriod(TripPeriod.of(LocalDate.of(2023,3,2), LocalDate.of(2023,3,2)))
+                        .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 2), LocalDate.of(2023, 3, 2)))
                         .build();
                 Day otherTripDay = Day.builder()
                         .id(2L)
-                        .tripDate(LocalDate.of(2023, 3,2))
+                        .tripDate(LocalDate.of(2023, 3, 2))
                         .trip(otherTrip)
                         .build();
 
@@ -653,7 +653,7 @@ public class TripTest {
 
                 Day day = Day.builder()
                         .id(1L)
-                        .tripDate(LocalDate.of(2023, 3,1))
+                        .tripDate(LocalDate.of(2023, 3, 1))
                         .trip(trip)
                         .build();
 
@@ -689,7 +689,7 @@ public class TripTest {
 
                 Day day = Day.builder()
                         .id(1L)
-                        .tripDate(LocalDate.of(2023, 3,1))
+                        .tripDate(LocalDate.of(2023, 3, 1))
                         .trip(trip)
                         .build();
 
@@ -728,10 +728,10 @@ public class TripTest {
                 // given
                 Trip trip = Trip.create("여행제목", 1L);
                 Day day = null;
-                Schedule schedule = trip.createSchedule(day, "일정제목",Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule = trip.createSchedule(day, "일정제목", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
 
                 // when & then
-                assertThatThrownBy(()-> trip.moveSchedule(schedule, day, -1))
+                assertThatThrownBy(() -> trip.moveSchedule(schedule, day, -1))
                         .isInstanceOf(InvalidScheduleMoveTargetOrderException.class);
             }
 
@@ -741,11 +741,11 @@ public class TripTest {
                 Trip trip = Trip.create("여행제목", 1L);
                 Day day = null;
 
-                Schedule schedule1 = trip.createSchedule(day, "일정제목",Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule2 = trip.createSchedule(day, "일정제목",Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(day, "일정제목", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(day, "일정제목", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when & then
-                assertThatThrownBy(()-> trip.moveSchedule(schedule1, day, 3))
+                assertThatThrownBy(() -> trip.moveSchedule(schedule1, day, 3))
                         .isInstanceOf(InvalidScheduleMoveTargetOrderException.class);
             }
 
@@ -755,8 +755,8 @@ public class TripTest {
                 Trip trip = Trip.create("여행제목", 1L);
                 Day day = null;
 
-                Schedule schedule1 = trip.createSchedule(day, "일정제목1",Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule2 = trip.createSchedule(day, "일정제목2",Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(day, "일정제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(day, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when
                 trip.moveSchedule(schedule2, day, 1);
@@ -779,8 +779,8 @@ public class TripTest {
                 Trip trip = Trip.create("여행제목", 1L);
                 Day day = null;
 
-                Schedule schedule1 = trip.createSchedule(day, "일정제목1",Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule2 = trip.createSchedule(day, "일정제목2",Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(day, "일정제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(day, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when
                 trip.moveSchedule(schedule2, day, 2);
@@ -797,6 +797,57 @@ public class TripTest {
                 assertThat(secondSchedule.getScheduleIndex()).isEqualTo(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP));
             }
 
+            @DisplayName("targetOrder가 임시보관함 크기와 똑같은 값이고, 끝 ScheduleIndex 범위가 안전하면 맨 뒤로 이동한다.")
+            @Test
+            public void when_targetOrder_isEqualTo_TemporaryStorageSize_and_tail_scheduleIndex_isSafe_schedule_move_to_Tail() {
+                Trip trip = Trip.create("여행제목", 1L);
+                Day day = null;
+
+                Schedule schedule1 = trip.createSchedule(day, "일정제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(day, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+
+                // when
+                trip.moveSchedule(schedule1, day, 2);
+
+                // then
+                List<Schedule> temporaryStorage = trip.getTemporaryStorage();
+
+                assertThat(temporaryStorage.size()).isEqualTo(2);
+                assertThat(temporaryStorage).containsExactlyInAnyOrder(schedule1, schedule2);
+                assertThat(schedule1.getScheduleIndex()).isEqualTo(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP * 2));
+                assertThat(schedule2.getScheduleIndex()).isEqualTo(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP));
+            }
+
+            @DisplayName("targetOrder가 임시보관함 크기와 똑같은 값이고, 끝 ScheduleIndex 범위가 안전하지 않으면 ScheduleIndexRangeException 발생")
+            @Test
+            public void when_targetOrder_isEqualTo_TemporaryStorageSize_and_tail_scheduleIndex_is_unSafe_it_throws_ScheduleIndexRangeException() {
+                Trip trip = Trip.create("여행제목", 1L);
+                Day day = null;
+
+                Schedule schedule1 = Schedule.builder()
+                        .day(day)
+                        .trip(trip)
+                        .title("일정제목1")
+                        .place(Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)))
+                        .scheduleIndex(ScheduleIndex.ZERO_INDEX)
+                        .build();
+
+                Schedule schedule2 = Schedule.builder()
+                        .day(day)
+                        .trip(trip)
+                        .title("일정제목2")
+                        .place(Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)))
+                        .scheduleIndex(ScheduleIndex.of(ScheduleIndex.MAX_INDEX_VALUE))
+                        .build();
+
+                trip.getTemporaryStorage().add(schedule1);
+                trip.getTemporaryStorage().add(schedule2);
+
+
+                // when & then
+                assertThatThrownBy(() -> trip.moveSchedule(schedule1, day, 2))
+                        .isInstanceOf(ScheduleIndexRangeException.class);
+            }
         }
 
         @Nested
@@ -810,16 +861,16 @@ public class TripTest {
                 Trip trip = Trip.create("여행제목", 1L);
 
                 Trip otherTrip = Trip.create("다른 여행 제목", 1L);
-                otherTrip.changePeriod(TripPeriod.of(LocalDate.of(2023,4,1), LocalDate.of(2023,4,1)));
+                otherTrip.changePeriod(TripPeriod.of(LocalDate.of(2023, 4, 1), LocalDate.of(2023, 4, 1)));
 
                 Day beforeDay = null;
-                Schedule schedule = trip.createSchedule(beforeDay, "일정제목",Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule = trip.createSchedule(beforeDay, "일정제목", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
 
                 Day targetDay = otherTrip.getDays().get(0);
 
 
                 // when & then
-                assertThatThrownBy(()-> trip.moveSchedule(schedule, targetDay, 0))
+                assertThatThrownBy(() -> trip.moveSchedule(schedule, targetDay, 0))
                         .isInstanceOf(InvalidTripDayException.class);
             }
 
@@ -828,14 +879,14 @@ public class TripTest {
             public void when_targetOrder_is_under_zero_then_it_throws_InvalidScheduleMoveTargetOrderException() {
                 // given
                 Trip trip = Trip.create("여행제목", 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023,3,1), LocalDate.of(2023,3,1)));
+                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
                 Day beforeDay = null;
-                Schedule schedule = trip.createSchedule(beforeDay, "일정제목",Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule = trip.createSchedule(beforeDay, "일정제목", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
 
                 Day targetDay = trip.getDays().get(0);
 
                 // when & then
-                assertThatThrownBy(()-> trip.moveSchedule(schedule, targetDay, -1))
+                assertThatThrownBy(() -> trip.moveSchedule(schedule, targetDay, -1))
                         .isInstanceOf(InvalidScheduleMoveTargetOrderException.class);
             }
 
@@ -843,17 +894,78 @@ public class TripTest {
             @Test
             public void when_targetOrder_is_over_day_schedules_max_size_then_it_throws_InvalidScheduleMoveTargetOrderException() {
                 Trip trip = Trip.create("여행제목", 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023,3,1), LocalDate.of(2023,3,1)));
+                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
 
                 Day beforeDay = null;
-                Schedule schedule1 = trip.createSchedule(beforeDay, "일정제목",Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(beforeDay, "일정제목", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
 
                 Day targetDay = trip.getDays().get(0);
-                Schedule schedule2 = trip.createSchedule(targetDay, "일정제목2" ,Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(targetDay, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when & then
-                assertThatThrownBy(()-> trip.moveSchedule(schedule1, targetDay, 2))
+                assertThatThrownBy(() -> trip.moveSchedule(schedule1, targetDay, 2))
                         .isInstanceOf(InvalidScheduleMoveTargetOrderException.class);
+            }
+
+
+            @DisplayName("targetOrder가 Schedules 크기와 똑같은 값이고, 끝 ScheduleIndex 범위가 안전하면 맨 뒤로 이동한다.")
+            @Test
+            public void when_targetOrder_isEqualTo_SchedulesSize_and_tail_scheduleIndex_isSafe_schedule_move_to_Tail() {
+                Trip trip = Trip.create("여행제목", 1L);
+                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
+
+                Day beforeDay = null;
+                Day targetDay = trip.getDays().get(0);
+
+                Schedule schedule1 = trip.createSchedule(beforeDay, "일정제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(targetDay, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+
+                // when
+                trip.moveSchedule(schedule1, targetDay, 1);
+
+                // then
+                List<Schedule> temporaryStorage = trip.getTemporaryStorage();
+                List<Schedule> schedules = targetDay.getSchedules();
+
+                assertThat(temporaryStorage).isEmpty();
+                assertThat(schedules.size()).isEqualTo(2);
+                assertThat(schedules).containsExactlyInAnyOrder(schedule1, schedule2);
+                assertThat(schedule1.getScheduleIndex()).isEqualTo(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP));
+                assertThat(schedule2.getScheduleIndex()).isEqualTo(ScheduleIndex.ZERO_INDEX);
+            }
+
+            @DisplayName("targetOrder가 Schedules 크기와 똑같은 값이고, 끝 ScheduleIndex 범위가 안전하지 않으면 ScheduleIndexRangeException 발생")
+            @Test
+            public void when_targetOrder_isEqualTo_SchedulesSize_and_tail_scheduleIndex_is_unSafe_it_throws_ScheduleIndexRangeException() {
+                Trip trip = Trip.create("여행제목", 1L);
+                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
+
+                Day beforeDay = null;
+                Day targetDay = trip.getDays().get(0);
+
+                Schedule schedule1 = Schedule.builder()
+                        .day(beforeDay)
+                        .trip(trip)
+                        .title("일정제목1")
+                        .place(Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)))
+                        .scheduleIndex(ScheduleIndex.ZERO_INDEX)
+                        .build();
+
+                Schedule schedule2 = Schedule.builder()
+                        .day(targetDay)
+                        .trip(trip)
+                        .title("일정제목2")
+                        .place(Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)))
+                        .scheduleIndex(ScheduleIndex.of(ScheduleIndex.MAX_INDEX_VALUE))
+                        .build();
+
+                trip.getTemporaryStorage().add(schedule1);
+                targetDay.getSchedules().add(schedule2);
+
+
+                // when & then
+                assertThatThrownBy(() -> trip.moveSchedule(schedule1, targetDay, 1))
+                        .isInstanceOf(ScheduleIndexRangeException.class);
             }
         }
 
@@ -866,16 +978,16 @@ public class TripTest {
             public void when_targetDay_is_not_in_trip_then_it_throws_InvalidTripDayException() {
                 // given
                 Trip trip = Trip.create("여행제목", 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023,3,1), LocalDate.of(2023,3,2)));
+                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
                 Day beforeDay = trip.getDays().get(0);
                 Schedule schedule = trip.createSchedule(beforeDay, "여행 제목", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
 
                 Trip otherTrip = Trip.create("다른 여행 제목", 1L);
-                otherTrip.changePeriod(TripPeriod.of(LocalDate.of(2023,4,1), LocalDate.of(2023,4,1)));
+                otherTrip.changePeriod(TripPeriod.of(LocalDate.of(2023, 4, 1), LocalDate.of(2023, 4, 1)));
                 Day targetDay = otherTrip.getDays().get(0);
 
                 // when & then
-                assertThatThrownBy(()-> trip.moveSchedule(schedule, targetDay, 0))
+                assertThatThrownBy(() -> trip.moveSchedule(schedule, targetDay, 0))
                         .isInstanceOf(InvalidTripDayException.class);
             }
 
@@ -884,14 +996,14 @@ public class TripTest {
             public void when_targetOrder_is_under_zero_then_it_throws_InvalidScheduleMoveTargetOrderException() {
                 // given
                 Trip trip = Trip.create("여행제목", 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023,3,1), LocalDate.of(2023,3,2)));
+                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
                 Day beforeDay = trip.getDays().get(0);
-                Schedule schedule = trip.createSchedule(beforeDay, "일정제목",Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule = trip.createSchedule(beforeDay, "일정제목", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
 
                 Day targetDay = trip.getDays().get(1);
 
                 // when & then
-                assertThatThrownBy(()-> trip.moveSchedule(schedule, targetDay, -1))
+                assertThatThrownBy(() -> trip.moveSchedule(schedule, targetDay, -1))
                         .isInstanceOf(InvalidScheduleMoveTargetOrderException.class);
             }
 
@@ -899,17 +1011,17 @@ public class TripTest {
             @Test
             public void when_targetOrder_is_over_day_schedules_max_size_then_it_throws_InvalidScheduleMoveTargetOrderException() {
                 Trip trip = Trip.create("여행제목", 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023,3,1), LocalDate.of(2023,3,2)));
+                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
 
                 Day beforeDay = trip.getDays().get(0);
-                Schedule schedule1 = trip.createSchedule(beforeDay, "일정제목",Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(beforeDay, "일정제목", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
 
 
                 Day targetDay = trip.getDays().get(1);
-                Schedule schedule2 = trip.createSchedule(targetDay, "일정제목2" ,Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(targetDay, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when & then
-                assertThatThrownBy(()-> trip.moveSchedule(schedule1, targetDay, 2))
+                assertThatThrownBy(() -> trip.moveSchedule(schedule1, targetDay, 2))
                         .isInstanceOf(InvalidScheduleMoveTargetOrderException.class);
             }
 
@@ -917,11 +1029,11 @@ public class TripTest {
             @Test
             public void when_move_to_same_day_and_same_position_then_nothing_changed() {
                 Trip trip = Trip.create("여행제목", 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023,3,1)));
+                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
                 Day day = trip.getDays().get(0);
 
-                Schedule schedule1 = trip.createSchedule(day, "일정제목1",Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule2 = trip.createSchedule(day, "일정제목2",Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(day, "일정제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(day, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when
                 trip.moveSchedule(schedule2, day, 1);
@@ -942,11 +1054,11 @@ public class TripTest {
             @Test
             public void when_move_to_same_day_and_after_currentOrder_then_nothing_changed() {
                 Trip trip = Trip.create("여행제목", 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023,3,1)));
+                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
                 Day day = trip.getDays().get(0);
 
-                Schedule schedule1 = trip.createSchedule(day, "일정제목1",Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule2 = trip.createSchedule(day, "일정제목2",Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(day, "일정제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(day, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when
                 trip.moveSchedule(schedule2, day, 2);
@@ -962,6 +1074,67 @@ public class TripTest {
                 assertThat(secondSchedule).isEqualTo(schedule2);
                 assertThat(secondSchedule.getScheduleIndex()).isEqualTo(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP));
             }
+
+
+            @DisplayName("targetOrder가 Schedules 크기와 똑같은 값이고, 끝 ScheduleIndex 범위가 안전하면 맨 뒤로 이동한다.")
+            @Test
+            public void when_targetOrder_isEqualTo_SchedulesSize_and_tail_scheduleIndex_isSafe_schedule_move_to_Tail() {
+                Trip trip = Trip.create("여행제목", 1L);
+                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
+
+                Day beforeDay = trip.getDays().get(0);
+                Day targetDay = trip.getDays().get(1);
+
+                Schedule schedule1 = trip.createSchedule(beforeDay, "일정제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(targetDay, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+
+                // when
+                trip.moveSchedule(schedule1, targetDay, 1);
+
+                // then
+                List<Schedule> beforeDaySchedules = beforeDay.getSchedules();
+                List<Schedule> targetDaySchedules = targetDay.getSchedules();
+
+                assertThat(beforeDaySchedules).isEmpty();
+                assertThat(targetDaySchedules.size()).isEqualTo(2);
+                assertThat(targetDaySchedules).containsExactlyInAnyOrder(schedule1, schedule2);
+                assertThat(schedule1.getScheduleIndex()).isEqualTo(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP));
+                assertThat(schedule2.getScheduleIndex()).isEqualTo(ScheduleIndex.ZERO_INDEX);
+            }
+
+            @DisplayName("targetOrder가 Schedules 크기와 똑같은 값이고, 끝 ScheduleIndex 범위가 안전하지 않으면 ScheduleIndexRangeException 발생")
+            @Test
+            public void when_targetOrder_isEqualTo_SchedulesSize_and_tail_scheduleIndex_is_unSafe_it_throws_ScheduleIndexRangeException() {
+                Trip trip = Trip.create("여행제목", 1L);
+                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
+
+                Day beforeDay = trip.getDays().get(0);
+                Day targetDay = trip.getDays().get(1);
+
+                Schedule schedule1 = Schedule.builder()
+                        .day(beforeDay)
+                        .trip(trip)
+                        .title("일정제목1")
+                        .place(Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)))
+                        .scheduleIndex(ScheduleIndex.ZERO_INDEX)
+                        .build();
+
+                Schedule schedule2 = Schedule.builder()
+                        .day(targetDay)
+                        .trip(trip)
+                        .title("일정제목2")
+                        .place(Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)))
+                        .scheduleIndex(ScheduleIndex.of(ScheduleIndex.MAX_INDEX_VALUE))
+                        .build();
+
+                beforeDay.getSchedules().add(schedule1);
+                targetDay.getSchedules().add(schedule2);
+
+
+                // when & then
+                assertThatThrownBy(() -> trip.moveSchedule(schedule1, targetDay, 1))
+                        .isInstanceOf(ScheduleIndexRangeException.class);
+            }
         }
 
         @Nested
@@ -973,14 +1146,14 @@ public class TripTest {
             public void when_targetOrder_is_under_zero_then_it_throws_InvalidScheduleMoveTargetOrderException() {
                 // given
                 Trip trip = Trip.create("여행제목", 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023,3,1), LocalDate.of(2023,3,1)));
+                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
                 Day beforeDay = trip.getDays().get(0);
-                Schedule schedule = trip.createSchedule(beforeDay, "일정제목",Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule = trip.createSchedule(beforeDay, "일정제목", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
 
                 Day targetDay = null;
 
                 // when & then
-                assertThatThrownBy(()-> trip.moveSchedule(schedule, targetDay, -1))
+                assertThatThrownBy(() -> trip.moveSchedule(schedule, targetDay, -1))
                         .isInstanceOf(InvalidScheduleMoveTargetOrderException.class);
             }
 
@@ -988,16 +1161,77 @@ public class TripTest {
             @Test
             public void when_targetOrder_is_over_temporary_storage_max_size_then_it_throws_InvalidScheduleMoveTargetOrderException() {
                 Trip trip = Trip.create("여행제목", 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023,3,1), LocalDate.of(2023,3,1)));
+                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
                 Day beforeDay = trip.getDays().get(0);
                 Day targetDay = null;
 
-                Schedule schedule1 = trip.createSchedule(beforeDay, "일정제목",Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule2 = trip.createSchedule(targetDay, "일정제목",Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(beforeDay, "일정제목", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(targetDay, "일정제목", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when & then
-                assertThatThrownBy(()-> trip.moveSchedule(schedule1, targetDay, 2))
+                assertThatThrownBy(() -> trip.moveSchedule(schedule1, targetDay, 2))
                         .isInstanceOf(InvalidScheduleMoveTargetOrderException.class);
+            }
+
+
+            @DisplayName("targetOrder가 임시보관함 크기와 똑같은 값이고, 끝 ScheduleIndex 범위가 안전하면 맨 뒤로 이동한다.")
+            @Test
+            public void when_targetOrder_isEqualTo_temporaryStorageSize_and_tail_scheduleIndex_isSafe_schedule_move_to_Tail() {
+                Trip trip = Trip.create("여행제목", 1L);
+                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
+
+                Day beforeDay = trip.getDays().get(0);
+                Day targetDay = null;
+
+                Schedule schedule1 = trip.createSchedule(beforeDay, "일정제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(targetDay, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+
+                // when
+                trip.moveSchedule(schedule1, targetDay, 1);
+
+                // then
+                List<Schedule> beforeDaySchedules = beforeDay.getSchedules();
+                List<Schedule> temporaryStorage = trip.getTemporaryStorage();
+
+                assertThat(beforeDaySchedules).isEmpty();
+                assertThat(temporaryStorage.size()).isEqualTo(2);
+                assertThat(temporaryStorage).containsExactlyInAnyOrder(schedule1, schedule2);
+                assertThat(schedule1.getScheduleIndex()).isEqualTo(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP));
+                assertThat(schedule2.getScheduleIndex()).isEqualTo(ScheduleIndex.ZERO_INDEX);
+            }
+
+            @DisplayName("targetOrder가 임시보관함 크기와 똑같은 값이고, 끝 ScheduleIndex 범위가 안전하지 않으면 ScheduleIndexRangeException 발생")
+            @Test
+            public void when_targetOrder_isEqualTo_temporaryStorageSize_and_tail_scheduleIndex_is_unSafe_it_throws_ScheduleIndexRangeException() {
+                Trip trip = Trip.create("여행제목", 1L);
+                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
+
+                Day beforeDay = trip.getDays().get(0);
+                Day targetDay = null;
+
+                Schedule schedule1 = Schedule.builder()
+                        .day(beforeDay)
+                        .trip(trip)
+                        .title("일정제목1")
+                        .place(Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)))
+                        .scheduleIndex(ScheduleIndex.ZERO_INDEX)
+                        .build();
+
+                Schedule schedule2 = Schedule.builder()
+                        .day(targetDay)
+                        .trip(trip)
+                        .title("일정제목2")
+                        .place(Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)))
+                        .scheduleIndex(ScheduleIndex.of(ScheduleIndex.MAX_INDEX_VALUE))
+                        .build();
+
+                beforeDay.getSchedules().add(schedule1);
+                trip.getTemporaryStorage().add(schedule2);
+
+
+                // when & then
+                assertThatThrownBy(() -> trip.moveSchedule(schedule1, targetDay, 1))
+                        .isInstanceOf(ScheduleIndexRangeException.class);
             }
         }
     }

--- a/src/test/java/com/cosain/trilo/unit/trip/command/domain/entity/TripTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/domain/entity/TripTest.java
@@ -11,7 +11,6 @@ import com.cosain.trilo.trip.command.domain.vo.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.cglib.core.Local;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -750,6 +749,54 @@ public class TripTest {
                         .isInstanceOf(InvalidScheduleMoveTargetOrderException.class);
             }
 
+            @DisplayName("임시보관함 내에서, 자신의 기존 순서로 이동할 경우, 아무런 변화도 일어나지 않는다.")
+            @Test
+            public void when_move_to_same_position_then_nothing_changed() {
+                Trip trip = Trip.create("여행제목", 1L);
+                Day day = null;
+
+                Schedule schedule1 = trip.createSchedule(day, "일정제목1",Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(day, "일정제목2",Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+
+                // when
+                trip.moveSchedule(schedule2, day, 1);
+
+                // then
+                List<Schedule> temporaryStorage = trip.getTemporaryStorage();
+                Schedule firstSchedule = temporaryStorage.get(0);
+                Schedule secondSchedule = temporaryStorage.get(1);
+
+                assertThat(temporaryStorage.size()).isEqualTo(2);
+                assertThat(firstSchedule).isEqualTo(schedule1);
+                assertThat(firstSchedule.getScheduleIndex()).isEqualTo(ScheduleIndex.ZERO_INDEX);
+                assertThat(secondSchedule).isEqualTo(schedule2);
+                assertThat(secondSchedule.getScheduleIndex()).isEqualTo(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP));
+            }
+
+            @DisplayName("임시보관함 내에 기존의 순서 다음으로 이동시키려 할 경우, 아무런 변화도 일어나지 않는다.")
+            @Test
+            public void when_move_to_after_currentOrder_then_nothing_changed() {
+                Trip trip = Trip.create("여행제목", 1L);
+                Day day = null;
+
+                Schedule schedule1 = trip.createSchedule(day, "일정제목1",Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(day, "일정제목2",Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+
+                // when
+                trip.moveSchedule(schedule2, day, 2);
+
+                // then
+                List<Schedule> temporaryStorage = trip.getTemporaryStorage();
+                Schedule firstSchedule = temporaryStorage.get(0);
+                Schedule secondSchedule = temporaryStorage.get(1);
+
+                assertThat(temporaryStorage.size()).isEqualTo(2);
+                assertThat(firstSchedule).isEqualTo(schedule1);
+                assertThat(firstSchedule.getScheduleIndex()).isEqualTo(ScheduleIndex.ZERO_INDEX);
+                assertThat(secondSchedule).isEqualTo(schedule2);
+                assertThat(secondSchedule.getScheduleIndex()).isEqualTo(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP));
+            }
+
         }
 
         @Nested
@@ -864,6 +911,56 @@ public class TripTest {
                 // when & then
                 assertThatThrownBy(()-> trip.moveSchedule(schedule1, targetDay, 2))
                         .isInstanceOf(InvalidScheduleMoveTargetOrderException.class);
+            }
+
+            @DisplayName("같은 Day의 기존의 순서로 이동할 경우, 아무런 변화도 일어나지 않는다.")
+            @Test
+            public void when_move_to_same_day_and_same_position_then_nothing_changed() {
+                Trip trip = Trip.create("여행제목", 1L);
+                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023,3,1)));
+                Day day = trip.getDays().get(0);
+
+                Schedule schedule1 = trip.createSchedule(day, "일정제목1",Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(day, "일정제목2",Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+
+                // when
+                trip.moveSchedule(schedule2, day, 1);
+
+                // then
+                List<Schedule> schedules = day.getSchedules();
+                Schedule firstSchedule = schedules.get(0);
+                Schedule secondSchedule = schedules.get(1);
+
+                assertThat(schedules.size()).isEqualTo(2);
+                assertThat(firstSchedule).isEqualTo(schedule1);
+                assertThat(firstSchedule.getScheduleIndex()).isEqualTo(ScheduleIndex.ZERO_INDEX);
+                assertThat(secondSchedule).isEqualTo(schedule2);
+                assertThat(secondSchedule.getScheduleIndex()).isEqualTo(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP));
+            }
+
+            @DisplayName("같은 Day의 기존의 순서 다음으로 이동시키려 할 경우, 아무런 변화도 일어나지 않는다.")
+            @Test
+            public void when_move_to_same_day_and_after_currentOrder_then_nothing_changed() {
+                Trip trip = Trip.create("여행제목", 1L);
+                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023,3,1)));
+                Day day = trip.getDays().get(0);
+
+                Schedule schedule1 = trip.createSchedule(day, "일정제목1",Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(day, "일정제목2",Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+
+                // when
+                trip.moveSchedule(schedule2, day, 2);
+
+                // then
+                List<Schedule> schedules = day.getSchedules();
+                Schedule firstSchedule = schedules.get(0);
+                Schedule secondSchedule = schedules.get(1);
+
+                assertThat(schedules.size()).isEqualTo(2);
+                assertThat(firstSchedule).isEqualTo(schedule1);
+                assertThat(firstSchedule.getScheduleIndex()).isEqualTo(ScheduleIndex.ZERO_INDEX);
+                assertThat(secondSchedule).isEqualTo(schedule2);
+                assertThat(secondSchedule.getScheduleIndex()).isEqualTo(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP));
             }
         }
 

--- a/src/test/java/com/cosain/trilo/unit/trip/command/domain/entity/TripTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/domain/entity/TripTest.java
@@ -10,7 +10,6 @@ import com.cosain.trilo.trip.command.domain.vo.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.cglib.core.Local;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -704,4 +703,80 @@ public class TripTest {
         }
     }
 
+
+    /**
+     * TODO
+     * 임시보관함 -> 임시보관함(같은 곳) // 임시보관함 -> Day(다른 곳) // Day -> 임시보관함 // Day -> Day(같은 곳)
+     * - targetOrder가 음수일 경우
+     * - targetOrder가 인덱스 범위를 벗어나는 경우
+     * - targetOrder가 자기 자신일 경우 변경 없음
+     * -
+     */
+
+    @Nested
+    @DisplayName("MoveSchedule 테스트")
+    class MoveScheduleTest {
+
+        @Nested
+        @DisplayName("임시보관함에서 임시보관함으로 옮길 떄")
+        class Case_From_TemporaryStorage_To_TemporaryStorage {
+
+        }
+
+        @Nested
+        @DisplayName("임시보관함에서 어떤 Day로 옮길 때")
+        class Case_From_TemporaryStorage_To_Day {
+
+            @Test
+            @DisplayName("targetDay가 Trip의 Day가 아니면, InvalidTripDayException 발생")
+            public void when_targetDay_is_not_in_trip_then_it_throws_InvalidTripDayException() {
+                // given
+                Trip trip = Trip.create("여행제목", 1L);
+
+                Trip otherTrip = Trip.create("다른 여행 제목", 1L);
+                otherTrip.changePeriod(TripPeriod.of(LocalDate.of(2023,4,1), LocalDate.of(2023,4,1)));
+
+                Day beforeDay = null;
+                Schedule schedule = trip.createSchedule(beforeDay, "일정제목",Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+
+                Day targetDay = otherTrip.getDays().get(0);
+
+
+                // when & then
+                assertThatThrownBy(()-> trip.moveSchedule(schedule, targetDay, 0))
+                        .isInstanceOf(InvalidTripDayException.class);
+            }
+
+        }
+
+        @Nested
+        @DisplayName("Day에서 Day로 옮길 때")
+        class Case_From_Day_To_Day {
+
+            @Test
+            @DisplayName("targetDay가 Trip의 Day가 아니면, InvalidTripDayException 발생")
+            public void when_targetDay_is_not_in_trip_then_it_throws_InvalidTripDayException() {
+                // given
+                Trip trip = Trip.create("여행제목", 1L);
+                trip.changePeriod(TripPeriod.of(LocalDate.of(2023,3,1), LocalDate.of(2023,3,2)));
+                Day beforeDay = trip.getDays().get(0);
+                Schedule schedule = trip.createSchedule(beforeDay, "여행 제목", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+
+                Trip otherTrip = Trip.create("다른 여행 제목", 1L);
+                otherTrip.changePeriod(TripPeriod.of(LocalDate.of(2023,4,1), LocalDate.of(2023,4,1)));
+                Day targetDay = otherTrip.getDays().get(0);
+
+                // when & then
+                assertThatThrownBy(()-> trip.moveSchedule(schedule, targetDay, 0))
+                        .isInstanceOf(InvalidTripDayException.class);
+            }
+
+        }
+
+        @Nested
+        @DisplayName("Day에서 임시보관함으로 옮길 때")
+        class Case_From_Day_To_TemporaryStorage {
+
+        }
+    }
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/command/domain/entity/TripTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/domain/entity/TripTest.java
@@ -1,5 +1,6 @@
 package com.cosain.trilo.unit.trip.command.domain.entity;
 
+import com.cosain.trilo.trip.command.domain.dto.ScheduleMoveDto;
 import com.cosain.trilo.trip.command.domain.entity.Day;
 import com.cosain.trilo.trip.command.domain.entity.Schedule;
 import com.cosain.trilo.trip.command.domain.entity.Trip;
@@ -746,7 +747,7 @@ public class TripTest {
                 Schedule schedule2 = trip.createSchedule(day, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when
-                trip.moveSchedule(schedule2, day, 1);
+                ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule2, day, 1);
 
                 // then
                 List<Schedule> temporaryStorage = trip.getTemporaryStorage();
@@ -758,6 +759,9 @@ public class TripTest {
                 assertThat(firstSchedule.getScheduleIndex()).isEqualTo(ScheduleIndex.ZERO_INDEX);
                 assertThat(secondSchedule).isEqualTo(schedule2);
                 assertThat(secondSchedule.getScheduleIndex()).isEqualTo(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP));
+                assertThat(scheduleMoveDto.getBeforeDayId()).isEqualTo(null);
+                assertThat(scheduleMoveDto.getAfterDayId()).isEqualTo(null);
+                assertThat(scheduleMoveDto.isPositionChanged()).isEqualTo(false);
             }
 
             @DisplayName("임시보관함 내에 기존의 순서 다음으로 이동시키려 할 경우, 아무런 변화도 일어나지 않는다.")
@@ -770,7 +774,7 @@ public class TripTest {
                 Schedule schedule2 = trip.createSchedule(day, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when
-                trip.moveSchedule(schedule2, day, 2);
+                ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule2, day, 2);
 
                 // then
                 List<Schedule> temporaryStorage = trip.getTemporaryStorage();
@@ -782,6 +786,9 @@ public class TripTest {
                 assertThat(firstSchedule.getScheduleIndex()).isEqualTo(ScheduleIndex.ZERO_INDEX);
                 assertThat(secondSchedule).isEqualTo(schedule2);
                 assertThat(secondSchedule.getScheduleIndex()).isEqualTo(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP));
+                assertThat(scheduleMoveDto.getBeforeDayId()).isEqualTo(null);
+                assertThat(scheduleMoveDto.getAfterDayId()).isEqualTo(null);
+                assertThat(scheduleMoveDto.isPositionChanged()).isEqualTo(false);
             }
 
             @DisplayName("targetOrder가 임시보관함 크기와 똑같은 값이고, 끝 ScheduleIndex 범위가 안전하면 맨 뒤로 이동한다.")
@@ -794,7 +801,7 @@ public class TripTest {
                 Schedule schedule2 = trip.createSchedule(day, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when
-                trip.moveSchedule(schedule1, day, 2);
+                ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule1, day, 2);
 
                 // then
                 List<Schedule> temporaryStorage = trip.getTemporaryStorage();
@@ -803,6 +810,9 @@ public class TripTest {
                 assertThat(temporaryStorage).containsExactlyInAnyOrder(schedule1, schedule2);
                 assertThat(schedule1.getScheduleIndex()).isEqualTo(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP * 2));
                 assertThat(schedule2.getScheduleIndex()).isEqualTo(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP));
+                assertThat(scheduleMoveDto.getBeforeDayId()).isEqualTo(null);
+                assertThat(scheduleMoveDto.getAfterDayId()).isEqualTo(null);
+                assertThat(scheduleMoveDto.isPositionChanged()).isEqualTo(true);
             }
 
             @DisplayName("targetOrder가 임시보관함 크기와 똑같은 값이고, 끝 ScheduleIndex 범위가 안전하지 않으면 ScheduleIndexRangeException 발생")
@@ -846,7 +856,7 @@ public class TripTest {
                 Schedule schedule2 = trip.createSchedule(day, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when
-                trip.moveSchedule(schedule2, day, 0);
+                ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule2, day, 0);
 
                 // then
                 List<Schedule> temporaryStorage = trip.getTemporaryStorage();
@@ -855,6 +865,9 @@ public class TripTest {
                 assertThat(temporaryStorage).containsExactlyInAnyOrder(schedule1, schedule2);
                 assertThat(schedule1.getScheduleIndex()).isEqualTo(ScheduleIndex.ZERO_INDEX);
                 assertThat(schedule2.getScheduleIndex()).isEqualTo(ScheduleIndex.of(-ScheduleIndex.DEFAULT_SEQUENCE_GAP));
+                assertThat(scheduleMoveDto.getBeforeDayId()).isEqualTo(null);
+                assertThat(scheduleMoveDto.getAfterDayId()).isEqualTo(null);
+                assertThat(scheduleMoveDto.isPositionChanged()).isEqualTo(true);
             }
 
             @DisplayName("targetOrder가 0이고, 맨 앞 ScheduleIndex 범위가 안전하지 않으면 ScheduleIndexRangeException 발생")
@@ -899,7 +912,7 @@ public class TripTest {
                 Schedule schedule3 = trip.createSchedule(day, "일정제목3", Place.of("place-id333", "place 이름333", Coordinate.of(37.72221, 137.86523)));
 
                 // when
-                trip.moveSchedule(schedule1, day, 2);
+                ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule1, day, 2);
 
                 // then
                 List<Schedule> temporaryStorage = trip.getTemporaryStorage();
@@ -908,6 +921,9 @@ public class TripTest {
                 assertThat(schedule1.getScheduleIndex()).isEqualTo(schedule2.getScheduleIndex().mid(schedule3.getScheduleIndex()));
                 assertThat(schedule2.getScheduleIndex()).isEqualTo(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP));
                 assertThat(schedule3.getScheduleIndex()).isEqualTo(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP * 2));
+                assertThat(scheduleMoveDto.getBeforeDayId()).isEqualTo(null);
+                assertThat(scheduleMoveDto.getAfterDayId()).isEqualTo(null);
+                assertThat(scheduleMoveDto.isPositionChanged()).isEqualTo(true);
             }
 
             @DisplayName("targetOrder가 다른 일정의 순서이고, 해당 순서 앞과 간격이 충분하지 않으면 MidScheduleIndexConflictException 발생")
@@ -1022,7 +1038,7 @@ public class TripTest {
                 Schedule schedule2 = trip.createSchedule(targetDay, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when
-                trip.moveSchedule(schedule1, targetDay, 1);
+                ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule1, targetDay, 1);
 
                 // then
                 List<Schedule> temporaryStorage = trip.getTemporaryStorage();
@@ -1033,6 +1049,9 @@ public class TripTest {
                 assertThat(schedules).containsExactlyInAnyOrder(schedule1, schedule2);
                 assertThat(schedule1.getScheduleIndex()).isEqualTo(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP));
                 assertThat(schedule2.getScheduleIndex()).isEqualTo(ScheduleIndex.ZERO_INDEX);
+                assertThat(scheduleMoveDto.getBeforeDayId()).isEqualTo(null);
+                assertThat(scheduleMoveDto.getAfterDayId()).isEqualTo(targetDay.getId());
+                assertThat(scheduleMoveDto.isPositionChanged()).isEqualTo(true);
             }
 
             @DisplayName("targetOrder가 Schedules 크기와 똑같은 값이고, 끝 ScheduleIndex 범위가 안전하지 않으면 ScheduleIndexRangeException 발생")
@@ -1082,7 +1101,7 @@ public class TripTest {
                 Schedule schedule2 = trip.createSchedule(targetDay, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when
-                trip.moveSchedule(schedule1, targetDay, 0);
+                ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule1, targetDay, 0);
 
                 // then
                 List<Schedule> temporaryStorage = trip.getTemporaryStorage();
@@ -1093,6 +1112,9 @@ public class TripTest {
                 assertThat(schedules).containsExactlyInAnyOrder(schedule1, schedule2);
                 assertThat(schedule1.getScheduleIndex()).isEqualTo(ScheduleIndex.of(-ScheduleIndex.DEFAULT_SEQUENCE_GAP));
                 assertThat(schedule2.getScheduleIndex()).isEqualTo(ScheduleIndex.ZERO_INDEX);
+                assertThat(scheduleMoveDto.getBeforeDayId()).isEqualTo(null);
+                assertThat(scheduleMoveDto.getAfterDayId()).isEqualTo(targetDay.getId());
+                assertThat(scheduleMoveDto.isPositionChanged()).isEqualTo(true);
             }
 
             @DisplayName("targetOrder가 0이고, 맨 앞 ScheduleIndex 범위가 안전하지 않으면 ScheduleIndexRangeException 발생")
@@ -1143,7 +1165,7 @@ public class TripTest {
                 Schedule schedule3 = trip.createSchedule(targetDay, "일정제목3", Place.of("place-id333", "place 이름333", Coordinate.of(37.72221, 137.86523)));
 
                 // when
-                trip.moveSchedule(schedule1, targetDay, 1);
+                ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule1, targetDay, 1);
 
                 // then
                 List<Schedule> temporaryStorage = trip.getTemporaryStorage();
@@ -1155,6 +1177,9 @@ public class TripTest {
                 assertThat(schedule1.getScheduleIndex()).isEqualTo(schedule2.getScheduleIndex().mid(schedule3.getScheduleIndex()));
                 assertThat(schedule2.getScheduleIndex()).isEqualTo(ScheduleIndex.ZERO_INDEX);
                 assertThat(schedule3.getScheduleIndex()).isEqualTo(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP));
+                assertThat(scheduleMoveDto.getBeforeDayId()).isEqualTo(null);
+                assertThat(scheduleMoveDto.getAfterDayId()).isEqualTo(targetDay.getId());
+                assertThat(scheduleMoveDto.isPositionChanged()).isEqualTo(true);
             }
 
             @DisplayName("targetOrder가 다른 일정의 순서이고, 해당 순서 앞과 간격이 충분하지 않으면 MidScheduleIndexConflictException 발생")
@@ -1268,7 +1293,7 @@ public class TripTest {
                 Schedule schedule2 = trip.createSchedule(day, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when
-                trip.moveSchedule(schedule2, day, 1);
+                ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule2, day, 1);
 
                 // then
                 List<Schedule> schedules = day.getSchedules();
@@ -1280,6 +1305,9 @@ public class TripTest {
                 assertThat(firstSchedule.getScheduleIndex()).isEqualTo(ScheduleIndex.ZERO_INDEX);
                 assertThat(secondSchedule).isEqualTo(schedule2);
                 assertThat(secondSchedule.getScheduleIndex()).isEqualTo(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP));
+                assertThat(scheduleMoveDto.getBeforeDayId()).isEqualTo(day.getId());
+                assertThat(scheduleMoveDto.getAfterDayId()).isEqualTo(day.getId());
+                assertThat(scheduleMoveDto.isPositionChanged()).isEqualTo(false);
             }
 
             @DisplayName("같은 Day의 기존의 순서 다음으로 이동시키려 할 경우, 아무런 변화도 일어나지 않는다.")
@@ -1293,7 +1321,7 @@ public class TripTest {
                 Schedule schedule2 = trip.createSchedule(day, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when
-                trip.moveSchedule(schedule2, day, 2);
+                ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule2, day, 2);
 
                 // then
                 List<Schedule> schedules = day.getSchedules();
@@ -1305,6 +1333,9 @@ public class TripTest {
                 assertThat(firstSchedule.getScheduleIndex()).isEqualTo(ScheduleIndex.ZERO_INDEX);
                 assertThat(secondSchedule).isEqualTo(schedule2);
                 assertThat(secondSchedule.getScheduleIndex()).isEqualTo(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP));
+                assertThat(scheduleMoveDto.getBeforeDayId()).isEqualTo(day.getId());
+                assertThat(scheduleMoveDto.getAfterDayId()).isEqualTo(day.getId());
+                assertThat(scheduleMoveDto.isPositionChanged()).isEqualTo(false);
             }
 
 
@@ -1321,7 +1352,7 @@ public class TripTest {
                 Schedule schedule2 = trip.createSchedule(targetDay, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when
-                trip.moveSchedule(schedule1, targetDay, 1);
+                ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule1, targetDay, 1);
 
                 // then
                 List<Schedule> beforeDaySchedules = beforeDay.getSchedules();
@@ -1332,6 +1363,9 @@ public class TripTest {
                 assertThat(targetDaySchedules).containsExactlyInAnyOrder(schedule1, schedule2);
                 assertThat(schedule1.getScheduleIndex()).isEqualTo(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP));
                 assertThat(schedule2.getScheduleIndex()).isEqualTo(ScheduleIndex.ZERO_INDEX);
+                assertThat(scheduleMoveDto.getBeforeDayId()).isEqualTo(beforeDay.getId());
+                assertThat(scheduleMoveDto.getAfterDayId()).isEqualTo(targetDay.getId());
+                assertThat(scheduleMoveDto.isPositionChanged()).isEqualTo(true);
             }
 
             @DisplayName("targetOrder가 Schedules 크기와 똑같은 값이고, 끝 ScheduleIndex 범위가 안전하지 않으면 ScheduleIndexRangeException 발생")
@@ -1381,7 +1415,7 @@ public class TripTest {
                 Schedule schedule2 = trip.createSchedule(targetDay, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when
-                trip.moveSchedule(schedule1, targetDay, 0);
+                ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule1, targetDay, 0);
 
                 // then
                 List<Schedule> beforeDaySchedules = beforeDay.getSchedules();
@@ -1392,6 +1426,9 @@ public class TripTest {
                 assertThat(targetDaySchedules).containsExactlyInAnyOrder(schedule1, schedule2);
                 assertThat(schedule1.getScheduleIndex()).isEqualTo(ScheduleIndex.of(-ScheduleIndex.DEFAULT_SEQUENCE_GAP));
                 assertThat(schedule2.getScheduleIndex()).isEqualTo(ScheduleIndex.ZERO_INDEX);
+                assertThat(scheduleMoveDto.getBeforeDayId()).isEqualTo(beforeDay.getId());
+                assertThat(scheduleMoveDto.getAfterDayId()).isEqualTo(targetDay.getId());
+                assertThat(scheduleMoveDto.isPositionChanged()).isEqualTo(true);
             }
 
             @DisplayName("targetOrder가 0이고, 맨 앞 ScheduleIndex 범위가 안전하지 않으면 ScheduleIndexRangeException 발생")
@@ -1442,7 +1479,7 @@ public class TripTest {
                 Schedule schedule3 = trip.createSchedule(targetDay, "일정제목3", Place.of("place-id333", "place 이름333", Coordinate.of(37.72221, 137.86523)));
 
                 // when
-                trip.moveSchedule(schedule1, targetDay, 1);
+                ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule1, targetDay, 1);
 
                 // then
                 List<Schedule> temporaryStorage = trip.getTemporaryStorage();
@@ -1454,6 +1491,9 @@ public class TripTest {
                 assertThat(schedule1.getScheduleIndex()).isEqualTo(schedule2.getScheduleIndex().mid(schedule3.getScheduleIndex()));
                 assertThat(schedule2.getScheduleIndex()).isEqualTo(ScheduleIndex.ZERO_INDEX);
                 assertThat(schedule3.getScheduleIndex()).isEqualTo(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP));
+                assertThat(scheduleMoveDto.getBeforeDayId()).isEqualTo(beforeDay.getId());
+                assertThat(scheduleMoveDto.getAfterDayId()).isEqualTo(targetDay.getId());
+                assertThat(scheduleMoveDto.isPositionChanged()).isEqualTo(true);
             }
 
             @DisplayName("targetOrder가 다른 일정의 순서이고, 해당 순서 앞과 간격이 충분하지 않으면 MidScheduleIndexConflictException 발생")
@@ -1550,7 +1590,7 @@ public class TripTest {
                 Schedule schedule2 = trip.createSchedule(targetDay, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when
-                trip.moveSchedule(schedule1, targetDay, 1);
+                ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule1, targetDay, 1);
 
                 // then
                 List<Schedule> beforeDaySchedules = beforeDay.getSchedules();
@@ -1561,6 +1601,9 @@ public class TripTest {
                 assertThat(temporaryStorage).containsExactlyInAnyOrder(schedule1, schedule2);
                 assertThat(schedule1.getScheduleIndex()).isEqualTo(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP));
                 assertThat(schedule2.getScheduleIndex()).isEqualTo(ScheduleIndex.ZERO_INDEX);
+                assertThat(scheduleMoveDto.getBeforeDayId()).isEqualTo(beforeDay.getId());
+                assertThat(scheduleMoveDto.getAfterDayId()).isEqualTo(null);
+                assertThat(scheduleMoveDto.isPositionChanged()).isEqualTo(true);
             }
 
             @DisplayName("targetOrder가 임시보관함 크기와 똑같은 값이고, 끝 ScheduleIndex 범위가 안전하지 않으면 ScheduleIndexRangeException 발생")
@@ -1611,7 +1654,7 @@ public class TripTest {
                 Schedule schedule2 = trip.createSchedule(targetDay, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when
-                trip.moveSchedule(schedule1, targetDay, 0);
+                ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule1, targetDay, 0);
 
                 // then
                 List<Schedule> beforeDaySchedules = beforeDay.getSchedules();
@@ -1622,6 +1665,9 @@ public class TripTest {
                 assertThat(temporaryStorage).containsExactlyInAnyOrder(schedule1, schedule2);
                 assertThat(schedule1.getScheduleIndex()).isEqualTo(ScheduleIndex.of(-ScheduleIndex.DEFAULT_SEQUENCE_GAP));
                 assertThat(schedule2.getScheduleIndex()).isEqualTo(ScheduleIndex.ZERO_INDEX);
+                assertThat(scheduleMoveDto.getBeforeDayId()).isEqualTo(beforeDay.getId());
+                assertThat(scheduleMoveDto.getAfterDayId()).isEqualTo(null);
+                assertThat(scheduleMoveDto.isPositionChanged()).isEqualTo(true);
             }
 
             @DisplayName("targetOrder가 0이고, 끝 ScheduleIndex 범위가 안전하지 않으면 ScheduleIndexRangeException 발생")
@@ -1672,7 +1718,7 @@ public class TripTest {
                 Schedule schedule3 = trip.createSchedule(targetDay, "일정제목3", Place.of("place-id333", "place 이름333", Coordinate.of(37.72221, 137.86523)));
 
                 // when
-                trip.moveSchedule(schedule1, targetDay, 1);
+                ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule1, targetDay, 1);
 
                 // then
                 List<Schedule> schedules = beforeDay.getSchedules();
@@ -1684,6 +1730,9 @@ public class TripTest {
                 assertThat(schedule1.getScheduleIndex()).isEqualTo(schedule2.getScheduleIndex().mid(schedule3.getScheduleIndex()));
                 assertThat(schedule2.getScheduleIndex()).isEqualTo(ScheduleIndex.ZERO_INDEX);
                 assertThat(schedule3.getScheduleIndex()).isEqualTo(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP));
+                assertThat(scheduleMoveDto.getBeforeDayId()).isEqualTo(beforeDay.getId());
+                assertThat(scheduleMoveDto.getAfterDayId()).isEqualTo(null);
+                assertThat(scheduleMoveDto.isPositionChanged()).isEqualTo(true);
             }
 
             @DisplayName("targetOrder가 다른 일정의 순서이고, 해당 순서 앞과 간격이 충분하지 않으면 MidScheduleIndexConflictException 발생")

--- a/src/test/java/com/cosain/trilo/unit/trip/command/domain/entity/TripTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/domain/entity/TripTest.java
@@ -4,6 +4,7 @@ import com.cosain.trilo.trip.command.domain.entity.Day;
 import com.cosain.trilo.trip.command.domain.entity.Schedule;
 import com.cosain.trilo.trip.command.domain.entity.Trip;
 import com.cosain.trilo.trip.command.domain.exception.EmptyPeriodUpdateException;
+import com.cosain.trilo.trip.command.domain.exception.InvalidScheduleMoveTargetOrderException;
 import com.cosain.trilo.trip.command.domain.exception.InvalidTripDayException;
 import com.cosain.trilo.trip.command.domain.exception.ScheduleIndexRangeException;
 import com.cosain.trilo.trip.command.domain.vo.*;
@@ -721,6 +722,19 @@ public class TripTest {
         @DisplayName("임시보관함에서 임시보관함으로 옮길 떄")
         class Case_From_TemporaryStorage_To_TemporaryStorage {
 
+            @DisplayName("targetOrder가 0보다 작으면 InvalidScheduleMoveTargetOrderException 발생")
+            @Test
+            public void when_targetOrder_is_under_zero_then_it_throws_InvalidScheduleMoveTargetOrderException() {
+                // given
+                Trip trip = Trip.create("여행제목", 1L);
+                Day day = null;
+                Schedule schedule = trip.createSchedule(day, "일정제목",Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+
+                // when & then
+                assertThatThrownBy(()-> trip.moveSchedule(schedule, day, -1))
+                        .isInstanceOf(InvalidScheduleMoveTargetOrderException.class);
+            }
+
         }
 
         @Nested
@@ -747,6 +761,21 @@ public class TripTest {
                         .isInstanceOf(InvalidTripDayException.class);
             }
 
+            @DisplayName("targetOrder가 0보다 작으면 InvalidScheduleMoveTargetOrderException 발생")
+            @Test
+            public void when_targetOrder_is_under_zero_then_it_throws_InvalidScheduleMoveTargetOrderException() {
+                // given
+                Trip trip = Trip.create("여행제목", 1L);
+                trip.changePeriod(TripPeriod.of(LocalDate.of(2023,3,1), LocalDate.of(2023,3,1)));
+                Day beforeDay = null;
+                Schedule schedule = trip.createSchedule(beforeDay, "일정제목",Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+
+                Day targetDay = trip.getDays().get(0);
+
+                // when & then
+                assertThatThrownBy(()-> trip.moveSchedule(schedule, targetDay, -1))
+                        .isInstanceOf(InvalidScheduleMoveTargetOrderException.class);
+            }
         }
 
         @Nested
@@ -771,12 +800,43 @@ public class TripTest {
                         .isInstanceOf(InvalidTripDayException.class);
             }
 
+
+            @DisplayName("targetOrder가 0보다 작으면 InvalidScheduleMoveTargetOrderException 발생")
+            @Test
+            public void when_targetOrder_is_under_zero_then_it_throws_InvalidScheduleMoveTargetOrderException() {
+                // given
+                Trip trip = Trip.create("여행제목", 1L);
+                trip.changePeriod(TripPeriod.of(LocalDate.of(2023,3,1), LocalDate.of(2023,3,2)));
+                Day beforeDay = trip.getDays().get(0);
+                Schedule schedule = trip.createSchedule(beforeDay, "일정제목",Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+
+                Day targetDay = trip.getDays().get(1);
+
+                // when & then
+                assertThatThrownBy(()-> trip.moveSchedule(schedule, targetDay, -1))
+                        .isInstanceOf(InvalidScheduleMoveTargetOrderException.class);
+            }
         }
 
         @Nested
         @DisplayName("Day에서 임시보관함으로 옮길 때")
         class Case_From_Day_To_TemporaryStorage {
 
+            @DisplayName("targetOrder가 0보다 작으면 InvalidScheduleMoveTargetOrderException 발생")
+            @Test
+            public void when_targetOrder_is_under_zero_then_it_throws_InvalidScheduleMoveTargetOrderException() {
+                // given
+                Trip trip = Trip.create("여행제목", 1L);
+                trip.changePeriod(TripPeriod.of(LocalDate.of(2023,3,1), LocalDate.of(2023,3,1)));
+                Day beforeDay = trip.getDays().get(0);
+                Schedule schedule = trip.createSchedule(beforeDay, "일정제목",Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+
+                Day targetDay = null;
+
+                // when & then
+                assertThatThrownBy(()-> trip.moveSchedule(schedule, targetDay, -1))
+                        .isInstanceOf(InvalidScheduleMoveTargetOrderException.class);
+            }
         }
     }
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/command/domain/vo/ScheduleIndexTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/domain/vo/ScheduleIndexTest.java
@@ -98,4 +98,66 @@ public class ScheduleIndexTest {
 
     }
 
+    @Nested
+    @DisplayName("Mid 메서드를 통해 중간 인덱스 생성되는 지 테스트")
+    class MidTest {
+
+        @Test
+        @DisplayName("1, 5 -> 3")
+        public void one_and_five_returns_three() {
+            // given
+            ScheduleIndex index1 = ScheduleIndex.of(1);
+            ScheduleIndex index2 = ScheduleIndex.of(5);
+
+            // when
+            ScheduleIndex midIndex = index1.mid(index2);
+
+            // then
+            assertThat(midIndex).isEqualTo(ScheduleIndex.of(3));
+        }
+
+        @Test
+        @DisplayName("(최대 인덱스 -2) , (최대 인덱스) -> (최댓인덱스 -1)")
+        public void max_minus_two_and_max_returns_max_minus_one() {
+            // given
+            ScheduleIndex index1 = ScheduleIndex.of(ScheduleIndex.MAX_INDEX_VALUE - 2);
+            ScheduleIndex index2 = ScheduleIndex.of(ScheduleIndex.MAX_INDEX_VALUE);
+
+            // when
+            ScheduleIndex midIndex = index1.mid(index2);
+
+            // then
+            assertThat(midIndex).isEqualTo(ScheduleIndex.of(ScheduleIndex.MAX_INDEX_VALUE - 1));
+        }
+
+        @Test
+        @DisplayName("(최소 인덱스) , (최대 인덱스) -> 0")
+        public void max_and_min_returns_zero() {
+            // given
+            ScheduleIndex index1 = ScheduleIndex.of(ScheduleIndex.MAX_INDEX_VALUE);
+            ScheduleIndex index2 = ScheduleIndex.of(ScheduleIndex.MIN_INDEX_VALUE);
+
+            // when
+            ScheduleIndex midIndex = index1.mid(index2);
+
+            // then
+            assertThat(midIndex).isEqualTo(ScheduleIndex.ZERO_INDEX);
+        }
+
+        @Test
+        @DisplayName("3, 4 -> 3")
+        public void three_and_four_returns_three() {
+            // given
+            ScheduleIndex index1 = ScheduleIndex.of(3);
+            ScheduleIndex index2 = ScheduleIndex.of(4);
+
+            // when
+            ScheduleIndex midIndex = index1.mid(index2);
+
+            // then
+            assertThat(midIndex).isEqualTo(ScheduleIndex.of(3));
+        }
+
+    }
+
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/command/domain/vo/ScheduleIndexTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/domain/vo/ScheduleIndexTest.java
@@ -73,4 +73,29 @@ public class ScheduleIndexTest {
 
     }
 
+    @Nested
+    @DisplayName("generateBeforeIndex 테스트")
+    class generateBeforeIndexTest {
+
+        @Test
+        @DisplayName("생성되는 순서가 범위를 벗어나는 경우 예외 발생")
+        public void when_generatedIndex_is_too_small_index_then_it_throws_ScheduleIndexRangeException() {
+            ScheduleIndex index = ScheduleIndex.of(ScheduleIndex.MIN_INDEX_VALUE);
+
+            assertThatThrownBy(index::generateBeforeIndex)
+                    .isInstanceOf(ScheduleIndexRangeException.class);
+        }
+
+
+        @Test
+        @DisplayName("다음에 오는 인덱스가 최솟값의 범위보다 크거나 같을 경우 정상적으로 인덱스 생성")
+        public void successfully_generate_nextIndex() {
+            ScheduleIndex index = ScheduleIndex.of(ScheduleIndex.MIN_INDEX_VALUE + ScheduleIndex.DEFAULT_SEQUENCE_GAP);
+
+            ScheduleIndex generatedIndex = index.generateBeforeIndex();
+            assertThat(generatedIndex.getValue()).isEqualTo(ScheduleIndex.MIN_INDEX_VALUE);
+        }
+
+    }
+
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/schedule/ScheduleMoveControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/schedule/ScheduleMoveControllerTest.java
@@ -65,7 +65,10 @@ public class ScheduleMoveControllerTest extends RestControllerTest {
                 )
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.scheduleId").value(scheduleId));
+                .andExpect(jsonPath("$.scheduleId").value(scheduleId))
+                .andExpect(jsonPath("$.beforeDayId").value(moveResult.getBeforeDayId()))
+                .andExpect(jsonPath("$.afterDayId").value(moveResult.getAfterDayId()))
+                .andExpect(jsonPath("$.positionChanged").value(moveResult.isPositionChanged()));
 
         verify(scheduleMoveUseCase).moveSchedule(eq(scheduleId), any(), any(ScheduleMoveCommand.class));
     }

--- a/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/schedule/ScheduleMoveControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/schedule/ScheduleMoveControllerTest.java
@@ -3,6 +3,7 @@ package com.cosain.trilo.unit.trip.command.preesentation.api.schedule;
 
 import com.cosain.trilo.support.RestControllerTest;
 import com.cosain.trilo.trip.command.application.command.ScheduleMoveCommand;
+import com.cosain.trilo.trip.command.application.result.ScheduleMoveResult;
 import com.cosain.trilo.trip.command.application.usecase.ScheduleMoveUseCase;
 import com.cosain.trilo.trip.command.presentation.schedule.ScheduleMoveController;
 import com.cosain.trilo.trip.command.presentation.schedule.dto.ScheduleMoveRequest;
@@ -19,6 +20,7 @@ import java.nio.charset.StandardCharsets;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -44,8 +46,16 @@ public class ScheduleMoveControllerTest extends RestControllerTest {
         Long targetDayId = 2L;
         int targetOrder = 3;
 
+        ScheduleMoveResult moveResult = ScheduleMoveResult.builder()
+                .scheduleId(scheduleId)
+                .beforeDayId(1L)
+                .afterDayId(targetDayId)
+                .positionChanged(true)
+                .build();
+
         ScheduleMoveRequest request = new ScheduleMoveRequest(targetDayId, targetOrder);
-        willDoNothing().given(scheduleMoveUseCase).moveSchedule(eq(scheduleId), any(), any(ScheduleMoveCommand.class));
+        given(scheduleMoveUseCase.moveSchedule(eq(scheduleId), any(), any(ScheduleMoveCommand.class)))
+                .willReturn(moveResult);
 
         mockMvc.perform(patch("/api/schedules/" + scheduleId)
                         .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)

--- a/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/schedule/ScheduleMoveControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/schedule/ScheduleMoveControllerTest.java
@@ -1,0 +1,84 @@
+package com.cosain.trilo.unit.trip.command.preesentation.api.schedule;
+
+
+import com.cosain.trilo.support.RestControllerTest;
+import com.cosain.trilo.trip.command.application.command.ScheduleMoveCommand;
+import com.cosain.trilo.trip.command.application.usecase.ScheduleMoveUseCase;
+import com.cosain.trilo.trip.command.presentation.schedule.ScheduleMoveController;
+import com.cosain.trilo.trip.command.presentation.schedule.dto.ScheduleMoveRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("[TripCommand] 일정 이동 API 테스트")
+@WebMvcTest(ScheduleMoveController.class)
+public class ScheduleMoveControllerTest extends RestControllerTest {
+
+    @MockBean
+    private ScheduleMoveUseCase scheduleMoveUseCase;
+
+    private final static String ACCESS_TOKEN = "Bearer accessToken";
+
+    @Test
+    @DisplayName("인증된 사용자의 올바른 요청 -> 일정 이동됨")
+    @WithMockUser
+    public void moveSchedule_with_authorizedUser() throws Exception {
+        mockingForLoginUserAnnotation();
+        Long scheduleId = 1L;
+        Long targetDayId = 2L;
+        int targetOrder = 3;
+
+        ScheduleMoveRequest request = new ScheduleMoveRequest(targetDayId, targetOrder);
+        willDoNothing().given(scheduleMoveUseCase).moveSchedule(eq(scheduleId), any(), any(ScheduleMoveCommand.class));
+
+        mockMvc.perform(patch("/api/schedules/" + scheduleId)
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(createJson(request))
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.scheduleId").value(scheduleId));
+
+        verify(scheduleMoveUseCase).moveSchedule(eq(scheduleId), any(), any(ScheduleMoveCommand.class));
+    }
+
+    @Test
+    @DisplayName("미인증 사용자 요청 -> 인증 실패 401")
+    @WithAnonymousUser
+    public void updateSchedulePlace_with_unauthorizedUser() throws Exception {
+        Long scheduleId = 1L;
+        Long targetDayId = 2L;
+        int targetOrder = 3;
+
+        ScheduleMoveRequest request = new ScheduleMoveRequest(targetDayId, targetOrder);
+
+        mockMvc.perform(patch("/api/schedules/" + scheduleId)
+                        .content(createJson(request))
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.errorCode").exists())
+                .andExpect(jsonPath("$.errorMessage").exists());
+    }
+
+}


### PR DESCRIPTION
# JIRA 티켓
- [TRL-213]

---

# 작업 내역
- [x] Schedeule 옮겨질 대상이 되는 Day가 Schedule의 Trip과 관련이 있는지 검증 (도메인)
- [x] 특정 Day(또는 임시보관함)의 맨 앞으로 일정을 이동하는 도메인 기능
  - [x] 앞에 이동되는 일정의 인덱스가 범위를 벗어날 경우 예외를 발생시키기
- [x] 특정 Day(또는 임시보관함)의 맨 뒤로 일정을 이동하는 도메인 기능
    - [x] 뒤에 이동되는 일정의 인덱스가 범위를 벗어날 경우 예외를 발생시키기
- [x] 특정 Day(또는 임시보관함)의 중간 순서로 이동하는 도메인 기능
  - [x] 중간 인덱스가 기존 인덱스와 중복되는 경우, 충돌이므로 예외를 발생시키기
- [x] 사용자가 옮기고자 하는 순서가 Day 또는 임시보관함 상에서 옮길 수 없는 위치의 인덱스이면 예외 발생
- [x] 일정 이동 애플리케이션 계층 구현
  - [x] 사용자가 이동시키고 싶은 Schedule의 존재성 검증
  - [x] 사용자가 일정을 이동시킬 권한이 있는 지 검증
  - [x] 새로 생성되는 인덱스가 범위를 벗어나는 경우 relocate 쿼리 메서드를 호출하여 재정렬 후 다시 조회해오도록 하기
- [x] 일정 이동 표현 계층 구현




[TRL-213]: https://cosain.atlassian.net/browse/TRL-213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ