### PR TITLE
[TRL-245] fix: Day에 일정 생성 시 Trip 동등성 검증부 오류 수정(JPA 지연로딩 프록시 문제)

### DIFF
--- a/src/main/java/com/cosain/trilo/trip/command/application/service/ScheduleCreateService.java
+++ b/src/main/java/com/cosain/trilo/trip/command/application/service/ScheduleCreateService.java
@@ -50,7 +50,7 @@ public class ScheduleCreateService implements ScheduleCreateUseCase {
     private Day findDay(Long dayId){
         return (dayId == null)
                 ? null
-                : dayRepository.findById(dayId).orElseThrow(() -> new DayNotFoundException("Schedule을 Day에 넣으려고 했는데, 해당하는 Day가 존재하지 않음."));
+                : dayRepository.findByIdWithTrip(dayId).orElseThrow(() -> new DayNotFoundException("Schedule을 Day에 넣으려고 했는데, 해당하는 Day가 존재하지 않음."));
     }
 
     private Trip findTrip(Long tripId){

--- a/src/main/java/com/cosain/trilo/trip/command/domain/entity/Day.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/entity/Day.java
@@ -177,4 +177,13 @@ public class Day {
     void detachSchedule(Schedule schedule) {
         this.schedules.remove(schedule);
     }
+
+    /**
+     * Day가 지정 Trip에 속해 있는 지 여부를 반환
+     * @param trip
+     * @return
+     */
+    boolean isBelongTo(Trip trip) {
+        return this.trip.equals(trip);
+    }
 }

--- a/src/main/java/com/cosain/trilo/trip/command/domain/entity/Trip.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/entity/Trip.java
@@ -164,7 +164,7 @@ public class Trip {
     }
 
     private Schedule makeDaySchedule(Day day, String title, Place place) {
-        if (!day.getTrip().equals(this)) {
+        if (!day.isBelongTo(this)) {
             throw new InvalidTripDayException("해당 day는 Trip의 Day가 아님");
         }
 
@@ -194,7 +194,7 @@ public class Trip {
         if (day == null) {
             return;
         }
-        if (!day.getTrip().equals(this)) {
+        if (!day.isBelongTo(this)) {
             throw new InvalidTripDayException("해당 Day는 Trip의 Day가 아님");
         }
     }

--- a/src/main/java/com/cosain/trilo/trip/command/domain/entity/Trip.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/entity/Trip.java
@@ -146,9 +146,23 @@ public class Trip {
     }
 
     public Schedule createSchedule(Day day, String title, Place place) {
+        validateTripDayRelationShip(day);
         return (day == null)
                 ? makeTemporaryStorageSchedule(title, place)
-                : makeDaySchedule(day, title, place);
+                : day.createSchedule(title, place);
+    }
+
+    /**
+     * Trip에 Day가 속해있는 지 검증합니다.
+     * @param day
+     */
+    private void validateTripDayRelationShip(Day day) {
+        if (day == null) {
+            return;
+        }
+        if (!day.isBelongTo(this)) {
+            throw new InvalidTripDayException("해당 Day는 Trip의 Day가 아님");
+        }
     }
 
     private Schedule makeTemporaryStorageSchedule(String title, Place place) {
@@ -163,14 +177,6 @@ public class Trip {
                 : temporaryStorage.get(temporaryStorage.size() - 1).getScheduleIndex().generateNextIndex();
     }
 
-    private Schedule makeDaySchedule(Day day, String title, Place place) {
-        if (!day.isBelongTo(this)) {
-            throw new InvalidTripDayException("해당 day는 Trip의 Day가 아님");
-        }
-
-        return day.createSchedule(title, place);
-    }
-
     /**
      * Schedule을 지정한 Day의 지정한 순서로 이동합니다. 이때, 지정한 Day가 null이면 임시보관함으로 이동합니다. 같은 Day를 지정하면
      * 같은 곳 안에서 순서 변경이 일어납니다.
@@ -179,24 +185,10 @@ public class Trip {
      * @param targetOrder
      */
     public ScheduleMoveDto moveSchedule(Schedule schedule, Day targetDay, int targetOrder) {
-        validateTripDayRelationShipShip(targetDay);
+        validateTripDayRelationShip(targetDay);
         return (targetDay == null)
                 ? moveScheduleToTemporaryStorage(schedule, targetOrder)
                 : targetDay.moveSchedule(schedule, targetOrder);
-    }
-
-    /**
-     * Trip에 Day가 속해있는 지 검증합니다.
-     * @param day
-     */
-
-    private void validateTripDayRelationShipShip(Day day) {
-        if (day == null) {
-            return;
-        }
-        if (!day.isBelongTo(this)) {
-            throw new InvalidTripDayException("해당 Day는 Trip의 Day가 아님");
-        }
     }
 
     /**

--- a/src/test/java/com/cosain/trilo/unit/trip/command/application/service/schedule/ScheduleCreateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/application/service/schedule/ScheduleCreateServiceTest.java
@@ -82,7 +82,7 @@ public class ScheduleCreateServiceTest {
                     .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                     .build();
 
-            given(dayRepository.findById(eq(dayId))).willReturn(Optional.of(day));
+            given(dayRepository.findByIdWithTrip(eq(dayId))).willReturn(Optional.of(day));
             given(tripRepository.findById(eq(tripId))).willReturn(Optional.of(trip));
             given(scheduleRepository.save(any(Schedule.class))).willReturn(createdSchedule);
 
@@ -90,7 +90,7 @@ public class ScheduleCreateServiceTest {
             scheduleCreateService.createSchedule(tripperId, scheduleCreateCommand);
 
             // then
-            verify(dayRepository, times(1)).findById(eq(dayId));
+            verify(dayRepository, times(1)).findByIdWithTrip(eq(dayId));
             verify(tripRepository, times(1)).findById(eq(tripId));
             verify(scheduleRepository, times(0)).relocateDaySchedules(eq(tripId), eq(dayId));
             verify(scheduleRepository, times(1)).save(any(Schedule.class));
@@ -168,7 +168,7 @@ public class ScheduleCreateServiceTest {
                     .scheduleIndex(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP))
                     .build();
 
-            when(dayRepository.findById(eq(dayId)))
+            when(dayRepository.findByIdWithTrip(eq(dayId)))
                     .thenReturn(Optional.of(beforeDay))
                     .thenReturn(Optional.of(rediscoveredDay));
 
@@ -183,7 +183,7 @@ public class ScheduleCreateServiceTest {
             scheduleCreateService.createSchedule(tripperId, scheduleCreateCommand);
 
             // then
-            verify(dayRepository, times(2)).findById(eq(dayId));
+            verify(dayRepository, times(2)).findByIdWithTrip(eq(dayId));
             verify(tripRepository, times(2)).findById(eq(tripId));
             verify(scheduleRepository, times(1)).relocateDaySchedules(eq(tripId), eq(dayId));
             verify(scheduleRepository, times(1)).save(any(Schedule.class));
@@ -227,7 +227,7 @@ public class ScheduleCreateServiceTest {
             scheduleCreateService.createSchedule(tripperId, scheduleCreateCommand);
 
             // then
-            verify(dayRepository, times(0)).findById(isNull());
+            verify(dayRepository, times(0)).findByIdWithTrip(isNull());
             verify(tripRepository, times(1)).findById(eq(tripId));
             verify(scheduleRepository, times(0)).relocateDaySchedules(eq(tripId), isNull());
             verify(scheduleRepository, times(1)).save(any(Schedule.class));
@@ -283,7 +283,7 @@ public class ScheduleCreateServiceTest {
             scheduleCreateService.createSchedule(tripperId, scheduleCreateCommand);
 
             // then
-            verify(dayRepository, times(0)).findById(isNull());
+            verify(dayRepository, times(0)).findByIdWithTrip(isNull());
             verify(tripRepository, times(2)).findById(eq(tripId));
             verify(scheduleRepository, times(1)).relocateDaySchedules(eq(tripId), isNull());
             verify(scheduleRepository, times(1)).save(any(Schedule.class));
@@ -301,13 +301,13 @@ public class ScheduleCreateServiceTest {
         Day day = Day.of(LocalDate.of(2023, 4, 5), trip);
 
         ScheduleCreateCommand scheduleCreateCommand = ScheduleCreateCommand.of(1L, 1L, "제목", "내용", "장소 식별자", 23.21, 23.24);
-        given(dayRepository.findById(anyLong())).willReturn(Optional.of(day));
+        given(dayRepository.findByIdWithTrip(anyLong())).willReturn(Optional.of(day));
         given(tripRepository.findById(anyLong())).willReturn(Optional.of(trip));
 
         // when & then
         assertThatThrownBy(() -> scheduleCreateService.createSchedule(noAuthorityTripperId, scheduleCreateCommand))
                 .isInstanceOf(NoScheduleCreateAuthorityException.class);
-        verify(dayRepository).findById(anyLong());
+        verify(dayRepository).findByIdWithTrip(anyLong());
         verify(tripRepository).findById(anyLong());
     }
 


### PR DESCRIPTION
# JIRA 티켓
- [TRL-245]

---

# 작업 내역
- ScheduleCreateService에서 Day 에 Schedule 생성시, Trip-Day간 관계를 검증하는 부분에서 의도치 않게 기능이 동작하는 문제가 발생해서 이를 수정함
- Day가 전달받은 Trip에 속해있는지 스스로 판단하게 변경
---

# 원인

```java
    @Override
    @Transactional
    public Long createSchedule(Long tripperId, ScheduleCreateCommand createCommand) {
        Long dayId = createCommand.getDayId();
        Long tripId = createCommand.getTripId();

        Day day = findDay(dayId);
        Trip trip = findTrip(tripId);
        validateCreateAuthority(trip, tripperId);

        Schedule schedule;
        try {
            schedule = trip.createSchedule(day, createCommand.getTitle(), createCommand.getPlace());
        } catch (ScheduleIndexRangeException e) {
            scheduleRepository.relocateDaySchedules(tripId, dayId);
            trip = findTrip(trip.getId());
            day = findDay(dayId);
            schedule =  trip.createSchedule(day, createCommand.getTitle(), createCommand.getPlace());
        }
        scheduleRepository.save(schedule);
        return schedule.getId();
    }
```
- 우리의 비즈니스 로직에서는 ScheduleCreateService에서 Schedule 생성시 Day를 찾아오고, Trip을 찾아온 뒤 trip에게 Schedule 생성을 위임하여 일정 생성이 진행됩니다.

```java
    private Day findDay(Long dayId){
        return (dayId == null)
                ? null
                : dayRepository.findById(dayId).orElseThrow(() -> new DayNotFoundException("Schedule을 Day에 넣으려고 했는데, 해당하는 Day가 존재하지 않음."));
    }
```
- 이때 Day를 가져올 때 Trip만 가져오는게 문제다.

```java
    public Schedule createSchedule(Day day, String title, Place place) {
        return (day == null)
                ? makeTemporaryStorageSchedule(title, place)
                : makeDaySchedule(day, title, place);
    }
```
```java
    private Schedule makeDaySchedule(Day day, String title, Place place) {
        if (!day.getTrip().equals(this)) {
            throw new InvalidTripDayException("해당 day는 Trip의 Day가 아님");
        }

        return day.createSchedule(title, place);
    }
```
- Trip에게 전달된 Day가 null이 아니면 day에게 Trip 생성이 위임되는데, 이 때 Day가 Trip의 Day인지 검증하는 로직이 있습니다.
- 여기서 day.getTrip을 통해 꺼내온 Trip과 Trip이 동등한 지를 비교하고 있습니다.
- 같은 영속성 컨텍스트에 있는 trip이면 동일할 것이라 예상했습니다.

![프록시](https://github.com/teamCoSaIn/trilo-be/assets/88282356/f1ea3ba9-9d8f-46d4-9f89-e645679db7b8)

- 그러나 실제 Day가 가진 Trip은 Trip 엔티티가 아닌 Trip엔티티의 프록시였습니다.
- 우리가 Day를 조회해올 때 Trip을 함께 가져오지 않고 지연로딩하도록 설정해뒀기 때문에 Trip을 프록시로 주입한 것이죠.
- 실제 Trip 내부에는 target이란 필드가 있고 지연 로딩시 이 target에 Trip이 주입됩니다.
- 어찌됐든 Trip과 프록시 Trip은 동등하지 않으므로 false가 반환되는 것입니다.

---

# 해결
```java
public interface ScheduleRepository extends JpaRepository<Schedule, Long> {

    @Query("SELECT s" +
            " FROM Schedule as s JOIN FETCH s.trip" +
            " WHERE s.id = :scheduleId")
    Optional<Schedule> findByIdWithTrip(@Param("scheduleId") Long scheduleId);
```
```java

    private Day findDay(Long dayId){
        return (dayId == null)
                ? null
                : dayRepository.findByIdWithTrip(dayId).orElseThrow(() -> new DayNotFoundException("Schedule을 Day에 넣으려고 했는데, 해당하는 Day가 존재하지 않음."));
    }
```
- 여러가지 해결방법이 있을 수 있으나, 제가 선택한 방식은 Day를 가져올 때 Trip도 같이 페치조인 하게 하는 것입니다.
- 이렇게 하면 Trip을 별도로 지연로딩할 필요가 없어지므로 쿼리도 한 방만 날아가고, 실제 Day의 Trip 자리에 들어오는 것도 실제 Trip 엔티티입니다.

---

# 결과
![실제](https://github.com/teamCoSaIn/trilo-be/assets/88282356/817d9cc6-2be5-407d-99c1-c06c6dd9fcfb)

- day.getTrip을 할때 가져와지는 Trip이 프록시가 아니라 실제 Trip 엔티티가 됐고 의도한 대로 기능이 동작합니다.
 
---

[TRL-245]: https://cosain.atlassian.net/browse/TRL-245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ