### PR TITLE
[TRL-240] feat: 쿼리 카운터 구현

### DIFF
--- a/src/main/java/com/cosain/trilo/common/logging/query/ConnectionProxyHandler.java
+++ b/src/main/java/com/cosain/trilo/common/logging/query/ConnectionProxyHandler.java
@@ -1,0 +1,34 @@
+package com.cosain.trilo.common.logging.query;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+
+public class ConnectionProxyHandler implements InvocationHandler {
+
+    private final Connection connection; // target
+    private final QueryCounter queryCounter;
+
+    public ConnectionProxyHandler(Connection connection, QueryCounter queryCounter) {
+        this.connection = connection;
+        this.queryCounter = queryCounter;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        Object ret = method.invoke(connection, args); // 타겟(Connection)으로 위임하고 결과 받음
+
+        // 메소드 선별 부가기능 적용
+        if (ret instanceof PreparedStatement && method.getName().equals("prepareStatement")) {
+            // PreparedStatement 동적 프록시 생성
+            return  Proxy.newProxyInstance(
+                    ret.getClass().getClassLoader(),
+                    ret.getClass().getInterfaces(),
+                    new PreparedStatementProxyHandler((PreparedStatement) ret, queryCounter)
+            );
+        }else return ret; // 결과 반환
+    }
+
+}

--- a/src/main/java/com/cosain/trilo/common/logging/query/DataSourceAspect.java
+++ b/src/main/java/com/cosain/trilo/common/logging/query/DataSourceAspect.java
@@ -1,0 +1,30 @@
+package com.cosain.trilo.common.logging.query;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Component
+@Aspect
+public class DataSourceAspect {
+
+    private final QueryCounter queryCounter;
+
+    public DataSourceAspect(QueryCounter queryCounter) {
+        this.queryCounter = queryCounter;
+    }
+
+    @Around("execution(* javax.sql.DataSource.getConnection(..))") // 어드바이스 & 포인트컷
+    public Connection getConnection(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        Connection connection = (Connection) proceedingJoinPoint.proceed();
+
+        return (Connection) Proxy.newProxyInstance(
+                connection.getClass().getClassLoader(),
+                connection.getClass().getInterfaces(),
+                new ConnectionProxyHandler(connection, queryCounter));
+    }
+}

--- a/src/main/java/com/cosain/trilo/common/logging/query/PreparedStatementProxyHandler.java
+++ b/src/main/java/com/cosain/trilo/common/logging/query/PreparedStatementProxyHandler.java
@@ -1,0 +1,29 @@
+package com.cosain.trilo.common.logging.query;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.sql.PreparedStatement;
+
+public class PreparedStatementProxyHandler implements InvocationHandler {
+
+    private final PreparedStatement preparedStatement; // target
+    private final QueryCounter queryCounter;
+
+    public PreparedStatementProxyHandler(PreparedStatement preparedStatement, QueryCounter queryCounter) {
+        this.preparedStatement = preparedStatement;
+        this.queryCounter = queryCounter;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        if (isExecuteQuery(method)) { // 조건에 따라 부가 기능 실행 : 쿼리 개수 ++
+            queryCounter.increaseCount();
+        }
+        return method.invoke(preparedStatement, args); // target 으로 위임하고 결과 반환
+    }
+
+    private boolean isExecuteQuery(Method method) {
+        String methodName = method.getName();
+        return methodName.contains("execute");
+    }
+}

--- a/src/main/java/com/cosain/trilo/common/logging/query/QueryCountInterceptor.java
+++ b/src/main/java/com/cosain/trilo/common/logging/query/QueryCountInterceptor.java
@@ -1,0 +1,32 @@
+package com.cosain.trilo.common.logging.query;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Slf4j
+@Component
+public class QueryCountInterceptor implements HandlerInterceptor {
+
+    private static final String QUERY_INFO_FORMAT = "QUERY_INFO : [{} {}] [STATUS CODE: {}] [QUERY_COUNT: {}]";
+    private final QueryCounter queryCounter;
+
+    public QueryCountInterceptor(QueryCounter queryCounter) {
+        this.queryCounter = queryCounter;
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response,
+                                Object handler, Exception ex) {
+
+        int count = queryCounter.getCount();
+        int status = response.getStatus();
+        String requestURI = request.getRequestURI();
+        String method = request.getMethod();
+
+        log.info(QUERY_INFO_FORMAT, method, requestURI, status, count);
+        queryCounter.resetCount();
+    }
+}

--- a/src/main/java/com/cosain/trilo/common/logging/query/QueryCounter.java
+++ b/src/main/java/com/cosain/trilo/common/logging/query/QueryCounter.java
@@ -1,0 +1,22 @@
+package com.cosain.trilo.common.logging.query;
+
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class QueryCounter {
+
+    private final ThreadLocal<Integer> count = ThreadLocal.withInitial(() -> 0);
+
+    public void increaseCount() {
+        count.set(count.get() + 1);
+    }
+
+    public int getCount() {
+        return count.get();
+    }
+
+    public void resetCount() {
+        count.set(0);
+    }
+}

--- a/src/main/java/com/cosain/trilo/config/WebConfig.java
+++ b/src/main/java/com/cosain/trilo/config/WebConfig.java
@@ -1,0 +1,19 @@
+package com.cosain.trilo.config;
+
+import com.cosain.trilo.common.logging.query.QueryCountInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final QueryCountInterceptor queryCountInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(queryCountInterceptor);
+    }
+}

--- a/src/test/java/com/cosain/trilo/common/logging/query/ConnectionProxyHandlerTest.java
+++ b/src/test/java/com/cosain/trilo/common/logging/query/ConnectionProxyHandlerTest.java
@@ -8,9 +8,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
@@ -25,7 +27,7 @@ public class ConnectionProxyHandlerTest {
     private PreparedStatement preparedStatement;
 
     @Test
-    @DisplayName("invoke() 실행 시 PreparedStatement 타입의 객체가 반환된다")
+    @DisplayName("invoke() 실행 시 Proxy & PreparedStatement 타입의 객체가 반환된다")
     void testInvoke_PreparedStatementProxy_Returned() throws Throwable{
 
         // given
@@ -37,7 +39,8 @@ public class ConnectionProxyHandlerTest {
         Object invoke = connectionProxyHandler.invoke(connection, method, new String[]{""});
 
         // then
-        Assertions.assertInstanceOf(PreparedStatement.class, invoke);
+        assertInstanceOf(PreparedStatement.class, invoke);
+        assertInstanceOf(Proxy.class, invoke);
     }
 
 }

--- a/src/test/java/com/cosain/trilo/common/logging/query/ConnectionProxyHandlerTest.java
+++ b/src/test/java/com/cosain/trilo/common/logging/query/ConnectionProxyHandlerTest.java
@@ -1,0 +1,43 @@
+package com.cosain.trilo.common.logging.query;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Method;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class ConnectionProxyHandlerTest {
+
+    @Mock
+    private Connection connection;
+    @Mock
+    private QueryCounter queryCounter;
+    @Mock
+    private PreparedStatement preparedStatement;
+
+    @Test
+    @DisplayName("invoke() 실행 시 PreparedStatement 타입의 객체가 반환된다")
+    void testInvoke_PreparedStatementProxy_Returned() throws Throwable{
+
+        // given
+        given(connection.prepareStatement(anyString())).willReturn(preparedStatement);
+        ConnectionProxyHandler connectionProxyHandler = new ConnectionProxyHandler(connection, queryCounter);
+        Method method = Connection.class.getMethod("prepareStatement", String.class);
+
+        // when
+        Object invoke = connectionProxyHandler.invoke(connection, method, new String[]{""});
+
+        // then
+        Assertions.assertInstanceOf(PreparedStatement.class, invoke);
+    }
+
+}

--- a/src/test/java/com/cosain/trilo/common/logging/query/DataSourceAspectTest.java
+++ b/src/test/java/com/cosain/trilo/common/logging/query/DataSourceAspectTest.java
@@ -1,0 +1,28 @@
+package com.cosain.trilo.common.logging.query;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class DataSourceAspectTest {
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Test
+    void testDataSourceAspect() throws SQLException {
+        // given
+        Object ret = dataSource.getConnection();
+
+        // when & then
+        assertThat(ret).isNotNull();
+        assertThat(ret).isInstanceOf(Connection.class);
+    }
+}

--- a/src/test/java/com/cosain/trilo/common/logging/query/PreparedStatementProxyHandlerTest.java
+++ b/src/test/java/com/cosain/trilo/common/logging/query/PreparedStatementProxyHandlerTest.java
@@ -1,0 +1,70 @@
+package com.cosain.trilo.common.logging.query;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Method;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class PreparedStatementProxyHandlerTest {
+
+    @Mock
+    private PreparedStatement preparedStatement;
+
+    @Mock
+    private QueryCounter queryCounter;
+
+    private PreparedStatementProxyHandler proxyHandler;
+
+    @BeforeEach
+    public void setup() {
+        proxyHandler = new PreparedStatementProxyHandler(preparedStatement, queryCounter);
+    }
+
+    @Test
+    @DisplayName("execute 문자열이 포함된 메서드가 실행될 경우 쿼리 카운터의 증가 메서드가 호출된다 - executeQuery()")
+    public void testInvoke_executeQuery_increasesQueryCount() throws Throwable {
+        Method executeQueryMethod = PreparedStatement.class.getMethod("executeQuery");
+        given(preparedStatement.executeQuery()).willReturn(mock(ResultSet.class));
+
+        proxyHandler.invoke(preparedStatement, executeQueryMethod, null);
+
+        verify(queryCounter, times(1)).increaseCount();
+    }
+
+    @Test
+    @DisplayName("execute 문자열이 포함된 메서드가 실행될 경우 쿼리 카운터의 증가 메서드가 호출된다 - executeUpdate()")
+    public void testInvoke_excuteUpdate_increasesQueryCount() throws Throwable {
+        Method executeQueryMethod = PreparedStatement.class.getMethod("executeUpdate");
+        given(preparedStatement.executeUpdate()).willReturn(1);
+
+        proxyHandler.invoke(preparedStatement, executeQueryMethod, null);
+        proxyHandler.invoke(preparedStatement, executeQueryMethod, null);
+
+        verify(queryCounter, times(2)).increaseCount();
+    }
+
+    @Test
+    @DisplayName("execute 문자열이 포함된 메서드가 실행될 경우 쿼리 카운터의 증가 메서드가 호출된다 - executeLargeUpdate")
+    public void testInvoke_executeLargeUpdate_increasesQueryCount() throws Throwable {
+        Method executeQueryMethod = PreparedStatement.class.getMethod("executeLargeUpdate");
+        given(preparedStatement.executeLargeUpdate()).willReturn(1L);
+
+        proxyHandler.invoke(preparedStatement, executeQueryMethod, null);
+        proxyHandler.invoke(preparedStatement, executeQueryMethod, null);
+        proxyHandler.invoke(preparedStatement, executeQueryMethod, null);
+
+        verify(queryCounter, times(3)).increaseCount();
+    }
+
+
+}

--- a/src/test/java/com/cosain/trilo/common/logging/query/QueryCounterTest.java
+++ b/src/test/java/com/cosain/trilo/common/logging/query/QueryCounterTest.java
@@ -1,0 +1,43 @@
+package com.cosain.trilo.common.logging.query;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class QueryCounterTest {
+
+    private QueryCounter queryCounter;
+
+    @BeforeEach
+    public void setUp() {
+        queryCounter = new QueryCounter();
+    }
+
+    @Test
+    @DisplayName("쿼리 개수 증가")
+    public void testIncreaseCount(){
+
+        queryCounter.increaseCount();
+        queryCounter.increaseCount();
+        queryCounter.increaseCount();
+        int count = queryCounter.getCount();
+
+        assertThat(count).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("쿼리 개수 초기화")
+    public void testReset(){
+
+        queryCounter.increaseCount();
+        queryCounter.increaseCount();
+
+        queryCounter.resetCount();
+
+        int count = queryCounter.getCount();
+
+        assertThat(count).isEqualTo(0);
+    }
+}

--- a/src/test/java/com/cosain/trilo/config/LoggingTestConfig.java
+++ b/src/test/java/com/cosain/trilo/config/LoggingTestConfig.java
@@ -1,0 +1,9 @@
+package com.cosain.trilo.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+
+@TestConfiguration
+@ComponentScan(basePackages = "com.cosain.trilo.common.logging.query")
+public class LoggingTestConfig {
+}

--- a/src/test/java/com/cosain/trilo/config/LoggingTestConfig.java
+++ b/src/test/java/com/cosain/trilo/config/LoggingTestConfig.java
@@ -1,9 +1,0 @@
-package com.cosain.trilo.config;
-
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.ComponentScan;
-
-@TestConfiguration
-@ComponentScan(basePackages = "com.cosain.trilo.common.logging.query")
-public class LoggingTestConfig {
-}

--- a/src/test/java/com/cosain/trilo/support/RestControllerTest.java
+++ b/src/test/java/com/cosain/trilo/support/RestControllerTest.java
@@ -3,7 +3,7 @@ package com.cosain.trilo.support;
 import com.cosain.trilo.auth.domain.repository.TokenRepository;
 import com.cosain.trilo.auth.infra.TokenAnalyzer;
 import com.cosain.trilo.auth.infra.TokenProvider;
-import com.cosain.trilo.config.LoggingTestConfig;
+import com.cosain.trilo.common.logging.query.QueryCounter;
 import com.cosain.trilo.config.MessageSourceTestConfig;
 import com.cosain.trilo.config.SecurityTestConfig;
 import com.cosain.trilo.user.domain.UserRepository;
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -27,10 +26,13 @@ import static com.cosain.trilo.fixture.UserFixture.KAKAO_MEMBER;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
-@Import({SecurityTestConfig.class, MessageSourceTestConfig.class, LoggingTestConfig.class})
+@Import({SecurityTestConfig.class, MessageSourceTestConfig.class})
 public class RestControllerTest {
 
     protected MockMvc mockMvc;
+
+    @MockBean
+    protected QueryCounter queryCounter;
 
     @Autowired
     protected WebApplicationContext context;

--- a/src/test/java/com/cosain/trilo/support/RestControllerTest.java
+++ b/src/test/java/com/cosain/trilo/support/RestControllerTest.java
@@ -3,6 +3,7 @@ package com.cosain.trilo.support;
 import com.cosain.trilo.auth.domain.repository.TokenRepository;
 import com.cosain.trilo.auth.infra.TokenAnalyzer;
 import com.cosain.trilo.auth.infra.TokenProvider;
+import com.cosain.trilo.config.LoggingTestConfig;
 import com.cosain.trilo.config.MessageSourceTestConfig;
 import com.cosain.trilo.config.SecurityTestConfig;
 import com.cosain.trilo.user.domain.UserRepository;
@@ -11,6 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -25,7 +27,7 @@ import static com.cosain.trilo.fixture.UserFixture.KAKAO_MEMBER;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
-@Import({SecurityTestConfig.class, MessageSourceTestConfig.class})
+@Import({SecurityTestConfig.class, MessageSourceTestConfig.class, LoggingTestConfig.class})
 public class RestControllerTest {
 
     protected MockMvc mockMvc;


### PR DESCRIPTION
# JIRA 티켓
[TRL-240]

# 작업 내역
- [x] 요청에 대한 총 실행 쿼리 개수를 로그로 남기는 부가 기능 구현

# 참고사항

Spring AOP, 다이나믹 프록시, JDBC API 의 구조 및 호출 순서 등을 활용해서 구현했습니다.

상세한 내용은 아래 블로그 게시물에 작성해두었습니다.

[AOP 활용 - 쿼리 카운터 만들기](https://castle-of-gyu.tistory.com/84#)




[TRL-240]: https://cosain.atlassian.net/browse/TRL-240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ