### PR TITLE
[TRL-271] feat: 단일 예외 API 사양 변경(코드, 메시지, 상세)

### DIFF
--- a/src/main/java/com/cosain/trilo/common/dto/BasicErrorResponse.java
+++ b/src/main/java/com/cosain/trilo/common/dto/BasicErrorResponse.java
@@ -3,17 +3,17 @@ package com.cosain.trilo.common.dto;
 import lombok.Getter;
 
 @Getter
-public class ErrorResponse {
+public class BasicErrorResponse {
 
     private final String errorCode;
     private final String errorMessage;
     private final String errorDetail;
 
-    public static ErrorResponse of(String errorCode, String errorMessage, String errorDetail){
-        return new ErrorResponse(errorCode, errorMessage, errorDetail);
+    public static BasicErrorResponse of(String errorCode, String errorMessage, String errorDetail){
+        return new BasicErrorResponse(errorCode, errorMessage, errorDetail);
     }
 
-    public ErrorResponse(String errorCode, String errorMessage, String errorDetail) {
+    public BasicErrorResponse(String errorCode, String errorMessage, String errorDetail) {
         this.errorCode = errorCode;
         this.errorMessage = errorMessage;
         this.errorDetail = errorDetail;

--- a/src/main/java/com/cosain/trilo/common/dto/ErrorResponse.java
+++ b/src/main/java/com/cosain/trilo/common/dto/ErrorResponse.java
@@ -5,15 +5,17 @@ import lombok.Getter;
 @Getter
 public class ErrorResponse {
 
-    private String errorCode;
-    private String errorMessage;
+    private final String errorCode;
+    private final String errorMessage;
+    private final String errorDetail;
 
-    private ErrorResponse(String errorCode, String errorMessage) {
-        this.errorCode = errorCode;
-        this.errorMessage = errorMessage;
+    public static ErrorResponse of(String errorCode, String errorMessage, String errorDetail){
+        return new ErrorResponse(errorCode, errorMessage, errorDetail);
     }
 
-    public static ErrorResponse of(String errorCode, String errorMessage){
-        return new ErrorResponse(errorCode, errorMessage);
+    public ErrorResponse(String errorCode, String errorMessage, String errorDetail) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+        this.errorDetail = errorDetail;
     }
 }

--- a/src/main/java/com/cosain/trilo/common/exception/CustomException.java
+++ b/src/main/java/com/cosain/trilo/common/exception/CustomException.java
@@ -20,7 +20,7 @@ public abstract class CustomException extends RuntimeException {
         super(debugMessage, cause);
     }
 
-    public abstract String getErrorName();
+    public abstract String getErrorCode();
 
     public abstract HttpStatus getHttpStatus();
 }

--- a/src/main/java/com/cosain/trilo/common/exception/NotExistRefreshTokenException.java
+++ b/src/main/java/com/cosain/trilo/common/exception/NotExistRefreshTokenException.java
@@ -4,12 +4,12 @@ import org.springframework.http.HttpStatus;
 
 public class NotExistRefreshTokenException extends CustomException {
 
-    private static final String ERROR_NAME = "NotExistRefreshToken";
+    private static final String ERROR_CODE = "auth-0007";
     private static final HttpStatus HTTP_STATUS = HttpStatus.UNAUTHORIZED;
 
     @Override
-    public String getErrorName() {
-        return ERROR_NAME;
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/src/main/java/com/cosain/trilo/common/exception/NotImplementedException.java
+++ b/src/main/java/com/cosain/trilo/common/exception/NotImplementedException.java
@@ -4,7 +4,7 @@ import org.springframework.http.HttpStatus;
 
 public class NotImplementedException extends CustomException {
 
-    private static final String ERROR_NAME = "NotImplemented";
+    private static final String ERROR_CODE = "server-9999";
     private static final HttpStatus HTTP_STATUS = HttpStatus.INTERNAL_SERVER_ERROR;
 
     public NotImplementedException(String debugMessage) {
@@ -12,8 +12,8 @@ public class NotImplementedException extends CustomException {
     }
 
     @Override
-    public String getErrorName() {
-        return ERROR_NAME;
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/src/main/java/com/cosain/trilo/common/exception/NotSupportClientIdException.java
+++ b/src/main/java/com/cosain/trilo/common/exception/NotSupportClientIdException.java
@@ -4,12 +4,12 @@ import org.springframework.http.HttpStatus;
 
 public class NotSupportClientIdException extends CustomException {
 
-    private static final String ERROR_NAME = "NotSupportClientId";
+    private static final String ERROR_CODE = "auth-0005";
     private static final HttpStatus HTTP_STATUS = HttpStatus.UNAUTHORIZED;
 
     @Override
-    public String getErrorName() {
-        return ERROR_NAME;
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/src/main/java/com/cosain/trilo/common/exception/NotValidTokenException.java
+++ b/src/main/java/com/cosain/trilo/common/exception/NotValidTokenException.java
@@ -4,12 +4,12 @@ import org.springframework.http.HttpStatus;
 
 public class NotValidTokenException extends CustomException {
 
-    private static final String ERROR_NAME = "NotValidToken";
+    private static final String ERROR_CODE = "auth-0004";
     private static final HttpStatus HTTP_STATUS = HttpStatus.UNAUTHORIZED;
 
     @Override
-    public String getErrorName() {
-        return ERROR_NAME;
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/src/main/java/com/cosain/trilo/common/exception/TokenAuthenticationFilterException.java
+++ b/src/main/java/com/cosain/trilo/common/exception/TokenAuthenticationFilterException.java
@@ -4,7 +4,7 @@ import org.springframework.http.HttpStatus;
 
 public class TokenAuthenticationFilterException extends CustomException {
 
-    private static final String ERROR_NAME = "TokenAuthenticationFilterError";
+    private static final String ERROR_CODE = "auth-0006";
     private static final HttpStatus HTTP_STATUS = HttpStatus.UNAUTHORIZED;
 
     public TokenAuthenticationFilterException(Throwable cause) {
@@ -12,8 +12,8 @@ public class TokenAuthenticationFilterException extends CustomException {
     }
 
     @Override
-    public String getErrorName() {
-        return ERROR_NAME;
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/src/main/java/com/cosain/trilo/common/exception/UserNotFoundException.java
+++ b/src/main/java/com/cosain/trilo/common/exception/UserNotFoundException.java
@@ -4,16 +4,16 @@ import org.springframework.http.HttpStatus;
 
 public class UserNotFoundException extends CustomException {
 
-    private static final String errorName = "UserNotFound";
-    private static final HttpStatus status = HttpStatus.UNAUTHORIZED;
+    private static final String ERROR_CODE = "auth-0003";
+    private static final HttpStatus HTTP_STATUS = HttpStatus.UNAUTHORIZED;
 
     @Override
-    public String getErrorName() {
-        return errorName;
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override
     public HttpStatus getHttpStatus() {
-        return status;
+        return HTTP_STATUS;
     }
 }

--- a/src/main/java/com/cosain/trilo/config/exception/ExceptionAdvice.java
+++ b/src/main/java/com/cosain/trilo/config/exception/ExceptionAdvice.java
@@ -32,10 +32,10 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
     public ErrorResponse handleUnKnownException(Exception e) {
         log.error("예상치 못 한 예외!", e);
 
-        String errorCode = getMessage("UnKnown.code");
-        String errorMessage = getMessage("UnKnown.message");
-
-        return ErrorResponse.of(errorCode, errorMessage);
+        String errorCode = "server-0001";
+        String errorMessage = getMessage(errorCode + ".message");
+        String errorDetail = getMessage(errorCode + ".detail");
+        return ErrorResponse.of(errorCode, errorMessage, errorDetail);
     }
 
     /**
@@ -46,39 +46,40 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorResponse missingCookieError(MissingRequestCookieException e) {
         log.info("쿠키 누락!");
-        log.info("debug message = {}", e.getMessage());
-        log.info("detail Message Argument = {}", e.getDetailMessageArguments());
-        log.info("Cookie Name = {}", e.getCookieName());
+        String errorCode = "request-0002";
+        String errorMessage = getMessage(errorCode + ".message");
+        String errorDetail = getMessage(errorCode + ".detail");
 
-        String errorCode = getMessage("MissingRequestCookie.code");
-        String errorMessage = getMessage("MissingRequestCookie.message");
-
-        log.info("errorCode={}, errorMessage={}", errorCode, errorMessage);
-        return ErrorResponse.of(errorCode, errorMessage);
+        log.info("[{}] errorMessage={}", errorCode, errorMessage);
+        log.info("-----> errorDetail={}", errorDetail);
+        return ErrorResponse.of(errorCode, errorMessage, errorDetail);
     }
 
     @ExceptionHandler(AuthenticationException.class)
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     public ErrorResponse handleAuthenticationException(AuthenticationException e) {
-        log.error("인증 예외!", e);
+        log.info("인증 예외!");
+        String errorCode = "auth-0001";
+        String errorMessage = getMessage(errorCode + ".message");
+        String errorDetail = getMessage(errorCode + ".detail");
 
-        String errorCode = getMessage("AuthenticationFailed.code");
-        String errorMessage = getMessage("AuthenticationFailed.message");
-
-        log.info("errorCode={}, errorMessage={}", errorCode, errorMessage);
-        return ErrorResponse.of(errorCode, errorMessage);
+        log.info("[{}] errorMessage={}", errorCode, errorMessage);
+        log.info("-----> errorDetail={}", errorDetail);
+        return ErrorResponse.of(errorCode, errorMessage, errorDetail);
     }
 
     @ExceptionHandler(AccessDeniedException.class)
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     public ErrorResponse handleAccessDeniedException(AccessDeniedException e) {
-        log.error("인가 예외!", e);
+        log.info("인가 예외!");
 
-        String errorCode = getMessage("AccessDenied.code");
-        String errorMessage = getMessage("AccessDenied.message");
+        String errorCode = "auth-0002";
+        String errorMessage = getMessage(errorCode + ".message");
+        String errorDetail = getMessage(errorCode + ".detail");
 
-        log.info("errorCode={}, errorMessage={}", errorCode, errorMessage);
-        return ErrorResponse.of(errorCode, errorMessage);
+        log.info("[{}] errorMessage={}", errorCode, errorMessage);
+        log.info("-----> errorDetail={}", errorDetail);
+        return ErrorResponse.of(errorCode, errorMessage, errorDetail);
     }
 
     /**
@@ -87,13 +88,18 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
      */
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
-        String errorCode = getMessage(e.getErrorName()+".code");
-        String errorMessage = getMessage(e.getErrorName()+".message");
+        String errorCode = e.getErrorCode();
+        String errorMessage = getMessage(errorCode + ".message");
+        String errorDetail = getMessage(errorCode + ".detail");
         HttpStatus status = e.getHttpStatus();
 
-        log.info("errorCode={}, errorMessage={}, status={}", errorCode, errorMessage, status);
 
-        return ResponseEntity.status(status).body(ErrorResponse.of(errorCode, errorMessage));
+        log.info("[{}] errorMessage={}", errorCode, errorMessage);
+        log.info("-----> errorDetail={}", errorDetail);
+
+        return ResponseEntity
+                .status(status)
+                .body(ErrorResponse.of(errorCode, errorMessage, errorDetail));
     }
 
     private String getMessage(String code) {

--- a/src/main/java/com/cosain/trilo/config/exception/ExceptionAdvice.java
+++ b/src/main/java/com/cosain/trilo/config/exception/ExceptionAdvice.java
@@ -1,6 +1,6 @@
 package com.cosain.trilo.config.exception;
 
-import com.cosain.trilo.common.dto.ErrorResponse;
+import com.cosain.trilo.common.dto.BasicErrorResponse;
 import com.cosain.trilo.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,13 +29,13 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
      */
     @ExceptionHandler(Exception.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-    public ErrorResponse handleUnKnownException(Exception e) {
+    public BasicErrorResponse handleUnKnownException(Exception e) {
         log.error("예상치 못 한 예외!", e);
 
         String errorCode = "server-0001";
         String errorMessage = getMessage(errorCode + ".message");
         String errorDetail = getMessage(errorCode + ".detail");
-        return ErrorResponse.of(errorCode, errorMessage, errorDetail);
+        return BasicErrorResponse.of(errorCode, errorMessage, errorDetail);
     }
 
     /**
@@ -44,7 +44,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
      */
     @ExceptionHandler(MissingRequestCookieException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public ErrorResponse missingCookieError(MissingRequestCookieException e) {
+    public BasicErrorResponse missingCookieError(MissingRequestCookieException e) {
         log.info("쿠키 누락!");
         String errorCode = "request-0002";
         String errorMessage = getMessage(errorCode + ".message");
@@ -52,12 +52,12 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
         log.info("[{}] errorMessage={}", errorCode, errorMessage);
         log.info("-----> errorDetail={}", errorDetail);
-        return ErrorResponse.of(errorCode, errorMessage, errorDetail);
+        return BasicErrorResponse.of(errorCode, errorMessage, errorDetail);
     }
 
     @ExceptionHandler(AuthenticationException.class)
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    public ErrorResponse handleAuthenticationException(AuthenticationException e) {
+    public BasicErrorResponse handleAuthenticationException(AuthenticationException e) {
         log.info("인증 예외!");
         String errorCode = "auth-0001";
         String errorMessage = getMessage(errorCode + ".message");
@@ -65,12 +65,12 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
         log.info("[{}] errorMessage={}", errorCode, errorMessage);
         log.info("-----> errorDetail={}", errorDetail);
-        return ErrorResponse.of(errorCode, errorMessage, errorDetail);
+        return BasicErrorResponse.of(errorCode, errorMessage, errorDetail);
     }
 
     @ExceptionHandler(AccessDeniedException.class)
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    public ErrorResponse handleAccessDeniedException(AccessDeniedException e) {
+    public BasicErrorResponse handleAccessDeniedException(AccessDeniedException e) {
         log.info("인가 예외!");
 
         String errorCode = "auth-0002";
@@ -79,7 +79,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
         log.info("[{}] errorMessage={}", errorCode, errorMessage);
         log.info("-----> errorDetail={}", errorDetail);
-        return ErrorResponse.of(errorCode, errorMessage, errorDetail);
+        return BasicErrorResponse.of(errorCode, errorMessage, errorDetail);
     }
 
     /**
@@ -87,7 +87,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
      * 개발자에 의해 정의된 커스텀 예외 처리
      */
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+    public ResponseEntity<BasicErrorResponse> handleCustomException(CustomException e) {
         String errorCode = e.getErrorCode();
         String errorMessage = getMessage(errorCode + ".message");
         String errorDetail = getMessage(errorCode + ".detail");
@@ -99,7 +99,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
         return ResponseEntity
                 .status(status)
-                .body(ErrorResponse.of(errorCode, errorMessage, errorDetail));
+                .body(BasicErrorResponse.of(errorCode, errorMessage, errorDetail));
     }
 
     private String getMessage(String code) {

--- a/src/main/java/com/cosain/trilo/trip/command/application/exception/DayNotFoundException.java
+++ b/src/main/java/com/cosain/trilo/trip/command/application/exception/DayNotFoundException.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public class DayNotFoundException extends CustomException {
 
-    private static final String ERROR_NAME = "DayNotFoundException";
+    private static final String ERROR_CODE = "day-0001";
     private static final HttpStatus HTTP_STATUS = HttpStatus.NOT_FOUND;
 
     public DayNotFoundException() {
@@ -24,8 +24,8 @@ public class DayNotFoundException extends CustomException {
     }
 
     @Override
-    public String getErrorName() {
-        return ERROR_NAME;
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/src/main/java/com/cosain/trilo/trip/command/application/exception/NoScheduleCreateAuthorityException.java
+++ b/src/main/java/com/cosain/trilo/trip/command/application/exception/NoScheduleCreateAuthorityException.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public class NoScheduleCreateAuthorityException extends CustomException {
 
-    private static final String ERROR_NAME = "NoTripCreateAuthority";
+    private static final String ERROR_CODE = "schedule-0002";
     private static final HttpStatus HTTP_STATUS = HttpStatus.FORBIDDEN;
 
     public NoScheduleCreateAuthorityException() {
@@ -24,8 +24,8 @@ public class NoScheduleCreateAuthorityException extends CustomException {
     }
 
     @Override
-    public String getErrorName() {
-        return ERROR_NAME;
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/src/main/java/com/cosain/trilo/trip/command/application/exception/NoScheduleDeleteAuthorityException.java
+++ b/src/main/java/com/cosain/trilo/trip/command/application/exception/NoScheduleDeleteAuthorityException.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public class NoScheduleDeleteAuthorityException extends CustomException {
 
-    private static final String ERROR_NAME = "NoScheduleDeleteAuthority";
+    private static final String ERROR_CODE = "schedule-0003";
     private static final HttpStatus HTTP_STATUS = HttpStatus.FORBIDDEN;
 
     public NoScheduleDeleteAuthorityException() {
@@ -24,8 +24,8 @@ public class NoScheduleDeleteAuthorityException extends CustomException {
     }
 
     @Override
-    public String getErrorName() {
-        return ERROR_NAME;
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/src/main/java/com/cosain/trilo/trip/command/application/exception/NoScheduleMoveAuthorityException.java
+++ b/src/main/java/com/cosain/trilo/trip/command/application/exception/NoScheduleMoveAuthorityException.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public class NoScheduleMoveAuthorityException extends CustomException {
 
-    private static final String ERROR_NAME = "NoScheduleUpdateAuthorityException";
+    private static final String ERROR_CODE = "schedule-0005";
     private static final HttpStatus HTTP_STATUS = HttpStatus.FORBIDDEN;
 
     public NoScheduleMoveAuthorityException() {
@@ -24,8 +24,8 @@ public class NoScheduleMoveAuthorityException extends CustomException {
     }
 
     @Override
-    public String getErrorName() {
-        return ERROR_NAME;
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/src/main/java/com/cosain/trilo/trip/command/application/exception/NoScheduleUpdateAuthorityException.java
+++ b/src/main/java/com/cosain/trilo/trip/command/application/exception/NoScheduleUpdateAuthorityException.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public class NoScheduleUpdateAuthorityException extends CustomException {
 
-    private static final String ERROR_NAME = "NoScheduleUpdateAuthorityException";
+    private static final String ERROR_CODE = "schedule-0004";
     private static final HttpStatus HTTP_STATUS = HttpStatus.FORBIDDEN;
 
     public NoScheduleUpdateAuthorityException(String debugMessage) {
@@ -13,8 +13,8 @@ public class NoScheduleUpdateAuthorityException extends CustomException {
     }
 
     @Override
-    public String getErrorName() {
-        return ERROR_NAME;
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/src/main/java/com/cosain/trilo/trip/command/application/exception/NoTripDeleteAuthorityException.java
+++ b/src/main/java/com/cosain/trilo/trip/command/application/exception/NoTripDeleteAuthorityException.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public class NoTripDeleteAuthorityException extends CustomException {
 
-    private static final String ERROR_NAME = "NoTripDeleteAuthority";
+    private static final String ERROR_CODE = "trip-0007";
     private static final HttpStatus HTTP_STATUS = HttpStatus.FORBIDDEN;
 
     public NoTripDeleteAuthorityException() {
@@ -24,8 +24,8 @@ public class NoTripDeleteAuthorityException extends CustomException {
     }
 
     @Override
-    public String getErrorName() {
-        return ERROR_NAME;
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/src/main/java/com/cosain/trilo/trip/command/application/exception/NoTripUpdateAuthorityException.java
+++ b/src/main/java/com/cosain/trilo/trip/command/application/exception/NoTripUpdateAuthorityException.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public class NoTripUpdateAuthorityException extends CustomException {
 
-    private static final String ERROR_NAME = "NoTripUpdateAuthority";
+    private static final String ERROR_CODE = "trip-0004";
     private static final HttpStatus HTTP_STATUS = HttpStatus.FORBIDDEN;
 
     public NoTripUpdateAuthorityException() {}
@@ -23,8 +23,8 @@ public class NoTripUpdateAuthorityException extends CustomException {
     }
 
     @Override
-    public String getErrorName() {
-        return ERROR_NAME;
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/src/main/java/com/cosain/trilo/trip/command/application/exception/ScheduleNotFoundException.java
+++ b/src/main/java/com/cosain/trilo/trip/command/application/exception/ScheduleNotFoundException.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public class ScheduleNotFoundException extends CustomException {
 
-    private static final String ERROR_NAME = "ScheduleNotFound";
+    private static final String ERROR_CODE = "schedule-0001";
     private static final HttpStatus HTTP_STATUS = HttpStatus.NOT_FOUND;
 
     public ScheduleNotFoundException() {
@@ -24,8 +24,8 @@ public class ScheduleNotFoundException extends CustomException {
     }
 
     @Override
-    public String getErrorName() {
-        return ERROR_NAME;
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/src/main/java/com/cosain/trilo/trip/command/application/exception/TripNotFoundException.java
+++ b/src/main/java/com/cosain/trilo/trip/command/application/exception/TripNotFoundException.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public class TripNotFoundException extends CustomException {
 
-    private static final String ERROR_NAME = "TripNotFound";
+    private static final String ERROR_CODE = "trip-0001";
     private static final HttpStatus HTTP_STATUS = HttpStatus.NOT_FOUND;
 
     public TripNotFoundException() {}
@@ -23,8 +23,8 @@ public class TripNotFoundException extends CustomException {
     }
 
     @Override
-    public String getErrorName() {
-        return ERROR_NAME;
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/src/main/java/com/cosain/trilo/trip/command/domain/exception/EmptyPeriodUpdateException.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/exception/EmptyPeriodUpdateException.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public class EmptyPeriodUpdateException extends CustomException {
 
-    private static final String ERROR_NAME = "InvalidTripPeriod";
+    private static final String ERROR_CODE = "trip-0006";
     private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
 
     public EmptyPeriodUpdateException() {
@@ -24,8 +24,8 @@ public class EmptyPeriodUpdateException extends CustomException {
     }
 
     @Override
-    public String getErrorName() {
-        return ERROR_NAME;
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/src/main/java/com/cosain/trilo/trip/command/domain/exception/InvalidCoordinateException.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/exception/InvalidCoordinateException.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public class InvalidCoordinateException extends CustomException {
 
-    private static final String ERROR_NAME = "InvalidCoordinate";
+    private static final String ERROR_CODE = "place-0001";
     private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
 
     public InvalidCoordinateException() {
@@ -24,8 +24,8 @@ public class InvalidCoordinateException extends CustomException {
     }
 
     @Override
-    public String getErrorName() {
-        return ERROR_NAME;
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/src/main/java/com/cosain/trilo/trip/command/domain/exception/InvalidPeriodException.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/exception/InvalidPeriodException.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public class InvalidPeriodException extends CustomException {
 
-    private static final String ERROR_NAME = "InvalidPeriod";
+    private static final String ERROR_CODE = "trip-0005";
     private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
 
     public InvalidPeriodException() {
@@ -24,8 +24,8 @@ public class InvalidPeriodException extends CustomException {
     }
 
     @Override
-    public String getErrorName() {
-        return ERROR_NAME;
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/src/main/java/com/cosain/trilo/trip/command/domain/exception/InvalidScheduleMoveTargetOrderException.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/exception/InvalidScheduleMoveTargetOrderException.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public class InvalidScheduleMoveTargetOrderException extends CustomException {
 
-    private static final String ERROR_NAME = "InvalidScheduleMoveTargetOrderException";
+    private static final String ERROR_CODE = "schedule-0006";
     private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
 
     public InvalidScheduleMoveTargetOrderException() {
@@ -24,8 +24,8 @@ public class InvalidScheduleMoveTargetOrderException extends CustomException {
     }
 
     @Override
-    public String getErrorName() {
-        return ERROR_NAME;
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/src/main/java/com/cosain/trilo/trip/command/domain/exception/InvalidTripDayException.java
+++ b/src/main/java/com/cosain/trilo/trip/command/domain/exception/InvalidTripDayException.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public class InvalidTripDayException extends CustomException {
 
-    private static final String ERROR_NAME = "InvalidTripDay";
+    private static final String ERROR_CODE = "day-0002";
     private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
 
     public InvalidTripDayException() {
@@ -24,8 +24,8 @@ public class InvalidTripDayException extends CustomException {
     }
 
     @Override
-    public String getErrorName() {
-        return ERROR_NAME;
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/src/main/java/com/cosain/trilo/trip/query/application/exception/NoTripDetailSearchAuthorityException.java
+++ b/src/main/java/com/cosain/trilo/trip/query/application/exception/NoTripDetailSearchAuthorityException.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public class NoTripDetailSearchAuthorityException extends CustomException {
 
-    private static final String ERROR_NAME = "NoTripDetailSearchAuthorityException";
+    private static final String ERROR_CODE = "trip-0008";
     private static final HttpStatus HTTP_STATUS = HttpStatus.FORBIDDEN;
 
     public NoTripDetailSearchAuthorityException(String debugMessage) {
@@ -13,8 +13,8 @@ public class NoTripDetailSearchAuthorityException extends CustomException {
     }
 
     @Override
-    public String getErrorName() {
-        return ERROR_NAME;
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/src/main/java/com/cosain/trilo/trip/query/application/exception/ScheduleNotFoundException.java
+++ b/src/main/java/com/cosain/trilo/trip/query/application/exception/ScheduleNotFoundException.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public class ScheduleNotFoundException extends CustomException {
 
-    private static final String ERROR_NAME = "ScheduleNotFound";
+    private static final String ERROR_CODE = "schedule-0001";
     private static final HttpStatus HTTP_STATUS = HttpStatus.NOT_FOUND;
 
     public ScheduleNotFoundException() {
@@ -24,8 +24,8 @@ public class ScheduleNotFoundException extends CustomException {
     }
 
     @Override
-    public String getErrorName() {
-        return ERROR_NAME;
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/src/main/java/com/cosain/trilo/trip/query/application/exception/TripNotFoundException.java
+++ b/src/main/java/com/cosain/trilo/trip/query/application/exception/TripNotFoundException.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public class TripNotFoundException extends CustomException {
 
-    private static final String ERROR_NAME = "TripNotFound";
+    private static final String ERROR_CODE = "trip-0001";
     private static final HttpStatus HTTP_STATUS = HttpStatus.NOT_FOUND;
 
     public TripNotFoundException() {}
@@ -23,8 +23,8 @@ public class TripNotFoundException extends CustomException {
     }
 
     @Override
-    public String getErrorName() {
-        return ERROR_NAME;
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/src/main/java/com/cosain/trilo/trip/query/application/exception/TripperNotFoundException.java
+++ b/src/main/java/com/cosain/trilo/trip/query/application/exception/TripperNotFoundException.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public class TripperNotFoundException extends CustomException {
 
-    private static final String ERROR_NAME = "TripperNotFound";
+    private static final String ERROR_CODE = "TripperNotFound";
     private static final HttpStatus HTTP_STATUS = HttpStatus.NOT_FOUND;
 
     public TripperNotFoundException() {}
@@ -23,8 +23,8 @@ public class TripperNotFoundException extends CustomException {
     }
 
     @Override
-    public String getErrorName() {
-        return ERROR_NAME;
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/src/main/resources/exceptions/exception.yml
+++ b/src/main/resources/exceptions/exception.yml
@@ -1,51 +1,135 @@
-# 공통
-UnKnown:
-  code: "TempCode"
-  message: 예상치 못 한 서버 예외가 발생했습니다.
+# 서버 문제
+server-0001:
+  message: Unknown Error
+  detail: 예상치 못 한 서버 예외가 발생했습니다.
+
+server-9999:
+  message: NotImplemented
+  detail: 미구현 기능입니다.
 
 
-NotImplemented:
-  code: "TempCode"
-  message: 미구현 기능입니다.
+# 웹 요청 관련
+request-0001:
+  message: Invalid Request Data Format
+  detail: 요청 데이터 형식 또는 데이터 타입이 올바르지 않습니다. 요청 데이터 형식, 파라미터를 다시 확인해주세요.
 
-
-# 요청 관련
-MissingRequestCookie:
-  code: "TempCode"
-  message: 요청에 필요한 쿠키가 누락 됐습니다.
+request-0002:
+  message: Missing Request Cookie
+  detail: 요청에 필요한 쿠키가 누락 됐습니다. 요청에 필요한 쿠키가 존재하는 지, 제대로 된 값인지 다시 확인해주세요.
 
 
 # 인증/인가 관련
-AuthenticationFailed:
-  code: "TempCode"
-  message: 인증에 실패했습니다.
+auth-0001:
+  message: AuthenticationFailed
+  detail: 인증에 실패했습니다.
+
+auth-0002:
+  message: AccessDenied
+  detail: 접근 권한이 없습니다.
 
 
-AccessDenied:
-  code: "TempCode"
-  message: 접근 권한이 없습니다.
+auth-0003:
+  message: UserNotFound
+  detail: 인증 대상에 해당하는 사용자를 찾을 수 없습니다.
 
 
-UserNotFound:
-  code: "TempCode"
-  message: 유저를 찾을 수 없습니다.
+auth-0004:
+  message: NotValidToken
+  detail: 전달한 토큰이 유효하지 않습니다.
 
 
-NotValidToken:
-  code: "TempCode"
-  message: 토큰 검증 과정에서 문제가 발생했습니다.
+auth-0005:
+  message: Not Support ClientId
+  detail: 지원하지 않는 로그인 방식입니다.
 
 
-NotSupportClientId:
-  code: "TempCode"
-  message: 지원하지 않는 로그인 방식입니다.
+auth-0006:
+  message: TokenAuthenticationFilterError
+  detail: 토큰 검증 과정에서 문제가 발생했습니다.
+
+auth-0007:
+  message: NotExistRefreshToken
+  detail: 리프레시 토큰이 존재하지 않습니다.
 
 
-TokenAuthenticationFilterError:
-  code: "TempCode"
-  message: 토큰 검증 과정에서 문제가 발생했습니다.
+# 사용자(여행자) 관련
+user-0001:
+  message: TripperNotFound
+  detail: 일치하는 식별자의 여행자를 찾을 수 없습니다.
 
 
-NotExistRefreshToken:
-  code: "TempCode"
-  message: 리프레시 토큰이 존재하지 않습니다.
+# 여행 관련
+trip-0001:
+  message: Trip Not Found
+  detail: 일치하는 식별자의 Trip을 찾을 수 없습니다.
+
+trip-0002:
+  message: Empty Trip Title
+  detail: 여행의 제목은 null 또는 공백일 수 없습니다.
+
+trip-0003:
+  message: Invalid Trip Title Length
+  detail: 여행 제목의 길이는 {min}자 이상 {max}자 이하여야 합니다.
+
+
+trip-0004:
+  message: No Trip Update Authority
+  detail: 해당 여행을 수정할 권한이 없습니다.
+
+trip-0005:
+  message: InvalidTripPeriod
+  detail: 여행의 기간이 올바르지 않습니다. 시작일보다 종료일이 앞서거나, 시작일 또는 종료일 중 어느 하나가 null일 수 없습니다.
+
+trip-0006:
+  message: EmptyPeriodUpdate Error
+  detail: 기간이 정해진 여행에 대해서, 빈 기간으로 변경할 수 없습니다.
+
+trip-0007:
+  message: NoTripDeleteAuthority
+  detail: 해당 여행을 삭제할 권한이 없습니다.
+
+trip-0008:
+  message: NoTripDetailSearchAuthority
+  detail: 해당 여행을 단건 조회할 권한이 없습니다.
+
+
+# Day 관련
+day-0001:
+  message: DayNotFound
+  detail: 일치하는 식별자의 Day를 찾을 수 없습니다.
+
+day-0002:
+  message: Invalid Trip-Day Relationship
+  detail: Day가 Trip에 속해있지 않습니다.
+
+
+# 일정 관련
+schedule-0001:
+  message: ScheduleNotFound
+  detail: 일치하는 식별자의 일정을 찾을 수 없습니다.
+
+schedule-0002:
+  message: NoScheduleCreateAuthority
+  detail: 해당 여행에 일정을 생성할 권한이 없습니다.
+
+schedule-0003:
+  message: NoScheduleDeleteAuthority
+  detail: 해당 일정을 삭제할 권한이 없습니다.
+
+schedule-0004:
+  message: NoScheduleUpdateAuthority
+  detail: 해당 일정을 수정할 권한이 없습니다.
+
+schedule-0005:
+  message: NoScheduleMoveAuthority
+  detail: 해당 일정을 이동할 권한이 없습니다.
+
+schedule-0006:
+  message: InvalidScheduleMoveTargetOrder
+  detail: 일정을 해당 순서로 이동시킬 수 없습니다. 유효한 순서 범위를 벗어납니다.
+
+
+# 장소 관련
+place-0001:
+  message: InvalidCoordinate
+  detail: 위도 또는 경도의 범위가 유효하지 않습니다.

--- a/src/main/resources/exceptions/exception_en.yml
+++ b/src/main/resources/exceptions/exception_en.yml
@@ -1,49 +1,135 @@
-# 공통
-UnKnown:
-  code: "TempCode"
-  message: UnKnown Server Error!
+# 서버 문제
+server-0001:
+  message: Unknown Error
+  detail: An unexpected server exception occurred.
+
+server-9999:
+  message: NotImplemented
+  detail: The feature is not implemented.
 
 
-NotImplemented:
-  code: "TempCode"
-  message: This operation is not implemented.
+# 웹 요청 관련
+request-0001:
+  message: Invalid Request Data Format
+  detail: The request data format or data type is incorrect. Please check the request data format and parameters again.
 
-# 요청 관련
-MissingRequestCookie:
-  code: "TempCode"
-  message: Some cookies required for your request do not exist.
+request-0002:
+  message: Missing Request Cookie
+  detail: The required cookie in the request is missing. Please check if the necessary cookie exists and if it has the correct value.
 
 
 # 인증/인가 관련
-AuthenticationFailed:
-  code: "TempCode"
-  message: Authentication failed.
+auth-0001:
+  message: AuthenticationFailed
+  detail: Authentication failed.
 
-AccessDenied:
-  code: "TempCode"
-  message: You do not have access.
-
-
-UserNotFound:
-  code: "TempCode"
-  message: Cannot find that user.
+auth-0002:
+  message: AccessDenied
+  detail: Access is denied.
 
 
-NotValidToken:
-  code: "TempCode"
-  message: A problem occurred during token validation.
+auth-0003:
+  message: UserNotFound
+  detail: The user corresponding to the authentication target could not be found.
 
 
-InvalidAuthorizationHeaderType:
-  code: "TempCode"
-  message: Authorization header type is incorrect.
+auth-0004:
+  message: NotValidToken
+  detail: The provided token is not valid.
 
 
-NotSupportClientId:
-  code: "TempCode"
-  message: This is an unsupported login method.
+auth-0005:
+  message: Not Support ClientId
+  detail: The login method is not supported.
 
 
-NotExistRefreshToken:
-  code: "TempCode"
-  message: Refresh token does not exist.
+auth-0006:
+  message: TokenAuthenticationFilterError
+  detail: An error occurred during token verification process.
+
+auth-0007:
+  message: NotExistRefreshToken
+  detail: The refresh token does not exist.
+
+
+# 사용자(여행자) 관련
+user-0001:
+  message: TripperNotFound
+  detail: The traveler with the matching identifier could not be found.
+
+
+# 여행 관련
+trip-0001:
+  message: Trip Not Found
+  detail: The Trip with the matching identifier could not be found.
+
+trip-0002:
+  message: Empty Trip Title
+  detail: The trip title cannot be null or empty.
+
+trip-0003:
+  message: Invalid Trip Title Length
+  detail: The trip title length must be between {min} and {max} characters.
+
+
+trip-0004:
+  message: No Trip Update Authority
+  detail: You do not have the authority to modify this trip.
+
+trip-0005:
+  message: InvalidTripPeriod
+  detail: The trip period is invalid. The end date cannot be before the start date, and neither the start nor end date can be null.
+
+trip-0006:
+  message: EmptyPeriodUpdate Error
+  detail: The period of a scheduled trip cannot be updated to an empty period.
+
+trip-0007:
+  message: NoTripDeleteAuthority
+  detail: You do not have the authority to delete this trip.
+
+trip-0008:
+  message: NoTripDetailSearchAuthority
+  detail: You do not have the authority to retrieve detailed information about this trip.
+
+
+# Day 관련
+day-0001:
+  message: DayNotFound
+  detail: The Day with the matching identifier could not be found.
+
+day-0002:
+  message: Invalid Trip-Day Relationship
+  detail: The Day does not belong to the Trip.
+
+
+# 일정 관련
+schedule-0001:
+  message: ScheduleNotFound
+  detail: The schedule with the matching identifier could not be found.
+
+schedule-0002:
+  message: NoScheduleCreateAuthority
+  detail: You do not have the authority to create a schedule for this trip.
+
+schedule-0003:
+  message: NoScheduleDeleteAuthority
+  detail: You do not have the authority to delete this schedule.
+
+schedule-0004:
+  message: NoScheduleUpdateAuthority
+  detail: You do not have the authority to modify this schedule.
+
+schedule-0005:
+  message: NoScheduleMoveAuthority
+  detail: You do not have the authority to move this schedule.
+
+schedule-0006:
+  message: InvalidScheduleMoveTargetOrder
+  detail: Unable to move the schedule to the specified order. It is outside the valid order range.
+
+
+# 장소 관련
+place-0001:
+  message: InvalidCoordinate
+  detail: The latitude or longitude range is invalid.

--- a/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/schedule/ScheduleCreateControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/schedule/ScheduleCreateControllerTest.java
@@ -83,7 +83,8 @@ class ScheduleCreateControllerTest extends RestControllerTest {
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorCode").exists())
-                .andExpect(jsonPath("$.errorMessage").exists());
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
     }
 
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/schedule/ScheduleDeleteControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/schedule/ScheduleDeleteControllerTest.java
@@ -62,7 +62,8 @@ class ScheduleDeleteControllerTest extends RestControllerTest {
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorCode").exists())
-                .andExpect(jsonPath("$.errorMessage").exists());
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
     }
 
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/schedule/ScheduleMoveControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/schedule/ScheduleMoveControllerTest.java
@@ -91,7 +91,8 @@ public class ScheduleMoveControllerTest extends RestControllerTest {
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorCode").exists())
-                .andExpect(jsonPath("$.errorMessage").exists());
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
     }
 
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/schedule/ScheduleUpdateControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/schedule/ScheduleUpdateControllerTest.java
@@ -64,7 +64,8 @@ class ScheduleUpdateControllerTest extends RestControllerTest {
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorCode").exists())
-                .andExpect(jsonPath("$.errorMessage").exists());
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
     }
 
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/trip/TripCreateControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/trip/TripCreateControllerTest.java
@@ -58,7 +58,8 @@ class TripCreateControllerTest extends RestControllerTest {
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorCode").exists())
-                .andExpect(jsonPath("$.errorMessage").exists());
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
     }
 }
 

--- a/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/trip/TripDeleteControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/trip/TripDeleteControllerTest.java
@@ -60,7 +60,8 @@ class TripDeleteControllerTest extends RestControllerTest {
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorCode").exists())
-                .andExpect(jsonPath("$.errorMessage").exists());
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
     }
 
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/trip/TripUpdateControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/trip/TripUpdateControllerTest.java
@@ -60,7 +60,8 @@ class TripUpdateControllerTest extends RestControllerTest {
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorCode").exists())
-                .andExpect(jsonPath("$.errorMessage").exists());
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
     }
 
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/query/presentation/api/day/SingleDayQueryControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/query/presentation/api/day/SingleDayQueryControllerTest.java
@@ -36,7 +36,8 @@ class SingleDayQueryControllerTest extends RestControllerTest {
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorCode").exists())
-                .andExpect(jsonPath("$.errorMessage").exists());
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
     }
 
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/query/presentation/api/day/TripDayListQueryControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/query/presentation/api/day/TripDayListQueryControllerTest.java
@@ -24,8 +24,9 @@ class TripDayListQueryControllerTest extends RestControllerTest {
         mockMvc.perform(get("/api/trips/1/days"))
                 .andDo(print())
                 .andExpect(status().isInternalServerError())
-                .andExpect(jsonPath("$.errorCode").exists())
-                .andExpect(jsonPath("$.errorMessage").exists());
+                .andExpect(jsonPath("$.errorCode").value("server-9999"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
     }
 
     @Test
@@ -36,6 +37,7 @@ class TripDayListQueryControllerTest extends RestControllerTest {
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorCode").exists())
-                .andExpect(jsonPath("$.errorMessage").exists());
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
     }
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/query/presentation/api/schedule/SingleScheduleQueryControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/query/presentation/api/schedule/SingleScheduleQueryControllerTest.java
@@ -62,6 +62,7 @@ class SingleScheduleQueryControllerTest extends RestControllerTest {
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorCode").exists())
-                .andExpect(jsonPath("$.errorMessage").exists());
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
     }
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/query/presentation/api/trip/SingleTripQueryControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/query/presentation/api/trip/SingleTripQueryControllerTest.java
@@ -68,7 +68,8 @@ class SingleTripQueryControllerTest extends RestControllerTest {
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorCode").exists())
-                .andExpect(jsonPath("$.errorMessage").exists());
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
     }
 
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/query/presentation/api/trip/TripTemporaryStorageQueryControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/query/presentation/api/trip/TripTemporaryStorageQueryControllerTest.java
@@ -71,6 +71,7 @@ class TripTemporaryStorageQueryControllerTest extends RestControllerTest {
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorCode").exists())
-                .andExpect(jsonPath("$.errorMessage").exists());
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
     }
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/query/presentation/api/trip/TripperTripListQueryControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/query/presentation/api/trip/TripperTripListQueryControllerTest.java
@@ -71,7 +71,8 @@ class TripperTripListQueryControllerTest extends RestControllerTest {
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorCode").exists())
-                .andExpect(jsonPath("$.errorMessage").exists());
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
     }
 
 }


### PR DESCRIPTION

# JIRA 티켓
- [TRL-271]

---

# 작업 내역
- 기존 에외 API에서 좀 더 예외 API의 내용을 상세화했습니다.
  - errorCode: 에러의 식별자
  - errorMessage: 간략한 에러 설명 문구
  - errorDetail : 좀 더 상세한 설명
- 이후 다중필드의 예외를 함께 보낼 떄의 DTO와 구분하기 위해 기존 단일 예외 응답 DTO의 이름을 BasicErrorResponse로 변경했습니다.


[TRL-271]: https://cosain.atlassian.net/browse/TRL-271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ