### PR TITLE
[TRL-272] feat: 표현계층 검증로직 추가 및 복수예외 API 정의

### DIFF
--- a/src/main/java/com/cosain/trilo/config/exception/ExceptionAdvice.java
+++ b/src/main/java/com/cosain/trilo/config/exception/ExceptionAdvice.java
@@ -6,14 +6,18 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @Slf4j
@@ -36,6 +40,22 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         String errorMessage = getMessage(errorCode + ".message");
         String errorDetail = getMessage(errorCode + ".detail");
         return BasicErrorResponse.of(errorCode, errorMessage, errorDetail);
+    }
+
+
+    /**
+     * 요청 데이터 형식 또는 데이터 타입이 올바르지 않을 때에 대한 예외 API
+     */
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(HttpMessageNotReadableException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        log.info("요청 데이터 형식이 올바르지 않음");
+        String errorCode = "request-0001";
+        String errorMessage = getMessage(errorCode + ".message");
+        String errorDetail = getMessage(errorCode + ".detail");
+
+        return ResponseEntity
+                .badRequest()
+                .body(BasicErrorResponse.of(errorCode, errorMessage, errorDetail));
     }
 
     /**

--- a/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/schedule/ScheduleCreateControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/schedule/ScheduleCreateControllerTest.java
@@ -36,7 +36,7 @@ class ScheduleCreateControllerTest extends RestControllerTest {
     @Test
     @DisplayName("인증된 사용자의 올바른 요청 -> 일정 생성됨")
     @WithMockUser
-    public void createSchedulePlace_with_authorizedUser() throws Exception {
+    public void createSchedule_with_authorizedUser() throws Exception {
         mockingForLoginUserAnnotation();
 
         ScheduleCreateRequest request = ScheduleCreateRequest.builder()
@@ -67,7 +67,7 @@ class ScheduleCreateControllerTest extends RestControllerTest {
     @Test
     @DisplayName("미인증 사용자 요청 -> 인증 실패 401")
     @WithAnonymousUser
-    public void updateSchedulePlace_with_unauthorizedUser() throws Exception {
+    public void createSchedule_with_unauthorizedUser() throws Exception {
         ScheduleCreateRequest request = ScheduleCreateRequest.builder()
                 .dayId(1L)
                 .title("일정 제목")
@@ -83,6 +83,85 @@ class ScheduleCreateControllerTest extends RestControllerTest {
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorCode").exists())
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
+    @Test
+    @DisplayName("비어있는 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void createSchedule_with_emptyContent() throws Exception {
+        mockingForLoginUserAnnotation();
+
+        String emptyContent = "";
+
+        mockMvc.perform(post("/api/schedules")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(emptyContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
+    @Test
+    @DisplayName("형식이 올바르지 않은 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void createSchedule_with_invalidContent() throws Exception {
+        mockingForLoginUserAnnotation();
+        String invalidContent = """
+                {
+                    "dayId"+ 1,
+                    "tripId": 2,
+                    "title": 괄호로 감싸지지 않은 문자열,
+                    "placeId": "place-5964",
+                    "placeName": "장소명",
+                    "latitude": 35.1234,
+                    "longitude": 123.1212
+                }
+                """;
+
+        mockMvc.perform(post("/api/schedules")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(invalidContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
+    @Test
+    @DisplayName("타입이 올바르지 않은 요청 데이터 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void createSchedule_with_invalidType() throws Exception {
+        mockingForLoginUserAnnotation();
+        String invalidTypeContent = """
+                {
+                    "dayId": 1,
+                    "tripId": "숫자가 아닌 값",
+                    "title": "제목",
+                    "placeId": "place-5964",
+                    "placeName": "장소명",
+                    "latitude": "숫자가 아닌 위도값",
+                    "longitude": "숫자가 아닌 경도값"
+                }
+                """;
+
+
+        mockMvc.perform(post("/api/schedules")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(invalidTypeContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
                 .andExpect(jsonPath("$.errorMessage").exists())
                 .andExpect(jsonPath("$.errorDetail").exists());
     }

--- a/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/schedule/ScheduleDeleteControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/schedule/ScheduleDeleteControllerTest.java
@@ -2,7 +2,6 @@ package com.cosain.trilo.unit.trip.command.preesentation.api.schedule;
 
 import com.cosain.trilo.support.RestControllerTest;
 import com.cosain.trilo.trip.command.application.usecase.ScheduleDeleteUseCase;
-import com.cosain.trilo.trip.command.application.usecase.TripDeleteUseCase;
 import com.cosain.trilo.trip.command.presentation.schedule.ScheduleDeleteController;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -65,5 +64,4 @@ class ScheduleDeleteControllerTest extends RestControllerTest {
                 .andExpect(jsonPath("$.errorMessage").exists())
                 .andExpect(jsonPath("$.errorDetail").exists());
     }
-
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/schedule/ScheduleMoveControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/schedule/ScheduleMoveControllerTest.java
@@ -21,9 +21,9 @@ import java.nio.charset.StandardCharsets;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -76,7 +76,7 @@ public class ScheduleMoveControllerTest extends RestControllerTest {
     @Test
     @DisplayName("미인증 사용자 요청 -> 인증 실패 401")
     @WithAnonymousUser
-    public void updateSchedulePlace_with_unauthorizedUser() throws Exception {
+    public void moveSchedule_with_unauthorizedUser() throws Exception {
         Long scheduleId = 1L;
         Long targetDayId = 2L;
         int targetOrder = 3;
@@ -94,5 +94,74 @@ public class ScheduleMoveControllerTest extends RestControllerTest {
                 .andExpect(jsonPath("$.errorMessage").exists())
                 .andExpect(jsonPath("$.errorDetail").exists());
     }
+
+    @Test
+    @DisplayName("비어있는 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void moveSchedule_with_emptyContent() throws Exception {
+        mockingForLoginUserAnnotation();
+
+        String emptyContent = "";
+
+        mockMvc.perform(patch("/api/schedules/1")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(emptyContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
+    @Test
+    @DisplayName("형식이 올바르지 않은 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void moveSchedule_with_invalidContent() throws Exception {
+        mockingForLoginUserAnnotation();
+        String invalidContent = """
+                {
+                    "targetDayId": 따옴표로 감싸지 않은 값,
+                    "targetOrder": 123
+                }
+                """;
+
+        mockMvc.perform(patch("/api/schedules/1")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(invalidContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
+    @Test
+    @DisplayName("타입이 올바르지 않은 요청 데이터 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void moveSchedule_with_invalidType() throws Exception {
+        mockingForLoginUserAnnotation();
+        String invalidTypeContent = """
+                {
+                    "targetDayId": 1,
+                    "targetOrder": "숫자가 아닌 값"
+                }
+                """;
+
+        mockMvc.perform(patch("/api/schedules/1")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(invalidTypeContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
 
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/schedule/ScheduleUpdateControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/schedule/ScheduleUpdateControllerTest.java
@@ -19,6 +19,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -64,6 +65,51 @@ class ScheduleUpdateControllerTest extends RestControllerTest {
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorCode").exists())
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
+
+    @Test
+    @DisplayName("비어있는 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void updateSchedule_with_emptyContent() throws Exception {
+        mockingForLoginUserAnnotation();
+
+        String emptyContent = "";
+
+        mockMvc.perform(put("/api/schedules/1")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(emptyContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
+    @Test
+    @DisplayName("형식이 올바르지 않은 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void updateSchedule_with_invalidContent() throws Exception {
+        mockingForLoginUserAnnotation();
+        String invalidContent = """
+                {
+                    "title": 따옴표로 감싸지 않은 제목,
+                    "content": "본문"
+                }
+                """;
+
+        mockMvc.perform(put("/api/schedules/1")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(invalidContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
                 .andExpect(jsonPath("$.errorMessage").exists())
                 .andExpect(jsonPath("$.errorDetail").exists());
     }

--- a/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/trip/TripCreateControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/trip/TripCreateControllerTest.java
@@ -61,5 +61,49 @@ class TripCreateControllerTest extends RestControllerTest {
                 .andExpect(jsonPath("$.errorMessage").exists())
                 .andExpect(jsonPath("$.errorDetail").exists());
     }
+
+    @Test
+    @DisplayName("비어있는 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void createTrip_with_emptyContent() throws Exception {
+        mockingForLoginUserAnnotation();
+
+        String emptyContent = "";
+
+        mockMvc.perform(post("/api/trips")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(emptyContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
+    @Test
+    @DisplayName("형식이 올바르지 않은 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void createTrip_with_invalidContent() throws Exception {
+        mockingForLoginUserAnnotation();
+        String invalidContent = """
+                {
+                    "title": 따옴표 안 감싼 제목
+                }
+                """;
+
+        mockMvc.perform(post("/api/trips")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(invalidContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
 }
 

--- a/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/trip/TripDeleteControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/trip/TripDeleteControllerTest.java
@@ -5,23 +5,22 @@ import com.cosain.trilo.trip.command.application.usecase.TripDeleteUseCase;
 import com.cosain.trilo.trip.command.presentation.trip.TripDeleteController;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.BDDMockito;
-import org.mockito.Mock;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithAnonymousUser;
-import org.springframework.security.test.context.support.WithMockUser;
 
 import java.nio.charset.StandardCharsets;
 
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayName("[TripCommand] 여행 삭제 API 테스트")
 @WebMvcTest(TripDeleteController.class)
@@ -63,5 +62,4 @@ class TripDeleteControllerTest extends RestControllerTest {
                 .andExpect(jsonPath("$.errorMessage").exists())
                 .andExpect(jsonPath("$.errorDetail").exists());
     }
-
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/trip/TripUpdateControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/command/preesentation/api/trip/TripUpdateControllerTest.java
@@ -56,7 +56,7 @@ class TripUpdateControllerTest extends RestControllerTest {
     @DisplayName("미인증 사용자 요청 -> 인증 실패 401")
     @WithAnonymousUser
     public void updateTrip_with_unauthorizedUser() throws Exception {
-        mockMvc.perform(put("/api/trips"))
+        mockMvc.perform(put("/api/trips/1"))
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorCode").exists())
@@ -64,4 +64,73 @@ class TripUpdateControllerTest extends RestControllerTest {
                 .andExpect(jsonPath("$.errorDetail").exists());
     }
 
+    @Test
+    @DisplayName("비어있는 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void updateTrip_with_emptyContent() throws Exception {
+        mockingForLoginUserAnnotation();
+
+        String emptyContent = "";
+
+        mockMvc.perform(put("/api/trips/1")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(emptyContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
+    @Test
+    @DisplayName("형식이 올바르지 않은 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void updateTrip_with_invalidContent() throws Exception {
+        mockingForLoginUserAnnotation();
+        String invalidContent = """
+                {
+                    "title": 괄호로 감싸지 않은 제목,
+                    "startDate": "2023-03-01",
+                    "endDate": "2023-03-02"
+                }
+                """;
+
+        mockMvc.perform(put("/api/trips/1")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(invalidContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
+    @Test
+    @DisplayName("타입이 올바르지 않은 요청 데이터 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void updateTrip_with_invalidType() throws Exception {
+        mockingForLoginUserAnnotation();
+        String invalidTypeContent = """
+                {
+                    "title": "제목",
+                    "startDate": "2023-03-01",
+                    "endDate": "날짜형식이 아닌 문자열"
+                }
+                """;
+
+        mockMvc.perform(put("/api/trips/1")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(invalidTypeContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
 }


### PR DESCRIPTION
# JIRA 티켓
- [TRL-272]

---

# 작업 내역
- [x] 요청 데이터 형식/데이터 타입이 올바르지 않을 때에 대한 예외 API 정의
- [ ] PathVariable로 전달된 값이 올바르지 않은 타입일 경우에 대한 예외 API 정의
- [ ] `@RequestBody` 로 매핑된 필드에 대한 예외 API 정의
- [ ] `@ModelAttribute`로 매핑된 필드에 대한 예외 API 정의
- [ ] 표현 계층에서 복수의 필드에서 예외가 발생할 경우 이들을 한번에 응답에 보낼 수 있도록 하기
- [ ] 표현 계층에서 복수의 필드를 함께 사용해서 검증해야하는 글로벌 예외 등에 대해 처리하기

---

# 용어
- 필드에러 : 단일 필드에 대한 예외
- 글로벌 에러 : 단일 필드 뿐 아니라, 2개 이상의 필드를 함께 확인해서 입력을 검증해야하는 경우

---


[TRL-272]: https://cosain.atlassian.net/browse/TRL-272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ