### PR TITLE
[TRL-272] feat: 표현계층 검증로직 추가 및 복수예외 API 정의

### DIFF
--- a/src/main/java/com/cosain/trilo/common/dto/ValidationErrorResponse.java
+++ b/src/main/java/com/cosain/trilo/common/dto/ValidationErrorResponse.java
@@ -1,0 +1,54 @@
+package com.cosain.trilo.common.dto;
+
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class ValidationErrorResponse {
+
+    private final String errorCode;
+    private final String errorMessage;
+    private final String errorDetail;
+    private final List<FieldErrorResponse> fieldErrors = new ArrayList<>();
+    private final List<GlobalErrorResponse> globalErrors = new ArrayList<>();
+
+    public static ValidationErrorResponse of(String errorCode, String errorMessage, String errorDetail) {
+        return new ValidationErrorResponse(errorCode, errorMessage, errorDetail);
+    }
+
+    public void addFieldError(String errorCode, String errorMessage, String errorDetail, String field) {
+        FieldErrorResponse fieldError = new FieldErrorResponse(errorCode, errorMessage, errorDetail, field);
+        fieldErrors.add(fieldError);
+    }
+
+
+    public ValidationErrorResponse(String errorCode, String errorMessage, String errorDetail) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+        this.errorDetail = errorDetail;
+    }
+
+
+    @Getter
+    private static class FieldErrorResponse {
+
+        private final String errorCode;
+        private final String errorMessage;
+        private final String errorDetail;
+        private final String field;
+
+        public FieldErrorResponse(String errorCode, String errorMessage, String errorDetail, String field) {
+            this.errorCode = errorCode;
+            this.errorMessage = errorMessage;
+            this.errorDetail = errorDetail;
+            this.field = field;
+        }
+    }
+
+    @Getter
+    private static class GlobalErrorResponse {
+
+    }
+}

--- a/src/main/java/com/cosain/trilo/common/dto/ValidationErrorResponse.java
+++ b/src/main/java/com/cosain/trilo/common/dto/ValidationErrorResponse.java
@@ -18,18 +18,21 @@ public class ValidationErrorResponse {
         return new ValidationErrorResponse(errorCode, errorMessage, errorDetail);
     }
 
-    public void addFieldError(String errorCode, String errorMessage, String errorDetail, String field) {
-        FieldErrorResponse fieldError = new FieldErrorResponse(errorCode, errorMessage, errorDetail, field);
-        fieldErrors.add(fieldError);
-    }
-
-
-    public ValidationErrorResponse(String errorCode, String errorMessage, String errorDetail) {
+    private ValidationErrorResponse(String errorCode, String errorMessage, String errorDetail) {
         this.errorCode = errorCode;
         this.errorMessage = errorMessage;
         this.errorDetail = errorDetail;
     }
 
+    public void addFieldError(String errorCode, String errorMessage, String errorDetail, String field) {
+        FieldErrorResponse fieldError = new FieldErrorResponse(errorCode, errorMessage, errorDetail, field);
+        fieldErrors.add(fieldError);
+    }
+
+    public void addGlobalError(String errorCode, String errorMessage, String errorDetail, String objectName) {
+        GlobalErrorResponse globalError = new GlobalErrorResponse(errorCode, errorMessage, errorDetail, objectName);
+        globalErrors.add(globalError);
+    }
 
     @Getter
     private static class FieldErrorResponse {
@@ -50,5 +53,16 @@ public class ValidationErrorResponse {
     @Getter
     private static class GlobalErrorResponse {
 
+        private final String errorCode;
+        private final String errorMessage;
+        private final String errorDetail;
+        private final String object;
+
+        public GlobalErrorResponse(String errorCode, String errorMessage, String errorDetail, String object) {
+            this.errorCode = errorCode;
+            this.errorMessage = errorMessage;
+            this.errorDetail = errorDetail;
+            this.object = object;
+        }
     }
 }

--- a/src/main/java/com/cosain/trilo/common/exception/CustomValidationException.java
+++ b/src/main/java/com/cosain/trilo/common/exception/CustomValidationException.java
@@ -1,0 +1,15 @@
+package com.cosain.trilo.common.exception;
+
+import lombok.Getter;
+import org.springframework.validation.BindingResult;
+
+@Getter
+public class CustomValidationException extends RuntimeException {
+
+    private final BindingResult bindingResult;
+
+    public CustomValidationException(BindingResult bindingResult) {
+        this.bindingResult = bindingResult;
+    }
+
+}

--- a/src/main/java/com/cosain/trilo/config/exception/ExceptionAdvice.java
+++ b/src/main/java/com/cosain/trilo/config/exception/ExceptionAdvice.java
@@ -5,6 +5,7 @@ import com.cosain.trilo.common.dto.ValidationErrorResponse;
 import com.cosain.trilo.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.TypeMismatchException;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.http.HttpHeaders;
@@ -80,6 +81,22 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         return BasicErrorResponse.of(errorCode, errorMessage, errorDetail);
     }
 
+    /**
+     * URL의 파라미터 변수 또는 쿼리 파라미터의 타입 에러
+     */
+    @Override
+    protected ResponseEntity<Object> handleTypeMismatch(TypeMismatchException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        log.info("URL의 파라미터 변수 또는 쿼리 파라미터의 타입 에러");
+
+        String errorCode = "request-0004";
+        String errorMessage = getMessage(errorCode + ".message");
+        String errorDetail = getMessage(errorCode + ".detail");
+
+        log.info("[{}] errorMessage={}", errorCode, errorMessage);
+        log.info("-----> errorDetail={}", errorDetail);
+        var response = BasicErrorResponse.of(errorCode, errorMessage, errorDetail);
+        return ResponseEntity.badRequest().body(response);
+    }
 
     /**
      * 필드 검증 에러 API

--- a/src/main/java/com/cosain/trilo/config/exception/ExceptionAdvice.java
+++ b/src/main/java/com/cosain/trilo/config/exception/ExceptionAdvice.java
@@ -6,14 +6,18 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @Slf4j
@@ -36,6 +40,21 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         String errorMessage = getMessage(errorCode + ".message");
         String errorDetail = getMessage(errorCode + ".detail");
         return BasicErrorResponse.of(errorCode, errorMessage, errorDetail);
+    }
+
+    /**
+     * 요청 데이터 형식 또는 데이터 타입이 올바르지 않을 때에 대한 예외 API
+     */
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(HttpMessageNotReadableException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        log.info("요청 데이터 형식이 올바르지 않음");
+        String errorCode = "request-0001";
+        String errorMessage = getMessage(errorCode + ".message");
+        String errorDetail = getMessage(errorCode + ".detail");
+
+        return ResponseEntity
+                .badRequest()
+                .body(BasicErrorResponse.of(errorCode, errorMessage, errorDetail));
     }
 
     /**

--- a/src/main/java/com/cosain/trilo/trip/presentation/trip/command/TripCreateController.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/trip/command/TripCreateController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,7 +23,7 @@ public class TripCreateController {
     private final TripCreateUseCase tripCreateUseCase;
 
     @PostMapping("/api/trips")
-    public ResponseEntity<TripCreateResponse> createTrip(@LoginUser User user, @RequestBody TripCreateRequest request) {
+    public ResponseEntity<TripCreateResponse> createTrip(@LoginUser User user, @RequestBody @Validated TripCreateRequest request) {
         Long tripperId = user.getId();
         TripCreateCommand createCommand = request.toCommand();
 

--- a/src/main/java/com/cosain/trilo/trip/presentation/trip/command/dto/request/TripCreateRequest.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/trip/command/dto/request/TripCreateRequest.java
@@ -1,6 +1,8 @@
 package com.cosain.trilo.trip.presentation.trip.command.dto.request;
 
 import com.cosain.trilo.trip.application.trip.command.usecase.dto.TripCreateCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,11 +11,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TripCreateRequest {
 
+    @NotBlank(message = "trip-0002")
+    @Size(min = 1, max = 20, message = "trip-0003")
     private String title;
 
     public TripCreateRequest(String title) {
         this.title = title;
     }
+
     public TripCreateCommand toCommand() {
         return new TripCreateCommand(title);
     }

--- a/src/main/resources/exceptions/exception.yml
+++ b/src/main/resources/exceptions/exception.yml
@@ -21,6 +21,11 @@ request-0003:
   message: Not Valid Request Parameter
   detail : 유효하지 않은 파라미터가 전달됐습니다. 요청 파라미터의 유효성을 다시 확인해주세요.
 
+request-0004:
+  message: Invalid Parameter Type in URL or Query Parameter
+  detail : URL의 파라미터 변수 또는 쿼리 파라미터의 타입이 올바르지 않습니다.
+
+
 # 인증/인가 관련
 auth-0001:
   message: AuthenticationFailed

--- a/src/main/resources/exceptions/exception.yml
+++ b/src/main/resources/exceptions/exception.yml
@@ -17,6 +17,9 @@ request-0002:
   message: Missing Request Cookie
   detail: 요청에 필요한 쿠키가 누락 됐습니다. 요청에 필요한 쿠키가 존재하는 지, 제대로 된 값인지 다시 확인해주세요.
 
+request-0003:
+  message: Not Valid Request Parameter
+  detail : 유효하지 않은 파라미터가 전달됐습니다. 요청 파라미터의 유효성을 다시 확인해주세요.
 
 # 인증/인가 관련
 auth-0001:
@@ -69,7 +72,7 @@ trip-0002:
 
 trip-0003:
   message: Invalid Trip Title Length
-  detail: 여행 제목의 길이는 {min}자 이상 {max}자 이하여야 합니다.
+  detail: 여행 제목의 길이는 1자 이상 20자 이하여야 합니다.
 
 
 trip-0004:

--- a/src/main/resources/exceptions/exception_en.yml
+++ b/src/main/resources/exceptions/exception_en.yml
@@ -69,7 +69,7 @@ trip-0002:
 
 trip-0003:
   message: Invalid Trip Title Length
-  detail: The trip title length must be between {min} and {max} characters.
+  detail: The trip title length must be between 1 and 20 characters.
 
 
 trip-0004:

--- a/src/main/resources/exceptions/exception_en.yml
+++ b/src/main/resources/exceptions/exception_en.yml
@@ -17,6 +17,14 @@ request-0002:
   message: Missing Request Cookie
   detail: The required cookie in the request is missing. Please check if the necessary cookie exists and if it has the correct value.
 
+request-0003:
+  message: Not Valid Request Parameter
+  detail : Invalid parameter(s) have been passed. Please recheck the validity of the request parameters.
+
+request-0004:
+  message: Invalid Parameter Type in URL or Query Parameter
+  detail : The type of the URL parameter or query parameter is invalid.
+
 
 # 인증/인가 관련
 auth-0001:

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/ScheduleDeleteControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/ScheduleDeleteControllerTest.java
@@ -23,7 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@DisplayName("[TripCommand] 일정 삭제 API 테스트")
+@DisplayName("일정 삭제 API 테스트")
 @WebMvcTest(ScheduleDeleteController.class)
 class ScheduleDeleteControllerTest extends RestControllerTest {
 

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/ScheduleMoveControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/ScheduleMoveControllerTest.java
@@ -27,7 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@DisplayName("[TripCommand] 일정 이동 API 테스트")
+@DisplayName("일정 이동 API 테스트")
 @WebMvcTest(ScheduleMoveController.class)
 public class ScheduleMoveControllerTest extends RestControllerTest {
 
@@ -90,6 +90,75 @@ public class ScheduleMoveControllerTest extends RestControllerTest {
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorCode").exists())
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
+
+    @Test
+    @DisplayName("비어있는 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void moveSchedule_with_emptyContent() throws Exception {
+        mockingForLoginUserAnnotation();
+
+        String emptyContent = "";
+
+        mockMvc.perform(patch("/api/schedules/1")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(emptyContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
+    @Test
+    @DisplayName("형식이 올바르지 않은 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void moveSchedule_with_invalidContent() throws Exception {
+        mockingForLoginUserAnnotation();
+        String invalidContent = """
+                {
+                    "targetDayId": 따옴표로 감싸지 않은 값,
+                    "targetOrder": 123
+                }
+                """;
+
+        mockMvc.perform(patch("/api/schedules/1")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(invalidContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
+    @Test
+    @DisplayName("타입이 올바르지 않은 요청 데이터 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void moveSchedule_with_invalidType() throws Exception {
+        mockingForLoginUserAnnotation();
+        String invalidTypeContent = """
+                {
+                    "targetDayId": 1,
+                    "targetOrder": "숫자가 아닌 값"
+                }
+                """;
+
+        mockMvc.perform(patch("/api/schedules/1")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(invalidTypeContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
                 .andExpect(jsonPath("$.errorMessage").exists())
                 .andExpect(jsonPath("$.errorDetail").exists());
     }

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/ScheduleUpdateControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/ScheduleUpdateControllerTest.java
@@ -68,4 +68,48 @@ class ScheduleUpdateControllerTest extends RestControllerTest {
                 .andExpect(jsonPath("$.errorDetail").exists());
     }
 
+
+    @Test
+    @DisplayName("비어있는 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void updateSchedule_with_emptyContent() throws Exception {
+        mockingForLoginUserAnnotation();
+
+        String emptyContent = "";
+
+        mockMvc.perform(put("/api/schedules/1")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(emptyContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
+    @Test
+    @DisplayName("형식이 올바르지 않은 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void updateSchedule_with_invalidContent() throws Exception {
+        mockingForLoginUserAnnotation();
+        String invalidContent = """
+                {
+                    "title": 따옴표로 감싸지 않은 제목,
+                    "content": "본문"
+                }
+                """;
+
+        mockMvc.perform(put("/api/schedules/1")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(invalidContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/TripCreateControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/TripCreateControllerTest.java
@@ -61,5 +61,49 @@ class TripCreateControllerTest extends RestControllerTest {
                 .andExpect(jsonPath("$.errorMessage").exists())
                 .andExpect(jsonPath("$.errorDetail").exists());
     }
-}
 
+
+    @Test
+    @DisplayName("비어있는 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void createTrip_with_emptyContent() throws Exception {
+        mockingForLoginUserAnnotation();
+
+        String emptyContent = "";
+
+        mockMvc.perform(post("/api/trips")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(emptyContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
+    @Test
+    @DisplayName("형식이 올바르지 않은 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void createTrip_with_invalidContent() throws Exception {
+        mockingForLoginUserAnnotation();
+        String invalidContent = """
+                {
+                    "title": 따옴표 안 감싼 제목
+                }
+                """;
+
+        mockMvc.perform(post("/api/trips")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(invalidContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
+}

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/TripCreateControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/TripCreateControllerTest.java
@@ -33,7 +33,7 @@ class TripCreateControllerTest extends RestControllerTest {
 
     @Test
     @DisplayName("인증된 사용자의 여행 생성 요청 -> 성공")
-    public void successTest() throws Exception{
+    public void successTest() throws Exception {
         mockingForLoginUserAnnotation();
         TripCreateRequest request = new TripCreateRequest("제목");
         given(tripCreateUseCase.createTrip(any(), any())).willReturn(1L);
@@ -106,4 +106,117 @@ class TripCreateControllerTest extends RestControllerTest {
                 .andExpect(jsonPath("$.errorDetail").exists());
     }
 
+    @Test
+    @DisplayName("제목이 null -> 필드 검증 실패 -> 400 예외")
+    public void createTrip_with_nullTitle() throws Exception {
+        mockingForLoginUserAnnotation();
+        TripCreateRequest request = new TripCreateRequest(null);
+
+        mockMvc.perform(post("/api/trips")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(createJson(request))
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0003"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists())
+                .andExpect(jsonPath("$.fieldErrors").exists())
+                .andExpect(jsonPath("$.fieldErrors").isNotEmpty())
+                .andExpect(jsonPath("$.fieldErrors[*].errorCode").exists())
+                .andExpect(jsonPath("$.fieldErrors[*].errorMessage").exists())
+                .andExpect(jsonPath("$.fieldErrors[*].errorDetail").exists())
+                .andExpect(jsonPath("$.fieldErrors[*].field").exists())
+                .andExpect(jsonPath("$.fieldErrors[?(@.field=='title' && @.errorCode=='trip-0002')]").exists())
+                .andExpect(jsonPath("$.globalErrors").exists())
+                .andExpect(jsonPath("$.globalErrors").isEmpty());
+    }
+
+    @Test
+    @DisplayName("제목이 빈 문자열 -> 필드 검증 실패 -> 400 예외")
+    public void createTrip_with_emptyTitle() throws Exception {
+        mockingForLoginUserAnnotation();
+        TripCreateRequest request = new TripCreateRequest("");
+
+        mockMvc.perform(post("/api/trips")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(createJson(request))
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0003"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists())
+                .andExpect(jsonPath("$.fieldErrors").exists())
+                .andExpect(jsonPath("$.fieldErrors").exists())
+                .andExpect(jsonPath("$.fieldErrors").isNotEmpty())
+                .andExpect(jsonPath("$.fieldErrors[*].errorCode").exists())
+                .andExpect(jsonPath("$.fieldErrors[*].errorMessage").exists())
+                .andExpect(jsonPath("$.fieldErrors[*].errorDetail").exists())
+                .andExpect(jsonPath("$.fieldErrors[*].field").exists())
+                .andExpect(jsonPath("$.fieldErrors[?(@.field=='title' && @.errorCode=='trip-0002')]").exists())
+                .andExpect(jsonPath("$.fieldErrors[?(@.field=='title' && @.errorCode=='trip-0003')]").exists())
+                .andExpect(jsonPath("$.globalErrors").exists())
+                .andExpect(jsonPath("$.globalErrors").isEmpty());
+    }
+
+    @Test
+    @DisplayName("제목이 공백만으로 구성된 문자열 -> 필드 검증 실패 -> 400 예외")
+    public void createTrip_with_whiteSpaceTitle() throws Exception {
+        mockingForLoginUserAnnotation();
+        TripCreateRequest request = new TripCreateRequest("     ");
+
+        mockMvc.perform(post("/api/trips")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(createJson(request))
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0003"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists())
+                .andExpect(jsonPath("$.fieldErrors").exists())
+                .andExpect(jsonPath("$.fieldErrors").isNotEmpty())
+                .andExpect(jsonPath("$.fieldErrors[*].errorCode").exists())
+                .andExpect(jsonPath("$.fieldErrors[*].errorMessage").exists())
+                .andExpect(jsonPath("$.fieldErrors[*].errorDetail").exists())
+                .andExpect(jsonPath("$.fieldErrors[*].field").exists())
+                .andExpect(jsonPath("$.fieldErrors[?(@.field=='title' && @.errorCode=='trip-0002')]").exists())
+                .andExpect(jsonPath("$.globalErrors").exists())
+                .andExpect(jsonPath("$.globalErrors").isEmpty());
+    }
+
+    @Test
+    @DisplayName("제목이 20자를 넘어갈 떄 -> 필드 검증 실패 -> 400 예외")
+    public void createTrip_with_tooLongTitle() throws Exception {
+        mockingForLoginUserAnnotation();
+        TripCreateRequest request = new TripCreateRequest("가".repeat(21));
+
+        mockMvc.perform(post("/api/trips")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(createJson(request))
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0003"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists())
+                .andExpect(jsonPath("$.fieldErrors").exists())
+                .andExpect(jsonPath("$.fieldErrors").isNotEmpty())
+                .andExpect(jsonPath("$.fieldErrors[*].errorCode").exists())
+                .andExpect(jsonPath("$.fieldErrors[*].errorMessage").exists())
+                .andExpect(jsonPath("$.fieldErrors[*].errorDetail").exists())
+                .andExpect(jsonPath("$.fieldErrors[*].field").exists())
+                .andExpect(jsonPath("$.fieldErrors[?(@.field=='title' && @.errorCode=='trip-0003')]").exists())
+                .andExpect(jsonPath("$.globalErrors").exists())
+                .andExpect(jsonPath("$.globalErrors").isEmpty());
+    }
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/TripDeleteControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/TripDeleteControllerTest.java
@@ -20,7 +20,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@DisplayName("[TripCommand] 여행 삭제 API 테스트")
+@DisplayName("여행 삭제 API 테스트")
 @WebMvcTest(TripDeleteController.class)
 class TripDeleteControllerTest extends RestControllerTest {
 

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/TripDeleteControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/TripDeleteControllerTest.java
@@ -61,4 +61,20 @@ class TripDeleteControllerTest extends RestControllerTest {
                 .andExpect(jsonPath("$.errorDetail").exists());
     }
 
+    @Test
+    @DisplayName("tripId으로 숫자가 아닌 문자열 주입 -> 올바르지 않은 경로 변수 타입 400 에러")
+    public void deleteTrip_with_stringTripId() throws Exception {
+        mockingForLoginUserAnnotation();
+
+        mockMvc.perform(delete("/api/trips/가가가")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0004"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/TripUpdateControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/TripUpdateControllerTest.java
@@ -64,4 +64,74 @@ class TripUpdateControllerTest extends RestControllerTest {
                 .andExpect(jsonPath("$.errorDetail").exists());
     }
 
+
+    @Test
+    @DisplayName("비어있는 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void updateTrip_with_emptyContent() throws Exception {
+        mockingForLoginUserAnnotation();
+
+        String emptyContent = "";
+
+        mockMvc.perform(put("/api/trips/1")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(emptyContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
+    @Test
+    @DisplayName("형식이 올바르지 않은 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void updateTrip_with_invalidContent() throws Exception {
+        mockingForLoginUserAnnotation();
+        String invalidContent = """
+                {
+                    "title": 괄호로 감싸지 않은 제목,
+                    "startDate": "2023-03-01",
+                    "endDate": "2023-03-02"
+                }
+                """;
+
+        mockMvc.perform(put("/api/trips/1")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(invalidContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
+    @Test
+    @DisplayName("타입이 올바르지 않은 요청 데이터 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void updateTrip_with_invalidType() throws Exception {
+        mockingForLoginUserAnnotation();
+        String invalidTypeContent = """
+                {
+                    "title": "제목",
+                    "startDate": "2023-03-01",
+                    "endDate": "날짜형식이 아닌 문자열"
+                }
+                """;
+
+        mockMvc.perform(put("/api/trips/1")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(invalidTypeContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
 }


### PR DESCRIPTION
# JIRA 티켓
- [TRL-272]

---

# 작업 내역
- [x] 요청 데이터 형식/데이터 타입이 올바르지 않을 때에 대한 예외 API 정의
- [x] PathVariable로 전달된 값이 올바르지 않은 타입일 경우에 대한 예외 API 정의
- [x] `@RequestBody` 로 매핑된 필드에 대한 예외 API 정의
- [x] `@ModelAttribute`로 매핑된 필드에 대한 예외 API 정의
- [ ] 표현 계층에서 복수의 필드에서 예외가 발생할 경우 이들을 한번에 응답에 보낼 수 있도록 하기
- [ ] 표현 계층에서 복수의 필드를 함께 사용해서 검증해야하는 글로벌 예외 등에 대해 처리하기

---

# 용어 및 개념 설명
- 필드에러 : 단일 필드에 대한 예외
- 글로벌 에러 : 단일 필드 뿐 아니라, 2개 이상의 필드를 함께 확인해서 입력을 검증해야하는 경우
- 필드 검증, 글로벌 검증을 통과하면 비즈니스 레이어로 전달됩니다.비즈니스 레이어에서 예외가 발생하는 경우(데이터베이스를 통해 조회한 결과 정합성에 맞지 않은 상황 등) 별도의 예외 API가 전달될 수 있습니다.

---


[TRL-272]: https://cosain.atlassian.net/browse/TRL-272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ