### PR TITLE
[TRL-272] feat: 입력 검증 로직 추가

### DIFF
--- a/src/main/java/com/cosain/trilo/common/dto/ValidationErrorResponse.java
+++ b/src/main/java/com/cosain/trilo/common/dto/ValidationErrorResponse.java
@@ -1,0 +1,54 @@
+package com.cosain.trilo.common.dto;
+
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class ValidationErrorResponse {
+
+    private final String errorCode;
+    private final String errorMessage;
+    private final String errorDetail;
+    private final List<FieldErrorResponse> fieldErrors = new ArrayList<>();
+    private final List<GlobalErrorResponse> globalErrors = new ArrayList<>();
+
+    public static ValidationErrorResponse of(String errorCode, String errorMessage, String errorDetail) {
+        return new ValidationErrorResponse(errorCode, errorMessage, errorDetail);
+    }
+
+    public void addFieldError(String errorCode, String errorMessage, String errorDetail, String field) {
+        FieldErrorResponse fieldError = new FieldErrorResponse(errorCode, errorMessage, errorDetail, field);
+        fieldErrors.add(fieldError);
+    }
+
+
+    public ValidationErrorResponse(String errorCode, String errorMessage, String errorDetail) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+        this.errorDetail = errorDetail;
+    }
+
+
+    @Getter
+    private static class FieldErrorResponse {
+
+        private final String errorCode;
+        private final String errorMessage;
+        private final String errorDetail;
+        private final String field;
+
+        public FieldErrorResponse(String errorCode, String errorMessage, String errorDetail, String field) {
+            this.errorCode = errorCode;
+            this.errorMessage = errorMessage;
+            this.errorDetail = errorDetail;
+            this.field = field;
+        }
+    }
+
+    @Getter
+    private static class GlobalErrorResponse {
+
+    }
+}

--- a/src/main/java/com/cosain/trilo/common/dto/ValidationErrorResponse.java
+++ b/src/main/java/com/cosain/trilo/common/dto/ValidationErrorResponse.java
@@ -11,44 +11,35 @@ public class ValidationErrorResponse {
     private final String errorCode;
     private final String errorMessage;
     private final String errorDetail;
-    private final List<FieldErrorResponse> fieldErrors = new ArrayList<>();
-    private final List<GlobalErrorResponse> globalErrors = new ArrayList<>();
+    private final List<PartErrorResponse> errors = new ArrayList<>();
 
     public static ValidationErrorResponse of(String errorCode, String errorMessage, String errorDetail) {
         return new ValidationErrorResponse(errorCode, errorMessage, errorDetail);
     }
 
-    public void addFieldError(String errorCode, String errorMessage, String errorDetail, String field) {
-        FieldErrorResponse fieldError = new FieldErrorResponse(errorCode, errorMessage, errorDetail, field);
-        fieldErrors.add(fieldError);
-    }
-
-
-    public ValidationErrorResponse(String errorCode, String errorMessage, String errorDetail) {
+    private ValidationErrorResponse(String errorCode, String errorMessage, String errorDetail) {
         this.errorCode = errorCode;
         this.errorMessage = errorMessage;
         this.errorDetail = errorDetail;
     }
 
+    public void addError(String errorCode, String errorMessage, String errorDetail) {
+        PartErrorResponse partError = new PartErrorResponse(errorCode, errorMessage, errorDetail);
+        errors.add(partError);
+    }
 
     @Getter
-    private static class FieldErrorResponse {
+    private static class PartErrorResponse {
 
         private final String errorCode;
         private final String errorMessage;
         private final String errorDetail;
-        private final String field;
 
-        public FieldErrorResponse(String errorCode, String errorMessage, String errorDetail, String field) {
+        public PartErrorResponse(String errorCode, String errorMessage, String errorDetail) {
             this.errorCode = errorCode;
             this.errorMessage = errorMessage;
             this.errorDetail = errorDetail;
-            this.field = field;
         }
     }
 
-    @Getter
-    private static class GlobalErrorResponse {
-
-    }
 }

--- a/src/main/java/com/cosain/trilo/common/exception/CustomValidationException.java
+++ b/src/main/java/com/cosain/trilo/common/exception/CustomValidationException.java
@@ -1,0 +1,18 @@
+package com.cosain.trilo.common.exception;
+
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class CustomValidationException extends RuntimeException {
+
+    public final List<CustomException> exceptions = new ArrayList<>();
+
+    public CustomValidationException(List<CustomException> exceptions) {
+        if (exceptions != null) {
+            this.exceptions.addAll(exceptions);
+        }
+    }
+}

--- a/src/main/java/com/cosain/trilo/config/exception/ExceptionAdvice.java
+++ b/src/main/java/com/cosain/trilo/config/exception/ExceptionAdvice.java
@@ -5,6 +5,7 @@ import com.cosain.trilo.common.dto.ValidationErrorResponse;
 import com.cosain.trilo.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.TypeMismatchException;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.http.HttpHeaders;
@@ -80,6 +81,22 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         return BasicErrorResponse.of(errorCode, errorMessage, errorDetail);
     }
 
+    /**
+     * URL의 파라미터 변수 또는 쿼리 파라미터의 타입 에러
+     */
+    @Override
+    protected ResponseEntity<Object> handleTypeMismatch(TypeMismatchException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        log.info("URL의 파라미터 변수 또는 쿼리 파라미터의 타입 에러");
+
+        String errorCode = "request-0004";
+        String errorMessage = getMessage(errorCode + ".message");
+        String errorDetail = getMessage(errorCode + ".detail");
+
+        log.info("[{}] errorMessage={}", errorCode, errorMessage);
+        log.info("-----> errorDetail={}", errorDetail);
+        var response = BasicErrorResponse.of(errorCode, errorMessage, errorDetail);
+        return ResponseEntity.badRequest().body(response);
+    }
 
     /**
      * 필드 검증 에러 API

--- a/src/main/java/com/cosain/trilo/config/exception/ExceptionAdvice.java
+++ b/src/main/java/com/cosain/trilo/config/exception/ExceptionAdvice.java
@@ -3,6 +3,7 @@ package com.cosain.trilo.config.exception;
 import com.cosain.trilo.common.dto.BasicErrorResponse;
 import com.cosain.trilo.common.dto.ValidationErrorResponse;
 import com.cosain.trilo.common.exception.CustomException;
+import com.cosain.trilo.common.exception.CustomValidationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.TypeMismatchException;
@@ -15,9 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -98,32 +97,25 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         return ResponseEntity.badRequest().body(response);
     }
 
-    /**
-     * 필드 검증 에러 API
-     */
-    @Override
-    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
-        BindingResult bindingResult = ex.getBindingResult();
-        log.info("필드 검증 실패!");
-
+    @ExceptionHandler(CustomValidationException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ValidationErrorResponse handleCustomValidationException(CustomValidationException ex) {
         String errorCode = "request-0003";
         String errorMessage = getMessage(errorCode + ".message");
         String errorDetail = getMessage(errorCode + ".detail");
 
         var response = ValidationErrorResponse.of(errorCode, errorMessage, errorDetail);
-        List<FieldError> fieldErrors = bindingResult.getFieldErrors();
-        addFieldErrors(response, fieldErrors);
-
-        return ResponseEntity.badRequest().body(response);
+        List<CustomException> exceptions = ex.getExceptions();
+        addExceptionsToValidationErrorResponse(response, exceptions);
+        return response;
     }
 
-    private void addFieldErrors(ValidationErrorResponse response, List<FieldError> fieldErrors) {
-        for (FieldError fieldError : fieldErrors) {
-            String fieldErrorCode = fieldError.getDefaultMessage();
-            String fieldErrorMessage = getMessage(fieldErrorCode + ".message");
-            String fieldErrorDetail = getMessage(fieldErrorCode + ".detail");
-            String field = fieldError.getField();
-            response.addFieldError(fieldErrorCode, fieldErrorMessage, fieldErrorDetail, field);
+    private void addExceptionsToValidationErrorResponse(ValidationErrorResponse response, List<CustomException> exceptions) {
+        for (CustomException ex : exceptions) {
+            String errorCode = ex.getErrorCode();
+            String errorMessage = getMessage(errorCode + ".message");
+            String errorDetail = getMessage(errorCode + ".detail");
+            response.addError(errorCode, errorMessage, errorDetail);
         }
     }
 

--- a/src/main/java/com/cosain/trilo/config/exception/ExceptionAdvice.java
+++ b/src/main/java/com/cosain/trilo/config/exception/ExceptionAdvice.java
@@ -6,14 +6,18 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @Slf4j
@@ -36,6 +40,21 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         String errorMessage = getMessage(errorCode + ".message");
         String errorDetail = getMessage(errorCode + ".detail");
         return BasicErrorResponse.of(errorCode, errorMessage, errorDetail);
+    }
+
+    /**
+     * 요청 데이터 형식 또는 데이터 타입이 올바르지 않을 때에 대한 예외 API
+     */
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(HttpMessageNotReadableException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        log.info("요청 데이터 형식이 올바르지 않음");
+        String errorCode = "request-0001";
+        String errorMessage = getMessage(errorCode + ".message");
+        String errorDetail = getMessage(errorCode + ".detail");
+
+        return ResponseEntity
+                .badRequest()
+                .body(BasicErrorResponse.of(errorCode, errorMessage, errorDetail));
     }
 
     /**

--- a/src/main/java/com/cosain/trilo/trip/application/exception/NullTripIdException.java
+++ b/src/main/java/com/cosain/trilo/trip/application/exception/NullTripIdException.java
@@ -1,0 +1,35 @@
+package com.cosain.trilo.trip.application.exception;
+
+import com.cosain.trilo.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class NullTripIdException extends CustomException {
+
+    private static final String ERROR_CODE = "schedule-0007"; // 일정 생성시 TripId를 안 넘겼을 때
+    private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+    public NullTripIdException() {
+    }
+
+    public NullTripIdException(String debugMessage) {
+        super(debugMessage);
+    }
+
+    public NullTripIdException(Throwable cause) {
+        super(cause);
+    }
+
+    public NullTripIdException(String debugMessage, Throwable cause) {
+        super(debugMessage, cause);
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HTTP_STATUS;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/application/schedule/command/service/ScheduleCreateService.java
+++ b/src/main/java/com/cosain/trilo/trip/application/schedule/command/service/ScheduleCreateService.java
@@ -36,12 +36,12 @@ public class ScheduleCreateService implements ScheduleCreateUseCase {
 
         Schedule schedule;
         try {
-            schedule = trip.createSchedule(day, createCommand.getTitle(), createCommand.getPlace());
+            schedule = trip.createSchedule(day, createCommand.getScheduleTitle(), createCommand.getPlace());
         } catch (ScheduleIndexRangeException e) {
             scheduleRepository.relocateDaySchedules(tripId, dayId);
             trip = findTrip(trip.getId());
             day = findDay(dayId);
-            schedule =  trip.createSchedule(day, createCommand.getTitle(), createCommand.getPlace());
+            schedule =  trip.createSchedule(day, createCommand.getScheduleTitle(), createCommand.getPlace());
         }
         scheduleRepository.save(schedule);
         return schedule.getId();

--- a/src/main/java/com/cosain/trilo/trip/application/schedule/command/service/ScheduleUpdateService.java
+++ b/src/main/java/com/cosain/trilo/trip/application/schedule/command/service/ScheduleUpdateService.java
@@ -22,7 +22,7 @@ public class ScheduleUpdateService implements ScheduleUpdateUseCase {
         Schedule schedule = findSchedule(scheduleId);
         validateScheduleUpdateAuthority(schedule, tripperId);
 
-        schedule.changeTitle(scheduleUpdateCommand.getTitle());
+        schedule.changeTitle(scheduleUpdateCommand.getScheduleTitle());
         schedule.changeContent(scheduleUpdateCommand.getContent());
 
         return schedule.getId();

--- a/src/main/java/com/cosain/trilo/trip/application/schedule/command/service/ScheduleUpdateService.java
+++ b/src/main/java/com/cosain/trilo/trip/application/schedule/command/service/ScheduleUpdateService.java
@@ -23,7 +23,7 @@ public class ScheduleUpdateService implements ScheduleUpdateUseCase {
         validateScheduleUpdateAuthority(schedule, tripperId);
 
         schedule.changeTitle(scheduleUpdateCommand.getScheduleTitle());
-        schedule.changeContent(scheduleUpdateCommand.getContent());
+        schedule.changeContent(scheduleUpdateCommand.getScheduleContent());
 
         return schedule.getId();
     }

--- a/src/main/java/com/cosain/trilo/trip/application/schedule/command/usecase/dto/ScheduleCreateCommand.java
+++ b/src/main/java/com/cosain/trilo/trip/application/schedule/command/usecase/dto/ScheduleCreateCommand.java
@@ -2,6 +2,7 @@ package com.cosain.trilo.trip.application.schedule.command.usecase.dto;
 
 import com.cosain.trilo.trip.domain.vo.Coordinate;
 import com.cosain.trilo.trip.domain.vo.Place;
+import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,25 +12,32 @@ public class ScheduleCreateCommand {
 
     private Long dayId;
     private Long tripId;
-
-    private String title;
+    private ScheduleTitle scheduleTitle;
     private Place place;
 
     public static ScheduleCreateCommand of(Long dayId, Long tripId, String title,
                                            String placeId, String placeName, double latitude, double longitude) {
+
         return ScheduleCreateCommand.builder()
                 .dayId(dayId)
                 .tripId(tripId)
-                .title(title)
+                .scheduleTitle(ScheduleTitle.of(title))
                 .place(Place.of(placeId, placeName, Coordinate.of(latitude, longitude)))
                 .build();
     }
 
-    @Builder(access = AccessLevel.PRIVATE)
-    private ScheduleCreateCommand(Long dayId, Long tripId, String title, Place place) {
+    @Builder(access = AccessLevel.PUBLIC)
+    private ScheduleCreateCommand(Long dayId, Long tripId, ScheduleTitle scheduleTitle, Place place) {
         this.dayId = dayId;
         this.tripId = tripId;
-        this.title = title;
+        this.scheduleTitle = scheduleTitle;
         this.place = place;
+    }
+
+    /**
+     * 임시로 남겨둠. 이후 지울 예정
+     */
+    public String getTitle() {
+        return scheduleTitle.getValue();
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/application/schedule/command/usecase/dto/ScheduleMoveCommand.java
+++ b/src/main/java/com/cosain/trilo/trip/application/schedule/command/usecase/dto/ScheduleMoveCommand.java
@@ -8,11 +8,7 @@ public class ScheduleMoveCommand {
     private Long targetDayId;
     private int targetOrder;
 
-    public static ScheduleMoveCommand of(Long targetDayId, int targetOrder) {
-        return new ScheduleMoveCommand(targetDayId, targetOrder);
-    }
-
-    private ScheduleMoveCommand(Long targetDayId, int targetOrder) {
+    public ScheduleMoveCommand(Long targetDayId, int targetOrder) {
         this.targetDayId = targetDayId;
         this.targetOrder = targetOrder;
     }

--- a/src/main/java/com/cosain/trilo/trip/application/schedule/command/usecase/dto/ScheduleUpdateCommand.java
+++ b/src/main/java/com/cosain/trilo/trip/application/schedule/command/usecase/dto/ScheduleUpdateCommand.java
@@ -1,18 +1,19 @@
 package com.cosain.trilo.trip.application.schedule.command.usecase.dto;
 
+import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
 import lombok.Getter;
 
 @Getter
 public class ScheduleUpdateCommand {
-    private String title;
+    private ScheduleTitle scheduleTitle;
     private String content;
 
     public static ScheduleUpdateCommand of(String title, String content){
-        return new ScheduleUpdateCommand(title, content);
+        return new ScheduleUpdateCommand(ScheduleTitle.of(title), content);
     }
 
-    private ScheduleUpdateCommand(String title, String content){
-        this.title = title;
+    private ScheduleUpdateCommand(ScheduleTitle scheduleTitle, String content){
+        this.scheduleTitle = scheduleTitle;
         this.content = content;
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/application/schedule/command/usecase/dto/ScheduleUpdateCommand.java
+++ b/src/main/java/com/cosain/trilo/trip/application/schedule/command/usecase/dto/ScheduleUpdateCommand.java
@@ -9,11 +9,7 @@ public class ScheduleUpdateCommand {
     private ScheduleTitle scheduleTitle;
     private ScheduleContent scheduleContent;
 
-    public static ScheduleUpdateCommand of(String title, String content){
-        return new ScheduleUpdateCommand(ScheduleTitle.of(title), ScheduleContent.of(content));
-    }
-
-    private ScheduleUpdateCommand(ScheduleTitle scheduleTitle, ScheduleContent scheduleContent){
+    public ScheduleUpdateCommand(ScheduleTitle scheduleTitle, ScheduleContent scheduleContent){
         this.scheduleTitle = scheduleTitle;
         this.scheduleContent = scheduleContent;
     }

--- a/src/main/java/com/cosain/trilo/trip/application/schedule/command/usecase/dto/ScheduleUpdateCommand.java
+++ b/src/main/java/com/cosain/trilo/trip/application/schedule/command/usecase/dto/ScheduleUpdateCommand.java
@@ -1,19 +1,20 @@
 package com.cosain.trilo.trip.application.schedule.command.usecase.dto;
 
+import com.cosain.trilo.trip.domain.vo.ScheduleContent;
 import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
 import lombok.Getter;
 
 @Getter
 public class ScheduleUpdateCommand {
     private ScheduleTitle scheduleTitle;
-    private String content;
+    private ScheduleContent scheduleContent;
 
     public static ScheduleUpdateCommand of(String title, String content){
-        return new ScheduleUpdateCommand(ScheduleTitle.of(title), content);
+        return new ScheduleUpdateCommand(ScheduleTitle.of(title), ScheduleContent.of(content));
     }
 
-    private ScheduleUpdateCommand(ScheduleTitle scheduleTitle, String content){
+    private ScheduleUpdateCommand(ScheduleTitle scheduleTitle, ScheduleContent scheduleContent){
         this.scheduleTitle = scheduleTitle;
-        this.content = content;
+        this.scheduleContent = scheduleContent;
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/application/schedule/command/usecase/dto/factory/ScheduleCreateCommandFactory.java
+++ b/src/main/java/com/cosain/trilo/trip/application/schedule/command/usecase/dto/factory/ScheduleCreateCommandFactory.java
@@ -1,0 +1,87 @@
+package com.cosain.trilo.trip.application.schedule.command.usecase.dto.factory;
+
+import com.cosain.trilo.common.exception.CustomException;
+import com.cosain.trilo.common.exception.CustomValidationException;
+import com.cosain.trilo.trip.application.exception.NullTripIdException;
+import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleCreateCommand;
+import com.cosain.trilo.trip.domain.vo.Coordinate;
+import com.cosain.trilo.trip.domain.vo.Place;
+import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class ScheduleCreateCommandFactory {
+
+    public static ScheduleCreateCommand createCommand(
+            Long dayId, Long tripId, String title,
+            String placeId, String placeName,
+            Double latitude, Double longitude) {
+
+        List<CustomException> exceptions = new ArrayList<>();
+
+        validateTripIdNotNull(tripId, exceptions);
+
+        ScheduleTitle scheduleTitle = makeScheduleTitle(title, exceptions);
+        Coordinate coordinate = makeCoordinate(latitude, longitude, exceptions);
+        Place place = makePlace(placeId, placeName, coordinate, exceptions);
+
+        if (!exceptions.isEmpty()) {
+            throw new CustomValidationException(exceptions);
+        }
+
+        return ScheduleCreateCommand.builder()
+                .dayId(dayId)
+                .tripId(tripId)
+                .scheduleTitle(scheduleTitle)
+                .place(place)
+                .build();
+    }
+
+    /**
+     * TridId가 Null이 아닌지 검증합니다. null이면, 예외 목록에 추가합니다.
+     */
+    private static void validateTripIdNotNull(Long tripId, List<CustomException> exceptions) {
+        if (tripId == null) {
+            exceptions.add(new NullTripIdException("Trip의 식별자가 전달되지 않음"));
+        }
+    }
+
+    /**
+     * 일정 제목을 생성합니다. 일정 제목 정합성이 맞지 않을 경우 예외 목록에 추가합니다.
+     */
+    private static ScheduleTitle makeScheduleTitle(String title, List<CustomException> exceptions) {
+        try {
+            return ScheduleTitle.of(title);
+        } catch (CustomException e) {
+            exceptions.add(e);
+            return null;
+        }
+    }
+
+    /**
+     * 좌표를 생성합니다. 좌표 정합성이 맞지 않을 경우, 예외 목록에 추가합니다.
+     */
+    private static Coordinate makeCoordinate(Double latitude, Double longitude, List<CustomException> exceptions) {
+        try {
+            return Coordinate.of(latitude, longitude);
+        } catch (CustomException e) {
+            exceptions.add(e);
+            return Coordinate.of(0.0, 0.0); // ...
+        }
+    }
+
+    /**
+     * 장소를 생성합니다. 정합성에 맞지 않으면 예외 목록에 추가합니다.
+     */
+    private static Place makePlace(String placeId, String placeName, Coordinate coordinate, List<CustomException> exceptions) {
+        try {
+            return Place.of(placeId, placeName, coordinate);
+        } catch (CustomException e) {
+            exceptions.add(e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/application/schedule/command/usecase/dto/factory/ScheduleCreateCommandFactory.java
+++ b/src/main/java/com/cosain/trilo/trip/application/schedule/command/usecase/dto/factory/ScheduleCreateCommandFactory.java
@@ -15,7 +15,7 @@ import java.util.List;
 @Component
 public class ScheduleCreateCommandFactory {
 
-    public static ScheduleCreateCommand createCommand(
+    public ScheduleCreateCommand createCommand(
             Long dayId, Long tripId, String title,
             String placeId, String placeName,
             Double latitude, Double longitude) {
@@ -43,7 +43,7 @@ public class ScheduleCreateCommandFactory {
     /**
      * TridId가 Null이 아닌지 검증합니다. null이면, 예외 목록에 추가합니다.
      */
-    private static void validateTripIdNotNull(Long tripId, List<CustomException> exceptions) {
+    private void validateTripIdNotNull(Long tripId, List<CustomException> exceptions) {
         if (tripId == null) {
             exceptions.add(new NullTripIdException("Trip의 식별자가 전달되지 않음"));
         }
@@ -52,7 +52,7 @@ public class ScheduleCreateCommandFactory {
     /**
      * 일정 제목을 생성합니다. 일정 제목 정합성이 맞지 않을 경우 예외 목록에 추가합니다.
      */
-    private static ScheduleTitle makeScheduleTitle(String title, List<CustomException> exceptions) {
+    private ScheduleTitle makeScheduleTitle(String title, List<CustomException> exceptions) {
         try {
             return ScheduleTitle.of(title);
         } catch (CustomException e) {
@@ -64,7 +64,7 @@ public class ScheduleCreateCommandFactory {
     /**
      * 좌표를 생성합니다. 좌표 정합성이 맞지 않을 경우, 예외 목록에 추가합니다.
      */
-    private static Coordinate makeCoordinate(Double latitude, Double longitude, List<CustomException> exceptions) {
+    private Coordinate makeCoordinate(Double latitude, Double longitude, List<CustomException> exceptions) {
         try {
             return Coordinate.of(latitude, longitude);
         } catch (CustomException e) {
@@ -76,7 +76,7 @@ public class ScheduleCreateCommandFactory {
     /**
      * 장소를 생성합니다. 정합성에 맞지 않으면 예외 목록에 추가합니다.
      */
-    private static Place makePlace(String placeId, String placeName, Coordinate coordinate, List<CustomException> exceptions) {
+    private Place makePlace(String placeId, String placeName, Coordinate coordinate, List<CustomException> exceptions) {
         try {
             return Place.of(placeId, placeName, coordinate);
         } catch (CustomException e) {

--- a/src/main/java/com/cosain/trilo/trip/application/schedule/command/usecase/dto/factory/ScheduleMoveCommandFactory.java
+++ b/src/main/java/com/cosain/trilo/trip/application/schedule/command/usecase/dto/factory/ScheduleMoveCommandFactory.java
@@ -1,0 +1,32 @@
+package com.cosain.trilo.trip.application.schedule.command.usecase.dto.factory;
+
+import com.cosain.trilo.common.exception.CustomException;
+import com.cosain.trilo.common.exception.CustomValidationException;
+import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleMoveCommand;
+import com.cosain.trilo.trip.domain.exception.InvalidScheduleMoveTargetOrderException;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class ScheduleMoveCommandFactory {
+
+
+    public ScheduleMoveCommand createCommand(Long targetDayId, Integer targetOrder) {
+        List<CustomException> exceptions = new ArrayList<>();
+        validateTargetOrder(targetOrder, exceptions);
+
+        if (!exceptions.isEmpty()) {
+            throw new CustomValidationException(exceptions);
+        }
+        return new ScheduleMoveCommand(targetDayId, targetOrder);
+    }
+
+    private void validateTargetOrder(Integer targetOrder, List<CustomException> exceptions) {
+        if (targetOrder == null || targetOrder < 0) {
+            exceptions.add(new InvalidScheduleMoveTargetOrderException("순서값이 null 또는 음수"));
+        }
+    }
+
+}

--- a/src/main/java/com/cosain/trilo/trip/application/schedule/command/usecase/dto/factory/ScheduleUpdateCommandFactory.java
+++ b/src/main/java/com/cosain/trilo/trip/application/schedule/command/usecase/dto/factory/ScheduleUpdateCommandFactory.java
@@ -1,0 +1,44 @@
+package com.cosain.trilo.trip.application.schedule.command.usecase.dto.factory;
+
+import com.cosain.trilo.common.exception.CustomException;
+import com.cosain.trilo.common.exception.CustomValidationException;
+import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleUpdateCommand;
+import com.cosain.trilo.trip.domain.vo.ScheduleContent;
+import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class ScheduleUpdateCommandFactory {
+
+    public ScheduleUpdateCommand createCommand(String rawTitle, String rawContent) {
+        List<CustomException> exceptions = new ArrayList<>();
+        ScheduleTitle scheduleTitle = makeScheduleTitle(rawTitle, exceptions);
+        ScheduleContent scheduleContent = makeScheduleContent(rawContent, exceptions);
+
+        if (!exceptions.isEmpty()) {
+            throw new CustomValidationException(exceptions);
+        }
+        return new ScheduleUpdateCommand(scheduleTitle, scheduleContent);
+    }
+
+    private ScheduleTitle makeScheduleTitle(String rawTitle, List<CustomException> exceptions) {
+        try {
+            return ScheduleTitle.of(rawTitle);
+        } catch (CustomException e) {
+            exceptions.add(e);
+            return null;
+        }
+    }
+
+    private ScheduleContent makeScheduleContent(String rawContent, List<CustomException> exceptions) {
+        try {
+            return ScheduleContent.of(rawContent);
+        } catch (CustomException e) {
+            exceptions.add(e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/application/trip/command/service/TripCreateService.java
+++ b/src/main/java/com/cosain/trilo/trip/application/trip/command/service/TripCreateService.java
@@ -17,13 +17,13 @@ public class TripCreateService implements TripCreateUseCase {
     /**
      * Trip을 생성하여 등록하고, 식별자를 반환합니다.
      * @param tripperId : 여행자 식별자
-     * @param createDto : 여행 생성에 필요한 정보들
+     * @param createCommand : 여행 생성에 필요한 정보들
      * @return 생성된 여행의 식별자
      */
     @Override
     @Transactional
-    public Long createTrip(Long tripperId, TripCreateCommand createDto) {
-        Trip trip = Trip.create(createDto.getTitle(), tripperId);
+    public Long createTrip(Long tripperId, TripCreateCommand createCommand) {
+        Trip trip = Trip.create(createCommand.getTripTitle(), tripperId);
         Trip savedTrip = tripRepository.save(trip);
         return savedTrip.getId();
     }

--- a/src/main/java/com/cosain/trilo/trip/application/trip/command/service/TripUpdateService.java
+++ b/src/main/java/com/cosain/trilo/trip/application/trip/command/service/TripUpdateService.java
@@ -30,7 +30,7 @@ public class TripUpdateService implements TripUpdateUseCase {
         Trip trip = findTrip(tripId);
         validateTripUpdateAuthority(trip, tripperId);
 
-        trip.changeTitle(updateCommand.getTitle());
+        trip.changeTitle(updateCommand.getTripTitle());
         changePeriod(trip, updateCommand.getTripPeriod());
     }
 

--- a/src/main/java/com/cosain/trilo/trip/application/trip/command/usecase/dto/TripCreateCommand.java
+++ b/src/main/java/com/cosain/trilo/trip/application/trip/command/usecase/dto/TripCreateCommand.java
@@ -1,12 +1,18 @@
 package com.cosain.trilo.trip.application.trip.command.usecase.dto;
 
+import com.cosain.trilo.trip.domain.vo.TripTitle;
 import lombok.Getter;
 
 @Getter
 public class TripCreateCommand {
 
-    private String title;
-    public TripCreateCommand(String title) {
-        this.title = title;
+    private TripTitle tripTitle;
+
+    public static TripCreateCommand from(String rawTitle) {
+        return new TripCreateCommand(TripTitle.of(rawTitle));
+    }
+
+    private TripCreateCommand(TripTitle tripTitle) {
+        this.tripTitle = tripTitle;
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/application/trip/command/usecase/dto/TripCreateCommand.java
+++ b/src/main/java/com/cosain/trilo/trip/application/trip/command/usecase/dto/TripCreateCommand.java
@@ -8,11 +8,7 @@ public class TripCreateCommand {
 
     private TripTitle tripTitle;
 
-    public static TripCreateCommand from(String rawTitle) {
-        return new TripCreateCommand(TripTitle.of(rawTitle));
-    }
-
-    private TripCreateCommand(TripTitle tripTitle) {
+    public TripCreateCommand(TripTitle tripTitle) {
         this.tripTitle = tripTitle;
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/application/trip/command/usecase/dto/TripUpdateCommand.java
+++ b/src/main/java/com/cosain/trilo/trip/application/trip/command/usecase/dto/TripUpdateCommand.java
@@ -1,6 +1,7 @@
 package com.cosain.trilo.trip.application.trip.command.usecase.dto;
 
 import com.cosain.trilo.trip.domain.vo.TripPeriod;
+import com.cosain.trilo.trip.domain.vo.TripTitle;
 import lombok.Getter;
 
 import java.time.LocalDate;
@@ -8,15 +9,16 @@ import java.time.LocalDate;
 @Getter
 public class TripUpdateCommand {
 
-    private String title;
+    private TripTitle tripTitle;
     private TripPeriod tripPeriod;
 
-    public static TripUpdateCommand of(String title, LocalDate startDate, LocalDate endDate) {
-        return new TripUpdateCommand(title, TripPeriod.of(startDate, endDate));
+    public static TripUpdateCommand of(String rawTitle, LocalDate startDate, LocalDate endDate) {
+        TripTitle tripTitle = TripTitle.of(rawTitle);
+        return new TripUpdateCommand(tripTitle, TripPeriod.of(startDate, endDate));
     }
 
-    private TripUpdateCommand(String title, TripPeriod tripPeriod) {
-        this.title = title;
+    private TripUpdateCommand(TripTitle tripTitle, TripPeriod tripPeriod) {
+        this.tripTitle = tripTitle;
         this.tripPeriod = tripPeriod;
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/application/trip/command/usecase/dto/TripUpdateCommand.java
+++ b/src/main/java/com/cosain/trilo/trip/application/trip/command/usecase/dto/TripUpdateCommand.java
@@ -4,20 +4,13 @@ import com.cosain.trilo.trip.domain.vo.TripPeriod;
 import com.cosain.trilo.trip.domain.vo.TripTitle;
 import lombok.Getter;
 
-import java.time.LocalDate;
-
 @Getter
 public class TripUpdateCommand {
 
     private TripTitle tripTitle;
     private TripPeriod tripPeriod;
 
-    public static TripUpdateCommand of(String rawTitle, LocalDate startDate, LocalDate endDate) {
-        TripTitle tripTitle = TripTitle.of(rawTitle);
-        return new TripUpdateCommand(tripTitle, TripPeriod.of(startDate, endDate));
-    }
-
-    private TripUpdateCommand(TripTitle tripTitle, TripPeriod tripPeriod) {
+    public TripUpdateCommand(TripTitle tripTitle, TripPeriod tripPeriod) {
         this.tripTitle = tripTitle;
         this.tripPeriod = tripPeriod;
     }

--- a/src/main/java/com/cosain/trilo/trip/application/trip/command/usecase/dto/factory/TripCreateCommandFactory.java
+++ b/src/main/java/com/cosain/trilo/trip/application/trip/command/usecase/dto/factory/TripCreateCommandFactory.java
@@ -1,0 +1,33 @@
+package com.cosain.trilo.trip.application.trip.command.usecase.dto.factory;
+
+import com.cosain.trilo.common.exception.CustomException;
+import com.cosain.trilo.common.exception.CustomValidationException;
+import com.cosain.trilo.trip.application.trip.command.usecase.dto.TripCreateCommand;
+import com.cosain.trilo.trip.domain.vo.TripTitle;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class TripCreateCommandFactory {
+
+    public TripCreateCommand createCommand(String rawTitle) {
+        List<CustomException> exceptions = new ArrayList<>();
+        TripTitle tripTitle = makeTripTitle(rawTitle, exceptions);
+
+        if (!exceptions.isEmpty()) {
+            throw new CustomValidationException(exceptions);
+        }
+        return new TripCreateCommand(tripTitle);
+    }
+
+    private TripTitle makeTripTitle(String rawTitle, List<CustomException> exceptions) {
+        try {
+            return TripTitle.of(rawTitle);
+        } catch (CustomException e) {
+            exceptions.add(e);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/application/trip/command/usecase/dto/factory/TripUpdateCommandFactory.java
+++ b/src/main/java/com/cosain/trilo/trip/application/trip/command/usecase/dto/factory/TripUpdateCommandFactory.java
@@ -1,0 +1,47 @@
+package com.cosain.trilo.trip.application.trip.command.usecase.dto.factory;
+
+import com.cosain.trilo.common.exception.CustomException;
+import com.cosain.trilo.common.exception.CustomValidationException;
+import com.cosain.trilo.trip.application.trip.command.usecase.dto.TripCreateCommand;
+import com.cosain.trilo.trip.application.trip.command.usecase.dto.TripUpdateCommand;
+import com.cosain.trilo.trip.domain.vo.TripPeriod;
+import com.cosain.trilo.trip.domain.vo.TripTitle;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class TripUpdateCommandFactory {
+
+    public TripUpdateCommand createCommand(String rawTitle, LocalDate startDate, LocalDate endDate) {
+        List<CustomException> exceptions = new ArrayList<>();
+        TripTitle tripTitle = makeTripTitle(rawTitle, exceptions);
+        TripPeriod tripPeriod = makeTripPeriod(startDate, endDate, exceptions);
+
+        if (!exceptions.isEmpty()) {
+            throw new CustomValidationException(exceptions);
+        }
+        return new TripUpdateCommand(tripTitle, tripPeriod);
+    }
+
+    private TripTitle makeTripTitle(String rawTitle, List<CustomException> exceptions) {
+        try {
+            return TripTitle.of(rawTitle);
+        } catch (CustomException e) {
+            exceptions.add(e);
+        }
+        return null;
+    }
+
+
+    private TripPeriod makeTripPeriod(LocalDate startDate, LocalDate endDate, List<CustomException> exceptions) {
+        try {
+            return TripPeriod.of(startDate, endDate);
+        } catch (CustomException e) {
+            exceptions.add(e);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/domain/entity/Day.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/entity/Day.java
@@ -5,6 +5,7 @@ import com.cosain.trilo.trip.domain.exception.InvalidScheduleMoveTargetOrderExce
 import com.cosain.trilo.trip.domain.exception.MidScheduleIndexConflictException;
 import com.cosain.trilo.trip.domain.vo.Place;
 import com.cosain.trilo.trip.domain.vo.ScheduleIndex;
+import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
 import com.cosain.trilo.trip.domain.vo.TripPeriod;
 import jakarta.persistence.*;
 import lombok.*;
@@ -69,8 +70,8 @@ public class Day {
         return tripPeriod.contains(tripDate);
     }
 
-    Schedule createSchedule(String title, Place place) {
-        Schedule schedule = Schedule.create(this, trip, title, place, generateNextScheduleIndex());
+    Schedule createSchedule(ScheduleTitle scheduleTitle, Place place) {
+        Schedule schedule = Schedule.create(this, trip, scheduleTitle, place, generateNextScheduleIndex());
         schedules.add(schedule);
         return schedule;
     }

--- a/src/main/java/com/cosain/trilo/trip/domain/entity/Schedule.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/entity/Schedule.java
@@ -1,6 +1,7 @@
 package com.cosain.trilo.trip.domain.entity;
 
 import com.cosain.trilo.trip.domain.vo.Place;
+import com.cosain.trilo.trip.domain.vo.ScheduleContent;
 import com.cosain.trilo.trip.domain.vo.ScheduleIndex;
 import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
 import jakarta.persistence.*;
@@ -32,8 +33,8 @@ public class Schedule {
     @Embedded
     private ScheduleTitle scheduleTitle;
 
-    @Column(nullable = true)
-    private String content;
+    @Embedded
+    private ScheduleContent scheduleContent;
 
     @Embedded
     private Place place;
@@ -55,12 +56,12 @@ public class Schedule {
      * 테스트의 편의성을 위해 Builder accessLevel = PUBLIC 으로 설정
      */
     @Builder(access = AccessLevel.PUBLIC)
-    private Schedule(Long id, Day day, Trip trip, ScheduleTitle scheduleTitle, String content, Place place, ScheduleIndex scheduleIndex) {
+    private Schedule(Long id, Day day, Trip trip, ScheduleTitle scheduleTitle, ScheduleContent scheduleContent, Place place, ScheduleIndex scheduleIndex) {
         this.id = id;
         this.day = day;
         this.trip = trip;
         this.scheduleTitle = scheduleTitle;
-        this.content = content;
+        this.scheduleContent = scheduleContent;
         this.place = place;
         this.scheduleIndex = scheduleIndex;
     }
@@ -69,8 +70,8 @@ public class Schedule {
         this.scheduleTitle = scheduleTitle;
     }
 
-    public void changeContent(String content){
-        this.content = content;
+    public void changeContent(ScheduleContent scheduleContent){
+        this.scheduleContent = scheduleContent;
     }
 
     /**

--- a/src/main/java/com/cosain/trilo/trip/domain/entity/Schedule.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/entity/Schedule.java
@@ -2,6 +2,7 @@ package com.cosain.trilo.trip.domain.entity;
 
 import com.cosain.trilo.trip.domain.vo.Place;
 import com.cosain.trilo.trip.domain.vo.ScheduleIndex;
+import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
@@ -28,8 +29,8 @@ public class Schedule {
     @JoinColumn(name = "trip_id", nullable = false)
     private Trip trip;
 
-    @Column(nullable = false)
-    private String title;
+    @Embedded
+    private ScheduleTitle scheduleTitle;
 
     @Column(nullable = true)
     private String content;
@@ -40,11 +41,11 @@ public class Schedule {
     @Embedded
     private ScheduleIndex scheduleIndex;
 
-    static Schedule create(Day day, Trip trip, String title, Place place, ScheduleIndex scheduleIndex) {
+    static Schedule create(Day day, Trip trip, ScheduleTitle scheduleTitle, Place place, ScheduleIndex scheduleIndex) {
         return Schedule.builder()
                 .day(day)
                 .trip(trip)
-                .title(title)
+                .scheduleTitle(scheduleTitle)
                 .place(place)
                 .scheduleIndex(scheduleIndex)
                 .build();
@@ -54,19 +55,20 @@ public class Schedule {
      * 테스트의 편의성을 위해 Builder accessLevel = PUBLIC 으로 설정
      */
     @Builder(access = AccessLevel.PUBLIC)
-    private Schedule(Long id, Day day, Trip trip, String title, String content, Place place, ScheduleIndex scheduleIndex) {
+    private Schedule(Long id, Day day, Trip trip, ScheduleTitle scheduleTitle, String content, Place place, ScheduleIndex scheduleIndex) {
         this.id = id;
         this.day = day;
         this.trip = trip;
-        this.title = title;
+        this.scheduleTitle = scheduleTitle;
         this.content = content;
         this.place = place;
         this.scheduleIndex = scheduleIndex;
     }
 
-    public void changeTitle(String title){
-        this.title = title;
+    public void changeTitle(ScheduleTitle scheduleTitle){
+        this.scheduleTitle = scheduleTitle;
     }
+
     public void changeContent(String content){
         this.content = content;
     }

--- a/src/main/java/com/cosain/trilo/trip/domain/entity/Trip.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/entity/Trip.java
@@ -145,11 +145,11 @@ public class Trip {
         return newDays;
     }
 
-    public Schedule createSchedule(Day day, String title, Place place) {
+    public Schedule createSchedule(Day day, ScheduleTitle scheduleTitle, Place place) {
         validateTripDayRelationShip(day);
         return (day == null)
-                ? makeTemporaryStorageSchedule(title, place)
-                : day.createSchedule(title, place);
+                ? makeTemporaryStorageSchedule(scheduleTitle, place)
+                : day.createSchedule(scheduleTitle, place);
     }
 
     /**
@@ -165,8 +165,8 @@ public class Trip {
         }
     }
 
-    private Schedule makeTemporaryStorageSchedule(String title, Place place) {
-        Schedule schedule = Schedule.create(null, this, title, place, generateNextTemporaryStorageScheduleIndex());
+    private Schedule makeTemporaryStorageSchedule(ScheduleTitle scheduleTitle, Place place) {
+        Schedule schedule = Schedule.create(null, this, scheduleTitle, place, generateNextTemporaryStorageScheduleIndex());
         temporaryStorage.add(schedule);
         return schedule;
     }

--- a/src/main/java/com/cosain/trilo/trip/domain/entity/Trip.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/entity/Trip.java
@@ -6,10 +6,7 @@ import com.cosain.trilo.trip.domain.exception.EmptyPeriodUpdateException;
 import com.cosain.trilo.trip.domain.exception.InvalidScheduleMoveTargetOrderException;
 import com.cosain.trilo.trip.domain.exception.InvalidTripDayException;
 import com.cosain.trilo.trip.domain.exception.MidScheduleIndexConflictException;
-import com.cosain.trilo.trip.domain.vo.Place;
-import com.cosain.trilo.trip.domain.vo.ScheduleIndex;
-import com.cosain.trilo.trip.domain.vo.TripPeriod;
-import com.cosain.trilo.trip.domain.vo.TripStatus;
+import com.cosain.trilo.trip.domain.vo.*;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -38,7 +35,7 @@ public class Trip {
     private Long tripperId;
 
     @Column(name = "title")
-    private String title;
+    private TripTitle tripTitle;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "trip_status")
@@ -58,14 +55,14 @@ public class Trip {
     /**
      * 여행(Trip)을 최초로 생성합니다. 최초 생성된 Trip은 UNDECIDED 상태입니다.
      *
-     * @param title:    여행의 제목
+     * @param tripTitle:    여행의 제목
      * @param tripperId : 여행자의 식별자
      * @return 생성된 Trip
      */
-    public static Trip create(String title, Long tripperId) {
+    public static Trip create(TripTitle tripTitle, Long tripperId) {
         return Trip.builder()
                 .tripperId(tripperId)
-                .title(title)
+                .tripTitle(tripTitle)
                 .status(TripStatus.UNDECIDED)
                 .tripPeriod(TripPeriod.empty())
                 .build();
@@ -75,10 +72,10 @@ public class Trip {
      * 테스트의 편의성을 위해 Builder accessLevel = PUBLIC 으로 설정
      */
     @Builder(access = AccessLevel.PUBLIC)
-    private Trip(Long id, Long tripperId, String title, TripStatus status, TripPeriod tripPeriod, List<Day> days, List<Schedule> temporaryStorage) {
+    private Trip(Long id, Long tripperId, TripTitle tripTitle, TripStatus status, TripPeriod tripPeriod, List<Day> days, List<Schedule> temporaryStorage) {
         this.id = id;
         this.tripperId = tripperId;
-        this.title = title;
+        this.tripTitle = tripTitle;
         this.status = status;
         this.tripPeriod = tripPeriod;
 
@@ -96,8 +93,8 @@ public class Trip {
      *
      * @param newTitle : 변경할 제목
      */
-    public void changeTitle(String newTitle) {
-        this.title = newTitle;
+    public void changeTitle(TripTitle newTitle) {
+        this.tripTitle = newTitle;
     }
 
     /**

--- a/src/main/java/com/cosain/trilo/trip/domain/exception/InvalidScheduleTitleException.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/exception/InvalidScheduleTitleException.java
@@ -1,0 +1,35 @@
+package com.cosain.trilo.trip.domain.exception;
+
+import com.cosain.trilo.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidScheduleTitleException extends CustomException {
+
+    private static final String ERROR_CODE = "schedule-0008";
+    private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+    public InvalidScheduleTitleException() {
+    }
+
+    public InvalidScheduleTitleException(String debugMessage) {
+        super(debugMessage);
+    }
+
+    public InvalidScheduleTitleException(Throwable cause) {
+        super(cause);
+    }
+
+    public InvalidScheduleTitleException(String debugMessage, Throwable cause) {
+        super(debugMessage, cause);
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HTTP_STATUS;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/domain/exception/InvalidTripTitleException.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/exception/InvalidTripTitleException.java
@@ -1,0 +1,35 @@
+package com.cosain.trilo.trip.domain.exception;
+
+import com.cosain.trilo.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidTripTitleException extends CustomException {
+
+    private static final String ERROR_CODE = "trip-0002";
+    private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+    public InvalidTripTitleException() {
+    }
+
+    public InvalidTripTitleException(String debugMessage) {
+        super(debugMessage);
+    }
+
+    public InvalidTripTitleException(Throwable cause) {
+        super(cause);
+    }
+
+    public InvalidTripTitleException(String debugMessage, Throwable cause) {
+        super(debugMessage, cause);
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HTTP_STATUS;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/domain/exception/TooLongPeriodException.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/exception/TooLongPeriodException.java
@@ -1,0 +1,35 @@
+package com.cosain.trilo.trip.domain.exception;
+
+import com.cosain.trilo.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class TooLongPeriodException extends CustomException {
+
+    private static final String ERROR_CODE = "trip-0009";
+    private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+    public TooLongPeriodException() {
+    }
+
+    public TooLongPeriodException(String debugMessage) {
+        super(debugMessage);
+    }
+
+    public TooLongPeriodException(Throwable cause) {
+        super(cause);
+    }
+
+    public TooLongPeriodException(String debugMessage, Throwable cause) {
+        super(debugMessage, cause);
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HTTP_STATUS;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/domain/vo/Coordinate.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/vo/Coordinate.java
@@ -24,7 +24,10 @@ public class Coordinate {
     @Column(name= "place_longitude", nullable = false)
     private double longitude;
 
-    public static Coordinate of(double latitude, double longitude) {
+    public static Coordinate of(Double latitude, Double longitude) {
+        if (latitude == null || longitude == null) {
+            throw new InvalidCoordinateException("위도 또는 경도가 누락됨");
+        }
         if (!(MIN_LATITUDE <= latitude && latitude <= MAX_LATITUDE)) {
             throw new InvalidCoordinateException("위도의 범위가 옳지 않음");
         }
@@ -34,7 +37,7 @@ public class Coordinate {
         return new Coordinate(latitude, longitude);
     }
 
-    public Coordinate(double latitude, double longitude) {
+    private Coordinate(double latitude, double longitude) {
         this.latitude = latitude;
         this.longitude = longitude;
     }

--- a/src/main/java/com/cosain/trilo/trip/domain/vo/Coordinate.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/vo/Coordinate.java
@@ -12,11 +12,11 @@ import lombok.*;
 @Embeddable
 public class Coordinate {
 
-    private static final double MIN_LATITUDE = -90;
-    private static final double MAX_LATITUDE = 90;
+    public static final double MIN_LATITUDE = -90;
+    public static final double MAX_LATITUDE = 90;
 
-    private static final double MIN_LONGITUDE = -180;
-    private static final double MAX_LONGITUDE = 180;
+    public static final double MIN_LONGITUDE = -180;
+    public static final double MAX_LONGITUDE = 180;
 
     @Column(name = "place_latitude", nullable = false)
     private double latitude;

--- a/src/main/java/com/cosain/trilo/trip/domain/vo/ScheduleContent.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/vo/ScheduleContent.java
@@ -1,0 +1,25 @@
+package com.cosain.trilo.trip.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+@Getter
+@EqualsAndHashCode(of = {"value"})
+@ToString(of = {"value"})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class ScheduleContent {
+
+    @Column(name = "content")
+    private String value;
+
+    public static ScheduleContent of(String rawContent) {
+        // 추후 검증이 필요한 부분이 있으면 여기에
+        return new ScheduleContent(rawContent);
+    }
+
+    private ScheduleContent(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/domain/vo/ScheduleTitle.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/vo/ScheduleTitle.java
@@ -1,0 +1,40 @@
+package com.cosain.trilo.trip.domain.vo;
+
+import com.cosain.trilo.trip.domain.exception.InvalidScheduleTitleException;
+import com.cosain.trilo.trip.domain.exception.InvalidTripTitleException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+@Getter
+@ToString(of = {"value"})
+@EqualsAndHashCode(of = {"value"})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class ScheduleTitle {
+
+    public static final int MIN_LENGTH = 1;
+    public static final int MAX_LENGTH = 20;
+
+    @Column(name = "title")
+    private String value;
+
+    public static ScheduleTitle of(String value) {
+        if (isNullOrBlank(value) || hasInvalidLength(value)) {
+            throw new InvalidScheduleTitleException("null 또는 공백이거나, 길이 조건에 맞지 않는 여행 제목");
+        }
+        return new ScheduleTitle(value);
+    }
+
+    private static boolean isNullOrBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private static boolean hasInvalidLength(String value) {
+        return value.length() < MIN_LENGTH || value.length() > MAX_LENGTH;
+    }
+
+    private ScheduleTitle(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/domain/vo/TripTitle.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/vo/TripTitle.java
@@ -1,0 +1,42 @@
+package com.cosain.trilo.trip.domain.vo;
+
+import com.cosain.trilo.trip.domain.exception.InvalidTripTitleException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString(of = {"value"})
+@EqualsAndHashCode(of = {"value"})
+@NoArgsConstructor
+@Embeddable
+public class TripTitle {
+
+    public static final int MIN_LENGTH = 1;
+    public static final int MAX_LENGTH = 20;
+
+    @Column(name = "trip_title")
+    private String value;
+
+    public static TripTitle of(String value) {
+        if (isNullOrBlank(value) || hasInvalidLength(value)) {
+            throw new InvalidTripTitleException("null 또는 공백이거나, 길이 조건에 맞지 않는 여행 제목");
+        }
+        return new TripTitle(value);
+    }
+
+    private static boolean isNullOrBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private static boolean hasInvalidLength(String value) {
+        return value.length() < MIN_LENGTH || value.length() > MAX_LENGTH;
+    }
+
+    private TripTitle(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/domain/vo/TripTitle.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/vo/TripTitle.java
@@ -3,15 +3,12 @@ package com.cosain.trilo.trip.domain.vo;
 import com.cosain.trilo.trip.domain.exception.InvalidTripTitleException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 @Getter
 @ToString(of = {"value"})
 @EqualsAndHashCode(of = {"value"})
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Embeddable
 public class TripTitle {
 

--- a/src/main/java/com/cosain/trilo/trip/infra/repository/day/jpa/DayQueryJpaRepositoryImpl.java
+++ b/src/main/java/com/cosain/trilo/trip/infra/repository/day/jpa/DayQueryJpaRepositoryImpl.java
@@ -32,7 +32,7 @@ public class DayQueryJpaRepositoryImpl implements DayQueryJpaRepositoryCustom{
                         day.tripDate,
                         GroupBy.list(new QScheduleSummary(
                                 schedule.id,
-                                schedule.title,
+                                schedule.scheduleTitle.value,
                                 schedule.place.placeName,
                                 schedule.place.placeId,
                                 schedule.place.coordinate.latitude,

--- a/src/main/java/com/cosain/trilo/trip/infra/repository/schedule/jpa/ScheduleQueryJpaRepositoryImpl.java
+++ b/src/main/java/com/cosain/trilo/trip/infra/repository/schedule/jpa/ScheduleQueryJpaRepositoryImpl.java
@@ -23,7 +23,7 @@ public class ScheduleQueryJpaRepositoryImpl implements ScheduleQueryJpaRepositor
     @Override
     public Optional<ScheduleDetail> findScheduleDetailById(Long scheduleId) {
         return Optional.ofNullable(query.select(
-            new QScheduleDetail(schedule.id, schedule.day.id, schedule.scheduleTitle.value, schedule.place.placeName, schedule.place.coordinate.latitude, schedule.place.coordinate.longitude, schedule.scheduleIndex.value, schedule.content))
+            new QScheduleDetail(schedule.id, schedule.day.id, schedule.scheduleTitle.value, schedule.place.placeName, schedule.place.coordinate.latitude, schedule.place.coordinate.longitude, schedule.scheduleIndex.value, schedule.scheduleContent.value))
                 .from(schedule)
                 .where(schedule.id.eq(scheduleId))
                 .fetchOne());

--- a/src/main/java/com/cosain/trilo/trip/infra/repository/schedule/jpa/ScheduleQueryJpaRepositoryImpl.java
+++ b/src/main/java/com/cosain/trilo/trip/infra/repository/schedule/jpa/ScheduleQueryJpaRepositoryImpl.java
@@ -23,7 +23,7 @@ public class ScheduleQueryJpaRepositoryImpl implements ScheduleQueryJpaRepositor
     @Override
     public Optional<ScheduleDetail> findScheduleDetailById(Long scheduleId) {
         return Optional.ofNullable(query.select(
-            new QScheduleDetail(schedule.id, schedule.day.id, schedule.title, schedule.place.placeName, schedule.place.coordinate.latitude, schedule.place.coordinate.longitude, schedule.scheduleIndex.value, schedule.content))
+            new QScheduleDetail(schedule.id, schedule.day.id, schedule.scheduleTitle.value, schedule.place.placeName, schedule.place.coordinate.latitude, schedule.place.coordinate.longitude, schedule.scheduleIndex.value, schedule.content))
                 .from(schedule)
                 .where(schedule.id.eq(scheduleId))
                 .fetchOne());
@@ -31,7 +31,7 @@ public class ScheduleQueryJpaRepositoryImpl implements ScheduleQueryJpaRepositor
 
     @Override
     public Slice<ScheduleSummary> findTemporaryScheduleListByTripId(Long tripId, Pageable pageable) {
-        JPAQuery<ScheduleSummary> jpaQuery = query.select(new QScheduleSummary(schedule.id, schedule.title, schedule.place.placeName, schedule.place.placeId, schedule.place.coordinate.latitude, schedule.place.coordinate.longitude))
+        JPAQuery<ScheduleSummary> jpaQuery = query.select(new QScheduleSummary(schedule.id, schedule.scheduleTitle.value, schedule.place.placeName, schedule.place.placeId, schedule.place.coordinate.latitude, schedule.place.coordinate.longitude))
                 .from(schedule)
                 .where(schedule.trip.id.eq(tripId).and(schedule.day.id.isNull()))
                 .orderBy(schedule.scheduleIndex.value.asc())

--- a/src/main/java/com/cosain/trilo/trip/infra/repository/trip/jpa/TripQueryJpaRepositoryImpl.java
+++ b/src/main/java/com/cosain/trilo/trip/infra/repository/trip/jpa/TripQueryJpaRepositoryImpl.java
@@ -33,7 +33,7 @@ public class TripQueryJpaRepositoryImpl implements TripQueryJpaRepositoryCustom{
     public Optional<TripDetail> findTripDetailById(Long tripId){
 
         return Optional.ofNullable(query.select(
-                new QTripDetail(trip.id, trip.tripperId, trip.title, trip.status, trip.tripPeriod.startDate, trip.tripPeriod.endDate))
+                        new QTripDetail(trip.id, trip.tripperId, trip.tripTitle.value, trip.status, trip.tripPeriod.startDate, trip.tripPeriod.endDate))
                 .from(trip)
                 .where(trip.id.eq(tripId))
                 .fetchOne());
@@ -41,7 +41,7 @@ public class TripQueryJpaRepositoryImpl implements TripQueryJpaRepositoryCustom{
 
     @Override
     public Slice<TripSummary> findTripSummariesByTripperId(Long tripperId, Pageable pageable) {
-        JPAQuery<TripSummary> jpaQuery = query.select(new QTripSummary(trip.id, trip.tripperId, trip.title, trip.status, trip.tripPeriod.startDate, trip.tripPeriod.endDate))
+        JPAQuery<TripSummary> jpaQuery = query.select(new QTripSummary(trip.id, trip.tripperId, trip.tripTitle.value, trip.status, trip.tripPeriod.startDate, trip.tripPeriod.endDate))
                 .from(trip)
                 .where(trip.tripperId.eq(tripperId))
                 .orderBy(trip.id.desc())

--- a/src/main/java/com/cosain/trilo/trip/presentation/schedule/command/ScheduleCreateController.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/schedule/command/ScheduleCreateController.java
@@ -1,13 +1,15 @@
 package com.cosain.trilo.trip.presentation.schedule.command;
 
 import com.cosain.trilo.common.LoginUser;
-import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleCreateCommand;
 import com.cosain.trilo.trip.application.schedule.command.usecase.ScheduleCreateUseCase;
+import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleCreateCommand;
+import com.cosain.trilo.trip.application.schedule.command.usecase.dto.factory.ScheduleCreateCommandFactory;
 import com.cosain.trilo.trip.presentation.schedule.command.dto.request.ScheduleCreateRequest;
 import com.cosain.trilo.trip.presentation.schedule.command.dto.response.ScheduleCreateResponse;
 import com.cosain.trilo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,15 +22,23 @@ import org.springframework.web.bind.annotation.RestController;
 public class ScheduleCreateController {
 
     private final ScheduleCreateUseCase scheduleCreateUseCase;
+    private final ScheduleCreateCommandFactory scheduleCreateCommandFactory;
 
     @PostMapping("/api/schedules")
     @ResponseStatus(HttpStatus.CREATED)
     public ScheduleCreateResponse createSchedule(@LoginUser User user, @RequestBody ScheduleCreateRequest request){
         Long tripperId = user.getId();
-        ScheduleCreateCommand createCommand = request.toCommand();
+        ScheduleCreateCommand command = createCommand(request);
 
-        Long scheduleId = scheduleCreateUseCase.createSchedule(tripperId, createCommand);
-
+        Long scheduleId = scheduleCreateUseCase.createSchedule(tripperId, command);
         return ScheduleCreateResponse.from(scheduleId);
+    }
+
+    private ScheduleCreateCommand createCommand(ScheduleCreateRequest request) {
+        return scheduleCreateCommandFactory.createCommand(
+                request.getDayId(), request.getTripId(), request.getTitle(),
+                request.getPlaceId(), request.getPlaceName(),
+                request.getLatitude(), request.getLongitude()
+        );
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/presentation/schedule/command/ScheduleMoveController.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/schedule/command/ScheduleMoveController.java
@@ -4,6 +4,7 @@ import com.cosain.trilo.common.LoginUser;
 import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleMoveCommand;
 import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleMoveResult;
 import com.cosain.trilo.trip.application.schedule.command.usecase.ScheduleMoveUseCase;
+import com.cosain.trilo.trip.application.schedule.command.usecase.dto.factory.ScheduleMoveCommandFactory;
 import com.cosain.trilo.trip.presentation.schedule.command.dto.request.ScheduleMoveRequest;
 import com.cosain.trilo.trip.presentation.schedule.command.dto.response.ScheduleMoveResponse;
 import com.cosain.trilo.user.domain.User;
@@ -18,13 +19,14 @@ import org.springframework.web.bind.annotation.*;
 public class ScheduleMoveController {
 
     private final ScheduleMoveUseCase scheduleMoveUseCase;
+    private final ScheduleMoveCommandFactory scheduleMoveCommandFactory;
 
     @PatchMapping("/api/schedules/{scheduleId}")
     @ResponseStatus(HttpStatus.OK)
-    public ScheduleMoveResponse moveSchedule(@LoginUser User user, @PathVariable Long scheduleId, @RequestBody ScheduleMoveRequest scheduleMoveRequest) {
+    public ScheduleMoveResponse moveSchedule(@LoginUser User user, @PathVariable Long scheduleId, @RequestBody ScheduleMoveRequest request) {
         Long moveTripperId = user.getId();
 
-        ScheduleMoveCommand scheduleMoveCommand = scheduleMoveRequest.toCommand();
+        ScheduleMoveCommand scheduleMoveCommand = scheduleMoveCommandFactory.createCommand(request.getTargetDayId(), request.getTargetOrder());
         ScheduleMoveResult scheduleMoveResult = scheduleMoveUseCase.moveSchedule(scheduleId, moveTripperId, scheduleMoveCommand);
 
         return ScheduleMoveResponse.from(scheduleMoveResult);

--- a/src/main/java/com/cosain/trilo/trip/presentation/schedule/command/ScheduleUpdateController.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/schedule/command/ScheduleUpdateController.java
@@ -3,6 +3,7 @@ package com.cosain.trilo.trip.presentation.schedule.command;
 import com.cosain.trilo.common.LoginUser;
 import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleUpdateCommand;
 import com.cosain.trilo.trip.application.schedule.command.usecase.ScheduleUpdateUseCase;
+import com.cosain.trilo.trip.application.schedule.command.usecase.dto.factory.ScheduleUpdateCommandFactory;
 import com.cosain.trilo.trip.presentation.schedule.command.dto.request.ScheduleUpdateRequest;
 import com.cosain.trilo.trip.presentation.schedule.command.dto.response.ScheduleUpdateResponse;
 import com.cosain.trilo.user.domain.User;
@@ -17,13 +18,14 @@ import org.springframework.web.bind.annotation.*;
 public class ScheduleUpdateController {
 
     private final ScheduleUpdateUseCase scheduleUpdateUseCase;
+    private final ScheduleUpdateCommandFactory scheduleUpdateCommandFactory;
 
     @PutMapping("/api/schedules/{scheduleId}")
     @ResponseStatus(HttpStatus.OK)
-    public ScheduleUpdateResponse updateSchedule(@LoginUser User user, @PathVariable Long scheduleId, @RequestBody ScheduleUpdateRequest scheduleUpdateRequest) {
+    public ScheduleUpdateResponse updateSchedule(@LoginUser User user, @PathVariable Long scheduleId, @RequestBody ScheduleUpdateRequest request) {
         Long tripperId = user.getId();
 
-        ScheduleUpdateCommand scheduleUpdateCommand = scheduleUpdateRequest.toCommand();
+        ScheduleUpdateCommand scheduleUpdateCommand = scheduleUpdateCommandFactory.createCommand(request.getTitle(), request.getContent());
         Long updatedScheduleId = scheduleUpdateUseCase.updateSchedule(scheduleId,tripperId, scheduleUpdateCommand);
 
         return ScheduleUpdateResponse.from(updatedScheduleId);

--- a/src/main/java/com/cosain/trilo/trip/presentation/schedule/command/dto/request/ScheduleCreateRequest.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/schedule/command/dto/request/ScheduleCreateRequest.java
@@ -16,14 +16,14 @@ public class ScheduleCreateRequest {
 
     private String placeId;
     private String placeName;
-    private double latitude;
-    private double longitude;
+    private Double latitude;
+    private Double longitude;
 
     /**
      * 테스트의 편의성을 위해 Builder accessLevel = PUBLIC 으로 설정
      */
     @Builder(access = AccessLevel.PUBLIC)
-    private ScheduleCreateRequest(Long dayId, Long tripId, String title, String placeId, String placeName, double latitude, double longitude) {
+    private ScheduleCreateRequest(Long dayId, Long tripId, String title, String placeId, String placeName, Double latitude, Double longitude) {
         this.dayId = dayId;
         this.tripId = tripId;
         this.title = title;
@@ -31,10 +31,6 @@ public class ScheduleCreateRequest {
         this.placeName = placeName;
         this.latitude = latitude;
         this.longitude = longitude;
-    }
-
-    public ScheduleCreateCommand toCommand() {
-        return ScheduleCreateCommand.of(dayId, tripId, title, placeId, placeName, latitude, longitude);
     }
 
 }

--- a/src/main/java/com/cosain/trilo/trip/presentation/schedule/command/dto/request/ScheduleMoveRequest.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/schedule/command/dto/request/ScheduleMoveRequest.java
@@ -1,6 +1,5 @@
 package com.cosain.trilo.trip.presentation.schedule.command.dto.request;
 
-import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleMoveCommand;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,14 +9,10 @@ import lombok.NoArgsConstructor;
 public class ScheduleMoveRequest {
 
     private Long targetDayId;
-    private int targetOrder;
+    private Integer targetOrder;
 
-    public ScheduleMoveRequest(Long targetDayId, int targetOrder) {
+    public ScheduleMoveRequest(Long targetDayId, Integer targetOrder) {
         this.targetDayId = targetDayId;
         this.targetOrder = targetOrder;
-    }
-
-    public ScheduleMoveCommand toCommand() {
-        return ScheduleMoveCommand.of(targetDayId, targetOrder);
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/presentation/schedule/command/dto/request/ScheduleUpdateRequest.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/schedule/command/dto/request/ScheduleUpdateRequest.java
@@ -1,6 +1,5 @@
 package com.cosain.trilo.trip.presentation.schedule.command.dto.request;
 
-import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleUpdateCommand;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,8 +11,4 @@ import lombok.NoArgsConstructor;
 public class ScheduleUpdateRequest {
     private String title;
     private String content;
-
-    public ScheduleUpdateCommand toCommand(){
-        return ScheduleUpdateCommand.of(this.title, this.content);
-    }
 }

--- a/src/main/java/com/cosain/trilo/trip/presentation/trip/command/TripCreateController.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/trip/command/TripCreateController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,7 +23,7 @@ public class TripCreateController {
     private final TripCreateUseCase tripCreateUseCase;
 
     @PostMapping("/api/trips")
-    public ResponseEntity<TripCreateResponse> createTrip(@LoginUser User user, @RequestBody TripCreateRequest request) {
+    public ResponseEntity<TripCreateResponse> createTrip(@LoginUser User user, @RequestBody @Validated TripCreateRequest request) {
         Long tripperId = user.getId();
         TripCreateCommand createCommand = request.toCommand();
 

--- a/src/main/java/com/cosain/trilo/trip/presentation/trip/command/TripCreateController.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/trip/command/TripCreateController.java
@@ -3,6 +3,7 @@ package com.cosain.trilo.trip.presentation.trip.command;
 import com.cosain.trilo.common.LoginUser;
 import com.cosain.trilo.trip.application.trip.command.usecase.dto.TripCreateCommand;
 import com.cosain.trilo.trip.application.trip.command.usecase.TripCreateUseCase;
+import com.cosain.trilo.trip.application.trip.command.usecase.dto.factory.TripCreateCommandFactory;
 import com.cosain.trilo.trip.presentation.trip.command.dto.request.TripCreateRequest;
 import com.cosain.trilo.trip.presentation.trip.command.dto.response.TripCreateResponse;
 import com.cosain.trilo.user.domain.User;
@@ -21,11 +22,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class TripCreateController {
 
     private final TripCreateUseCase tripCreateUseCase;
+    private final TripCreateCommandFactory tripCreateCommandFactory;
 
     @PostMapping("/api/trips")
-    public ResponseEntity<TripCreateResponse> createTrip(@LoginUser User user, @RequestBody @Validated TripCreateRequest request) {
+    public ResponseEntity<TripCreateResponse> createTrip(@LoginUser User user, @RequestBody TripCreateRequest request) {
         Long tripperId = user.getId();
-        TripCreateCommand createCommand = request.toCommand();
+        TripCreateCommand createCommand = tripCreateCommandFactory.createCommand(request.getTitle());
 
         Long tripId = tripCreateUseCase.createTrip(tripperId, createCommand);
 

--- a/src/main/java/com/cosain/trilo/trip/presentation/trip/command/TripUpdateController.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/trip/command/TripUpdateController.java
@@ -1,8 +1,9 @@
 package com.cosain.trilo.trip.presentation.trip.command;
 
 import com.cosain.trilo.common.LoginUser;
-import com.cosain.trilo.trip.application.trip.command.usecase.dto.TripUpdateCommand;
 import com.cosain.trilo.trip.application.trip.command.usecase.TripUpdateUseCase;
+import com.cosain.trilo.trip.application.trip.command.usecase.dto.TripUpdateCommand;
+import com.cosain.trilo.trip.application.trip.command.usecase.dto.factory.TripUpdateCommandFactory;
 import com.cosain.trilo.trip.presentation.trip.command.dto.request.TripUpdateRequest;
 import com.cosain.trilo.trip.presentation.trip.command.dto.response.TripUpdateResponse;
 import com.cosain.trilo.user.domain.User;
@@ -11,24 +12,21 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-/**
- * TODO: 여행 수정
- */
 @Slf4j
 @RequiredArgsConstructor
 @RestController
 public class TripUpdateController {
 
     private final TripUpdateUseCase tripUpdateUseCase;
+    private final TripUpdateCommandFactory tripUpdateCommandFactory;
 
     @PutMapping("/api/trips/{tripId}")
     @ResponseStatus(HttpStatus.OK)
     public TripUpdateResponse updateTrip(@LoginUser User user, @PathVariable Long tripId, @RequestBody TripUpdateRequest request) {
         Long tripperId = user.getId();
-        TripUpdateCommand command = request.toCommand();
+        TripUpdateCommand command = tripUpdateCommandFactory.createCommand(request.getTitle(), request.getStartDate(), request.getEndDate());
 
         tripUpdateUseCase.updateTrip(tripId, tripperId, command);
-
         return TripUpdateResponse.from(tripId);
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/presentation/trip/command/dto/request/TripCreateRequest.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/trip/command/dto/request/TripCreateRequest.java
@@ -20,6 +20,6 @@ public class TripCreateRequest {
     }
 
     public TripCreateCommand toCommand() {
-        return new TripCreateCommand(title);
+        return TripCreateCommand.from(title);
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/presentation/trip/command/dto/request/TripCreateRequest.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/trip/command/dto/request/TripCreateRequest.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 public class TripCreateRequest {
 
     @NotBlank(message = "trip-0002")
-    @Size(min = 1, max = 20, message = "trip-0003")
+    @Size(min = 1, max = 20, message = "trip-0002")
     private String title;
 
     public TripCreateRequest(String title) {

--- a/src/main/java/com/cosain/trilo/trip/presentation/trip/command/dto/request/TripCreateRequest.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/trip/command/dto/request/TripCreateRequest.java
@@ -1,6 +1,8 @@
 package com.cosain.trilo.trip.presentation.trip.command.dto.request;
 
 import com.cosain.trilo.trip.application.trip.command.usecase.dto.TripCreateCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,11 +11,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TripCreateRequest {
 
+    @NotBlank(message = "trip-0002")
+    @Size(min = 1, max = 20, message = "trip-0003")
     private String title;
 
     public TripCreateRequest(String title) {
         this.title = title;
     }
+
     public TripCreateCommand toCommand() {
         return new TripCreateCommand(title);
     }

--- a/src/main/java/com/cosain/trilo/trip/presentation/trip/command/dto/request/TripCreateRequest.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/trip/command/dto/request/TripCreateRequest.java
@@ -1,8 +1,5 @@
 package com.cosain.trilo.trip.presentation.trip.command.dto.request;
 
-import com.cosain.trilo.trip.application.trip.command.usecase.dto.TripCreateCommand;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,15 +8,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TripCreateRequest {
 
-    @NotBlank(message = "trip-0002")
-    @Size(min = 1, max = 20, message = "trip-0002")
     private String title;
 
     public TripCreateRequest(String title) {
         this.title = title;
     }
 
-    public TripCreateCommand toCommand() {
-        return TripCreateCommand.from(title);
-    }
 }

--- a/src/main/java/com/cosain/trilo/trip/presentation/trip/command/dto/request/TripUpdateRequest.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/trip/command/dto/request/TripUpdateRequest.java
@@ -21,7 +21,4 @@ public class TripUpdateRequest {
         this.endDate = endDate;
     }
 
-    public TripUpdateCommand toCommand() {
-        return TripUpdateCommand.of(title, startDate, endDate);
-    }
 }

--- a/src/main/resources/exceptions/exception.yml
+++ b/src/main/resources/exceptions/exception.yml
@@ -135,6 +135,14 @@ schedule-0006:
   message: InvalidScheduleMoveTargetOrder
   detail: 일정을 해당 순서로 이동시킬 수 없습니다. 유효한 순서 범위를 벗어납니다.
 
+schedule-0007:
+  message: Schedule Create Failed - Null TripId
+  detail: 일정 생성 시 필요한 TripId가 누락됐습니다.
+
+schedule-0008:
+  message: Invalid Schedule Title
+  detail: 일정 제목이 올바르지 않습니다. 일정 제목은 null 또는 공백으로만 구성된 문자열일 수 없고, 길이는 1자 이상 20자 이하여야 합니다.
+
 
 # 장소 관련
 place-0001:

--- a/src/main/resources/exceptions/exception.yml
+++ b/src/main/resources/exceptions/exception.yml
@@ -21,6 +21,11 @@ request-0003:
   message: Not Valid Request Parameter
   detail : 유효하지 않은 파라미터가 전달됐습니다. 요청 파라미터의 유효성을 다시 확인해주세요.
 
+request-0004:
+  message: Invalid Parameter Type in URL or Query Parameter
+  detail : URL의 파라미터 변수 또는 쿼리 파라미터의 타입이 올바르지 않습니다.
+
+
 # 인증/인가 관련
 auth-0001:
   message: AuthenticationFailed

--- a/src/main/resources/exceptions/exception.yml
+++ b/src/main/resources/exceptions/exception.yml
@@ -73,8 +73,7 @@ trip-0001:
 
 trip-0002:
   message: Invalid Trip Title
-  detail: 여행의 제목은 null 또는 공백일 수 없습니다. 또한, 여행 제목의 길이는 1자 이상 20자 이하여야 합니다.
-
+  detail: 여행 제목이 올바르지 않습니다. 여행 제목은 null 또는 공백으로만 구성된 문자열일 수 없고, 길이는 1자 이상 20자 이하여야 합니다.
 
 trip-0004:
   message: No Trip Update Authority

--- a/src/main/resources/exceptions/exception.yml
+++ b/src/main/resources/exceptions/exception.yml
@@ -95,6 +95,10 @@ trip-0008:
   message: NoTripDetailSearchAuthority
   detail: 해당 여행을 단건 조회할 권한이 없습니다.
 
+trip-0009:
+  message: Too Long TripPeriod
+  detail: 여행 기간이 너무 깁니다. 여행의 최대 일수는 10일까지만 허용됩니다.
+
 
 # Day 관련
 day-0001:

--- a/src/main/resources/exceptions/exception.yml
+++ b/src/main/resources/exceptions/exception.yml
@@ -133,7 +133,7 @@ schedule-0005:
 
 schedule-0006:
   message: InvalidScheduleMoveTargetOrder
-  detail: 일정을 해당 순서로 이동시킬 수 없습니다. 유효한 순서 범위를 벗어납니다.
+  detail: 일정을 해당 순서로 이동시킬 수 없습니다. 순서값은 null 또는 음수일 수 없으며, 옮기려는 day 또는 임시보관함에서 유효한 순서값이여야합니다.
 
 schedule-0007:
   message: Schedule Create Failed - Null TripId

--- a/src/main/resources/exceptions/exception.yml
+++ b/src/main/resources/exceptions/exception.yml
@@ -72,12 +72,8 @@ trip-0001:
   detail: 일치하는 식별자의 Trip을 찾을 수 없습니다.
 
 trip-0002:
-  message: Empty Trip Title
-  detail: 여행의 제목은 null 또는 공백일 수 없습니다.
-
-trip-0003:
-  message: Invalid Trip Title Length
-  detail: 여행 제목의 길이는 1자 이상 20자 이하여야 합니다.
+  message: Invalid Trip Title
+  detail: 여행의 제목은 null 또는 공백일 수 없습니다. 또한, 여행 제목의 길이는 1자 이상 20자 이하여야 합니다.
 
 
 trip-0004:

--- a/src/main/resources/exceptions/exception.yml
+++ b/src/main/resources/exceptions/exception.yml
@@ -17,6 +17,9 @@ request-0002:
   message: Missing Request Cookie
   detail: 요청에 필요한 쿠키가 누락 됐습니다. 요청에 필요한 쿠키가 존재하는 지, 제대로 된 값인지 다시 확인해주세요.
 
+request-0003:
+  message: Not Valid Request Parameter
+  detail : 유효하지 않은 파라미터가 전달됐습니다. 요청 파라미터의 유효성을 다시 확인해주세요.
 
 # 인증/인가 관련
 auth-0001:
@@ -69,7 +72,7 @@ trip-0002:
 
 trip-0003:
   message: Invalid Trip Title Length
-  detail: 여행 제목의 길이는 {min}자 이상 {max}자 이하여야 합니다.
+  detail: 여행 제목의 길이는 1자 이상 20자 이하여야 합니다.
 
 
 trip-0004:

--- a/src/main/resources/exceptions/exception_en.yml
+++ b/src/main/resources/exceptions/exception_en.yml
@@ -96,6 +96,9 @@ trip-0008:
   message: NoTripDetailSearchAuthority
   detail: You do not have the authority to retrieve detailed information about this trip.
 
+trip-0009:
+  message: Too Long TripPeriod
+  detail: The TripPeriod is too long. The maximum allowed TripPeriod is 10 days.
 
 # Day 관련
 day-0001:

--- a/src/main/resources/exceptions/exception_en.yml
+++ b/src/main/resources/exceptions/exception_en.yml
@@ -69,7 +69,7 @@ trip-0002:
 
 trip-0003:
   message: Invalid Trip Title Length
-  detail: The trip title length must be between {min} and {max} characters.
+  detail: The trip title length must be between 1 and 20 characters.
 
 
 trip-0004:

--- a/src/main/resources/exceptions/exception_en.yml
+++ b/src/main/resources/exceptions/exception_en.yml
@@ -135,6 +135,13 @@ schedule-0006:
   message: InvalidScheduleMoveTargetOrder
   detail: Unable to move the schedule to the specified order. It is outside the valid order range.
 
+schedule-0007:
+  message: Schedule Create Failed - Null TripId
+  detail: The TripId required for generating the schedule is missing.
+
+schedule-0008:
+  message: Invalid Schedule Title
+  detail: The ScheduleTitle is not valid. The ScheduleTitle cannot be a null or empty string, and its length must be between 1 and 20 characters
 
 # 장소 관련
 place-0001:

--- a/src/main/resources/exceptions/exception_en.yml
+++ b/src/main/resources/exceptions/exception_en.yml
@@ -86,7 +86,7 @@ trip-0005:
 
 trip-0006:
   message: EmptyPeriodUpdate Error
-  detail: The period of a scheduled trip cannot be updated to an empty period.
+  detail: It is not possible to move the schedule in the specified order. The order value cannot be null or negative, and it should be a valid order value in the day or the temporary storage.
 
 trip-0007:
   message: NoTripDeleteAuthority

--- a/src/main/resources/exceptions/exception_en.yml
+++ b/src/main/resources/exceptions/exception_en.yml
@@ -73,7 +73,7 @@ trip-0001:
 
 trip-0002:
   message: Invalid Trip Title
-  detail: The TripTitle cannot be null or empty. Additionally, the TripTitle must be between 1 and 20 characters.
+  detail: The TripTitle is not valid. The TripTitle cannot be null or blank, and its length should be between 1 and 20 characters.
 
 
 trip-0004:

--- a/src/main/resources/exceptions/exception_en.yml
+++ b/src/main/resources/exceptions/exception_en.yml
@@ -72,12 +72,8 @@ trip-0001:
   detail: The Trip with the matching identifier could not be found.
 
 trip-0002:
-  message: Empty Trip Title
-  detail: The trip title cannot be null or empty.
-
-trip-0003:
-  message: Invalid Trip Title Length
-  detail: The trip title length must be between 1 and 20 characters.
+  message: Invalid Trip Title
+  detail: The TripTitle cannot be null or empty. Additionally, the TripTitle must be between 1 and 20 characters.
 
 
 trip-0004:

--- a/src/main/resources/exceptions/exception_en.yml
+++ b/src/main/resources/exceptions/exception_en.yml
@@ -17,6 +17,14 @@ request-0002:
   message: Missing Request Cookie
   detail: The required cookie in the request is missing. Please check if the necessary cookie exists and if it has the correct value.
 
+request-0003:
+  message: Not Valid Request Parameter
+  detail : Invalid parameter(s) have been passed. Please recheck the validity of the request parameters.
+
+request-0004:
+  message: Invalid Parameter Type in URL or Query Parameter
+  detail : The type of the URL parameter or query parameter is invalid.
+
 
 # 인증/인가 관련
 auth-0001:

--- a/src/test/java/com/cosain/trilo/fixture/TripFixture.java
+++ b/src/test/java/com/cosain/trilo/fixture/TripFixture.java
@@ -4,6 +4,7 @@ import com.cosain.trilo.trip.domain.entity.Day;
 import com.cosain.trilo.trip.domain.entity.Trip;
 import com.cosain.trilo.trip.domain.vo.TripPeriod;
 import com.cosain.trilo.trip.domain.vo.TripStatus;
+import com.cosain.trilo.trip.domain.vo.TripTitle;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,23 +22,23 @@ public enum TripFixture {
         this.status = status;
     }
 
-    public Trip createUndecided(Long id, Long tripperId, String title){
+    public Trip createUndecided(Long id, Long tripperId, String rawTitle){
         if(this.status.equals(TripStatus.DECIDED)) throw new IllegalArgumentException("status 가 DECIDED 일 경우 startDate와 endDate를 지정해주어야 합니다.");
         return Trip.builder()
                 .id(id)
                 .tripperId(tripperId)
-                .title(title)
+                .tripTitle(TripTitle.of(rawTitle))
                 .status(this.status)
                 .tripPeriod(TripPeriod.empty())
                 .build();
     }
 
-    public Trip createDecided(Long id, Long tripperId, String title, LocalDate startDate, LocalDate endDate){
+    public Trip createDecided(Long id, Long tripperId, String rawTitle, LocalDate startDate, LocalDate endDate){
         if(this.status.equals(TripStatus.UNDECIDED)) throw new IllegalArgumentException("status 가 UNDECIDED 일 경우 startDate와 endDate를 지정해 줄 수 없습니다.");
         Trip trip = Trip.builder()
                 .id(id)
                 .tripperId(tripperId)
-                .title(title)
+                .tripTitle(TripTitle.of(rawTitle))
                 .status(this.status)
                 .build();
         List<Day> days = createDays(startDate, endDate, trip);
@@ -45,7 +46,7 @@ public enum TripFixture {
         return Trip.builder()
                 .id(id)
                 .tripperId(tripperId)
-                .title(title)
+                .tripTitle(TripTitle.of(rawTitle))
                 .tripPeriod(TripPeriod.of(startDate, endDate))
                 .days(days)
                 .status(this.status)

--- a/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/dto/factory/ScheduleCreateCommandFactoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/dto/factory/ScheduleCreateCommandFactoryTest.java
@@ -1,0 +1,389 @@
+package com.cosain.trilo.unit.trip.application.schedule.command.dto.factory;
+
+import com.cosain.trilo.common.exception.CustomValidationException;
+import com.cosain.trilo.trip.application.exception.NullTripIdException;
+import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleCreateCommand;
+import com.cosain.trilo.trip.application.schedule.command.usecase.dto.factory.ScheduleCreateCommandFactory;
+import com.cosain.trilo.trip.domain.exception.InvalidCoordinateException;
+import com.cosain.trilo.trip.domain.exception.InvalidScheduleTitleException;
+import com.cosain.trilo.trip.domain.vo.Coordinate;
+import com.cosain.trilo.trip.domain.vo.Place;
+import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+
+@DisplayName("ScheduleCreateCommandFactory 테스트")
+public class ScheduleCreateCommandFactoryTest {
+
+    private ScheduleCreateCommandFactory scheduleCreateCommandFactory = new ScheduleCreateCommandFactory();
+
+    @DisplayName("tripId null -> 검증 예외 발생")
+    @Test
+    void nullTripIdTest() {
+        // given
+        Long dayId = 1L;
+        Long tripId = null;
+        String rawScheduleTitle = "일정 제목";
+        String placeId = "place-id";
+        String placeName = "place-name";
+        Double latitude = 39.123;
+        Double longitude = 123.7712;
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> scheduleCreateCommandFactory.createCommand(
+                        dayId, tripId, rawScheduleTitle,
+                        placeId, placeName,
+                        latitude, longitude),
+                CustomValidationException.class);
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(NullTripIdException.class);
+    }
+
+    @DisplayName("제목 null -> 검증 예외 발생")
+    @Test
+    void nullScheduleTitleTest() {
+        // given
+        Long dayId = 1L;
+        Long tripId = 1L;
+        String rawScheduleTitle = null;
+        String placeId = "place-id";
+        String placeName = "place-name";
+        Double latitude = 39.123;
+        Double longitude = 123.7712;
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> scheduleCreateCommandFactory.createCommand(
+                        dayId, tripId, rawScheduleTitle,
+                        placeId, placeName,
+                        latitude, longitude),
+                CustomValidationException.class);
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidScheduleTitleException.class);
+    }
+
+    @DisplayName("제목 빈 문자열 -> 검증 예외 발생")
+    @Test
+    void emptyScheduleTitleTest() {
+        // given
+        Long dayId = 1L;
+        Long tripId = 1L;
+        String rawScheduleTitle = "";
+        String placeId = "place-id";
+        String placeName = "place-name";
+        Double latitude = 39.123;
+        Double longitude = 123.7712;
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> scheduleCreateCommandFactory.createCommand(
+                        dayId, tripId, rawScheduleTitle,
+                        placeId, placeName,
+                        latitude, longitude),
+                CustomValidationException.class);
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidScheduleTitleException.class);
+    }
+
+    @DisplayName("제목 공백으로만 구성된 문자열 -> 검증 예외 발생")
+    @Test
+    void whiteSpaceScheduleTitleTest() {
+        // given
+        Long dayId = 1L;
+        Long tripId = 1L;
+        String rawScheduleTitle = "    ";
+        String placeId = "place-id";
+        String placeName = "place-name";
+        Double latitude = 39.123;
+        Double longitude = 123.7712;
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> scheduleCreateCommandFactory.createCommand(
+                        dayId, tripId, rawScheduleTitle,
+                        placeId, placeName,
+                        latitude, longitude),
+                CustomValidationException.class);
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidScheduleTitleException.class);
+    }
+
+    @DisplayName("제목이 제한 글자수보다 긴 문자열 -> 검증 예외 발생")
+    @Test
+    void tooLongScheduleTitleTest() {
+        // given
+        Long dayId = 1L;
+        Long tripId = 1L;
+        String rawScheduleTitle = "가".repeat(ScheduleTitle.MAX_LENGTH + 1);
+        String placeId = "place-id";
+        String placeName = "place-name";
+        Double latitude = 39.123;
+        Double longitude = 123.7712;
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> scheduleCreateCommandFactory.createCommand(
+                        dayId, tripId, rawScheduleTitle,
+                        placeId, placeName,
+                        latitude, longitude),
+                CustomValidationException.class);
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidScheduleTitleException.class);
+    }
+
+    @DisplayName("위도 누락 -> 검증 예외 발생")
+    @Test
+    void nullLatitudeTest() {
+        // given
+        Long dayId = 1L;
+        Long tripId = 1L;
+        String rawScheduleTitle = "일정 제목";
+        String placeId = "place-id";
+        String placeName = "place-name";
+        Double latitude = null;
+        Double longitude = 123.7712;
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> scheduleCreateCommandFactory.createCommand(
+                        dayId, tripId, rawScheduleTitle,
+                        placeId, placeName,
+                        latitude, longitude),
+                CustomValidationException.class);
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidCoordinateException.class);
+    }
+
+    @DisplayName("경도 누락 -> 검증 예외 발생")
+    @Test
+    void nullLongitudeTest() {
+        // given
+        Long dayId = 1L;
+        Long tripId = 1L;
+        String rawScheduleTitle = "일정 제목";
+        String placeId = "place-id";
+        String placeName = "place-name";
+        Double latitude = 39.123;
+        Double longitude = null;
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> scheduleCreateCommandFactory.createCommand(
+                        dayId, tripId, rawScheduleTitle,
+                        placeId, placeName,
+                        latitude, longitude),
+                CustomValidationException.class);
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidCoordinateException.class);
+    }
+
+    @DisplayName("위도, 경도 누락 -> 검증 예외 발생")
+    @Test
+    void nullLatitudeAndLongitudeTest() {
+        // given
+        Long dayId = 1L;
+        Long tripId = 1L;
+        String rawScheduleTitle = "일정 제목";
+        String placeId = "place-id";
+        String placeName = "place-name";
+        Double latitude = null;
+        Double longitude = null;
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> scheduleCreateCommandFactory.createCommand(
+                        dayId, tripId, rawScheduleTitle,
+                        placeId, placeName,
+                        latitude, longitude),
+                CustomValidationException.class);
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidCoordinateException.class);
+    }
+
+    @DisplayName("위도가 제한보다 작은 값 -> 검증 예외 발생")
+    @Test
+    void tooSmallLatitudeTest() {
+        // given
+        Long dayId = 1L;
+        Long tripId = 1L;
+        String rawScheduleTitle = "일정 제목";
+        String placeId = "place-id";
+        String placeName = "place-name";
+        Double latitude = Coordinate.MIN_LATITUDE - 0.001;
+        Double longitude = 127.123;
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> scheduleCreateCommandFactory.createCommand(
+                        dayId, tripId, rawScheduleTitle,
+                        placeId, placeName,
+                        latitude, longitude),
+                CustomValidationException.class);
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidCoordinateException.class);
+    }
+
+    @DisplayName("위도가 제한보다 큰 값 -> 검증 예외 발생")
+    @Test
+    void tooBigLatitudeTest() {
+        // given
+        Long dayId = 1L;
+        Long tripId = 1L;
+        String rawScheduleTitle = "일정 제목";
+        String placeId = "place-id";
+        String placeName = "place-name";
+        Double latitude = Coordinate.MAX_LATITUDE + 0.001;
+        Double longitude = 127.123;
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> scheduleCreateCommandFactory.createCommand(
+                        dayId, tripId, rawScheduleTitle,
+                        placeId, placeName,
+                        latitude, longitude),
+                CustomValidationException.class);
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidCoordinateException.class);
+    }
+
+    @DisplayName("경도가 제한보다 작은 값 -> 검증 예외 발생")
+    @Test
+    void tooSmallLongitudeTest() {
+        // given
+        Long dayId = 1L;
+        Long tripId = 1L;
+        String rawScheduleTitle = "일정 제목";
+        String placeId = "place-id";
+        String placeName = "place-name";
+        Double latitude = 37.1234;
+        Double longitude = Coordinate.MIN_LONGITUDE - 0.001;
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> scheduleCreateCommandFactory.createCommand(
+                        dayId, tripId, rawScheduleTitle,
+                        placeId, placeName,
+                        latitude, longitude),
+                CustomValidationException.class);
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidCoordinateException.class);
+    }
+
+    @DisplayName("경도가 제한보다 큰 값 -> 검증 예외 발생")
+    @Test
+    void tooBigLongitudeTest() {
+        // given
+        Long dayId = 1L;
+        Long tripId = 1L;
+        String rawScheduleTitle = "일정 제목";
+        String placeId = "place-id";
+        String placeName = "place-name";
+        Double latitude = 37.1234;
+        Double longitude = Coordinate.MAX_LONGITUDE + 0.001;
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> scheduleCreateCommandFactory.createCommand(
+                        dayId, tripId, rawScheduleTitle,
+                        placeId, placeName,
+                        latitude, longitude),
+                CustomValidationException.class);
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidCoordinateException.class);
+    }
+
+    @DisplayName("TripId, 제목 누락, 위도 누락 -> 검증 예외 발생")
+    @Test
+    void nullTripId_And_NullTitle_And_NullLatitudeTest() {
+        // given
+        Long dayId = 1L;
+        Long tripId = null;
+        String rawScheduleTitle = null;
+        String placeId = "place-id";
+        String placeName = "place-name";
+        Double latitude = null;
+        Double longitude = 37.124;
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> scheduleCreateCommandFactory.createCommand(
+                        dayId, tripId, rawScheduleTitle,
+                        placeId, placeName,
+                        latitude, longitude),
+                CustomValidationException.class);
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(3);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(NullTripIdException.class);
+        assertThat(cve.getExceptions().get(1)).isInstanceOf(InvalidScheduleTitleException.class);
+        assertThat(cve.getExceptions().get(2)).isInstanceOf(InvalidCoordinateException.class);
+    }
+
+    @DisplayName("정상 입력 -> command 정상 생성")
+    @Test
+    void successTest() {
+        // given
+        Long dayId = 1L;
+        Long tripId = 1L;
+        String rawScheduleTitle = "일정 제목";
+        String placeId = "place-id";
+        String placeName = "place-name";
+        Double latitude = 37.11924;
+        Double longitude = 123.1274;
+
+        // when
+        ScheduleCreateCommand command = scheduleCreateCommandFactory.createCommand(
+                dayId, tripId, rawScheduleTitle,
+                placeId, placeName,
+                latitude, longitude);
+
+
+        // then
+        assertThat(command).isNotNull();
+        assertThat(command.getDayId()).isEqualTo(dayId);
+        assertThat(command.getTripId()).isEqualTo(tripId);
+        assertThat(command.getScheduleTitle()).isEqualTo(ScheduleTitle.of(rawScheduleTitle));
+        assertThat(command.getPlace()).isEqualTo(Place.of(placeId, placeName, Coordinate.of(latitude, longitude)));
+    }
+}

--- a/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/dto/factory/ScheduleMoveCommandFactoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/dto/factory/ScheduleMoveCommandFactoryTest.java
@@ -1,0 +1,76 @@
+package com.cosain.trilo.unit.trip.application.schedule.command.dto.factory;
+
+import com.cosain.trilo.common.exception.CustomValidationException;
+import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleMoveCommand;
+import com.cosain.trilo.trip.application.schedule.command.usecase.dto.factory.ScheduleMoveCommandFactory;
+import com.cosain.trilo.trip.domain.exception.InvalidScheduleMoveTargetOrderException;
+import com.cosain.trilo.trip.domain.exception.InvalidScheduleTitleException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+
+@DisplayName("ScheduleMoveCommandFactory 테스트")
+public class ScheduleMoveCommandFactoryTest {
+
+    private ScheduleMoveCommandFactory scheduleMoveCommandFactory = new ScheduleMoveCommandFactory();
+
+    @DisplayName("tatgetOrder가 null -> 검증 에러")
+    @Test
+    public void nullTargetOrderTest() {
+        // given
+        Long targetDayId = 1L;
+        Integer targetOrder = null;
+
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> scheduleMoveCommandFactory.createCommand(targetDayId, targetOrder),
+                CustomValidationException.class);
+
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidScheduleMoveTargetOrderException.class);
+    }
+
+    @DisplayName("tatgetOrder가 음수 -> 검증 에러")
+    @Test
+    public void negativeTargetOrderTest() {
+        // given
+        Long targetDayId = 1L;
+        Integer targetOrder = -1;
+
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> scheduleMoveCommandFactory.createCommand(targetDayId, targetOrder),
+                CustomValidationException.class);
+
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidScheduleMoveTargetOrderException.class);
+    }
+
+    @DisplayName("targetOrder가 음이 아닌 정수 -> 성공")
+    @Test
+    public void successTest() {
+        // given
+        Long targetDayId = 1L;
+        Integer targetOrder = 0;
+
+
+        // when
+        ScheduleMoveCommand command = scheduleMoveCommandFactory.createCommand(targetDayId, targetOrder);
+
+
+        // then
+        assertThat(command).isNotNull();
+        assertThat(command.getTargetDayId()).isEqualTo(targetDayId);
+        assertThat(command.getTargetOrder()).isEqualTo(targetOrder);
+    }
+}

--- a/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/dto/factory/ScheduleUpdateCommandFactoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/dto/factory/ScheduleUpdateCommandFactoryTest.java
@@ -1,0 +1,91 @@
+package com.cosain.trilo.unit.trip.application.schedule.command.dto.factory;
+
+import com.cosain.trilo.common.exception.CustomValidationException;
+import com.cosain.trilo.trip.application.exception.NullTripIdException;
+import com.cosain.trilo.trip.application.schedule.command.usecase.dto.factory.ScheduleUpdateCommandFactory;
+import com.cosain.trilo.trip.domain.exception.InvalidScheduleTitleException;
+import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+
+@DisplayName("ScheduleUpdateCommandFactory 테스트")
+public class ScheduleUpdateCommandFactoryTest {
+
+    private ScheduleUpdateCommandFactory scheduleUpdateCommandFactory = new ScheduleUpdateCommandFactory();
+
+
+    @DisplayName("제목 null -> 검증 예외 발생")
+    @Test
+    void nullScheduleTitleTest() {
+        // given
+        String rawScheduleTitle = null;
+        String rawScheduleContent = "일정 본문";
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> scheduleUpdateCommandFactory.createCommand(rawScheduleTitle, rawScheduleContent),
+                CustomValidationException.class);
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidScheduleTitleException.class);
+    }
+
+    @DisplayName("제목 빈 문자열 -> 검증 예외 발생")
+    @Test
+    void emptyScheduleTitleTest() {
+        // given
+        String rawScheduleTitle = "";
+        String rawScheduleContent = "일정 본문";
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> scheduleUpdateCommandFactory.createCommand(rawScheduleTitle, rawScheduleContent),
+                CustomValidationException.class);
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidScheduleTitleException.class);
+    }
+
+    @DisplayName("제목 공백으로만 구성된 문자열 -> 검증 예외 발생")
+    @Test
+    void whiteSpaceScheduleTitleTest() {
+        // given
+        String rawScheduleTitle = "    ";
+        String rawScheduleContent = "일정 본문";
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> scheduleUpdateCommandFactory.createCommand(rawScheduleTitle, rawScheduleContent),
+                CustomValidationException.class);
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidScheduleTitleException.class);
+    }
+
+    @DisplayName("제목이 제한 글자수보다 긴 문자열 -> 검증 예외 발생")
+    @Test
+    void tooLongScheduleTitleTest() {
+        // given
+        String rawScheduleTitle = "가".repeat(ScheduleTitle.MAX_LENGTH + 1);
+        String rawScheduleContent = "일정 본문";
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> scheduleUpdateCommandFactory.createCommand(rawScheduleTitle, rawScheduleContent),
+                CustomValidationException.class);
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+    }
+
+}

--- a/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleCreateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleCreateServiceTest.java
@@ -70,13 +70,18 @@ public class ScheduleCreateServiceTest {
 
             trip.getDays().add(day);
 
-            ScheduleCreateCommand scheduleCreateCommand = ScheduleCreateCommand.of(dayId, tripId, "일정 제목", "장소식별자", "장소명", 23.21, 23.24);
+            ScheduleCreateCommand scheduleCreateCommand = ScheduleCreateCommand.builder()
+                    .dayId(dayId)
+                    .tripId(tripId)
+                    .scheduleTitle(ScheduleTitle.of("일정 제목"))
+                    .place(Place.of("장소식별자", "장소명", Coordinate.of(23.21, 23.24)))
+                    .build();
 
             Schedule createdSchedule = Schedule.builder()
                     .id(1L)
                     .day(day)
                     .trip(trip)
-                    .title("일정 제목")
+                    .scheduleTitle(ScheduleTitle.of("일정 제목"))
                     .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
                     .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                     .build();
@@ -122,14 +127,19 @@ public class ScheduleCreateServiceTest {
                     .id(1L)
                     .day(beforeDay)
                     .trip(beforeTrip)
-                    .title("제목")
+                    .scheduleTitle(ScheduleTitle.of("제목"))
                     .place(Place.of("장소식별자", "장소명", Coordinate.of(23.21, 23.24)))
                     .scheduleIndex(ScheduleIndex.of(ScheduleIndex.MAX_INDEX_VALUE))
                     .build();
             beforeDay.getSchedules().add(beforeSchedule);
             beforeTrip.getDays().add(beforeDay);
 
-            ScheduleCreateCommand scheduleCreateCommand = ScheduleCreateCommand.of(dayId, tripId, "일정 제목", "장소식별자", "장소명", 23.21, 23.24);
+            ScheduleCreateCommand scheduleCreateCommand = ScheduleCreateCommand.builder()
+                    .dayId(dayId)
+                    .tripId(tripId)
+                    .scheduleTitle(ScheduleTitle.of("일정 제목"))
+                    .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
+                    .build();
 
 
             Trip rediscoveredTrip = Trip.builder()
@@ -150,7 +160,7 @@ public class ScheduleCreateServiceTest {
                     .id(1L)
                     .day(rediscoveredDay)
                     .trip(rediscoveredTrip)
-                    .title("제목")
+                    .scheduleTitle(ScheduleTitle.of("제목"))
                     .place(Place.of("장소식별자", "장소명", Coordinate.of(23.21, 23.24)))
                     .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                     .build();
@@ -162,7 +172,7 @@ public class ScheduleCreateServiceTest {
                     .id(2L)
                     .day(rediscoveredDay)
                     .trip(rediscoveredTrip)
-                    .title("일정 제목")
+                    .scheduleTitle(ScheduleTitle.of("일정 제목"))
                     .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
                     .scheduleIndex(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP))
                     .build();
@@ -208,13 +218,18 @@ public class ScheduleCreateServiceTest {
                     .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
                     .build();
 
-            ScheduleCreateCommand scheduleCreateCommand = ScheduleCreateCommand.of(null, tripId, "일정 제목", "장소식별자", "장소명", 23.21, 23.24);
+            ScheduleCreateCommand scheduleCreateCommand = ScheduleCreateCommand.builder()
+                    .dayId(null)
+                    .tripId(tripId)
+                    .scheduleTitle(ScheduleTitle.of("일정 제목"))
+                    .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
+                    .build();
 
             Schedule createdSchedule = Schedule.builder()
                     .id(1L)
                     .day(null)
                     .trip(trip)
-                    .title("일정 제목")
+                    .scheduleTitle(ScheduleTitle.of("일정 제목"))
                     .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
                     .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                     .build();
@@ -244,7 +259,7 @@ public class ScheduleCreateServiceTest {
                     .id(1L)
                     .day(null)
                     .trip(trip)
-                    .title("제목")
+                    .scheduleTitle(ScheduleTitle.of("제목"))
                     .place(Place.of("장소식별자", "장소명", Coordinate.of(23.21, 23.24)))
                     .scheduleIndex(ScheduleIndex.of(ScheduleIndex.MAX_INDEX_VALUE))
                     .build();
@@ -255,19 +270,24 @@ public class ScheduleCreateServiceTest {
                     .id(1L)
                     .day(null)
                     .trip(trip)
-                    .title("제목")
+                    .scheduleTitle(ScheduleTitle.of("제목"))
                     .place(Place.of("장소식별자", "장소명", Coordinate.of(23.21, 23.24)))
                     .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                     .build();
             rediscoveredTrip.getTemporaryStorage().add(relocatedSchedule);
 
-            ScheduleCreateCommand scheduleCreateCommand = ScheduleCreateCommand.of(null, tripId, "일정제목2", "장소식별자2", "장소이름2", 19.18, 27.15);
+            ScheduleCreateCommand scheduleCreateCommand = ScheduleCreateCommand.builder()
+                    .dayId(null)
+                    .tripId(tripId)
+                    .scheduleTitle(ScheduleTitle.of("일정제목2"))
+                    .place(Place.of("장소식별자2", "장소이름2", Coordinate.of(19.18, 27.15)))
+                    .build();
 
             Schedule newSchedule = Schedule.builder()
                     .id(2L)
                     .day(null)
                     .trip(trip)
-                    .title("일정제목2")
+                    .scheduleTitle(ScheduleTitle.of("일정제목2"))
                     .place(Place.of("장소식별자2", "장소이름2", Coordinate.of(19.18, 27.15)))
                     .scheduleIndex(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP))
                     .build();
@@ -294,20 +314,29 @@ public class ScheduleCreateServiceTest {
     @DisplayName("권한 없는 사람이 Schedule을 생성하면, NoScheduleCreateAuthortyException이 발생한다.")
     public void when_no_authority_tripper_create_schedule_it_throws_NoScheduleCreateAuthorityException() {
         // given
+        Long tripOwnerId = 1L;
         Long noAuthorityTripperId = 2L;
+        Long tripId = 3L;
+        Long dayId = 4L;
 
-        Trip trip = Trip.create(TripTitle.of("제목"), 1L);
+        Trip trip = Trip.create(TripTitle.of("제목"), tripOwnerId);
         Day day = Day.of(LocalDate.of(2023, 4, 5), trip);
 
-        ScheduleCreateCommand scheduleCreateCommand = ScheduleCreateCommand.of(1L, 1L, "제목", "내용", "장소 식별자", 23.21, 23.24);
-        given(dayRepository.findByIdWithTrip(anyLong())).willReturn(Optional.of(day));
-        given(tripRepository.findById(anyLong())).willReturn(Optional.of(trip));
+        ScheduleCreateCommand scheduleCreateCommand = ScheduleCreateCommand.builder()
+                .dayId(dayId)
+                .tripId(tripId)
+                .scheduleTitle(ScheduleTitle.of("제목"))
+                .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
+                .build();
+
+        given(dayRepository.findByIdWithTrip(eq(dayId))).willReturn(Optional.of(day));
+        given(tripRepository.findById(eq(tripId))).willReturn(Optional.of(trip));
 
         // when & then
         assertThatThrownBy(() -> scheduleCreateService.createSchedule(noAuthorityTripperId, scheduleCreateCommand))
                 .isInstanceOf(NoScheduleCreateAuthorityException.class);
-        verify(dayRepository).findByIdWithTrip(anyLong());
-        verify(tripRepository).findById(anyLong());
+        verify(dayRepository).findByIdWithTrip(eq(dayId));
+        verify(tripRepository).findById(eq(tripId));
     }
 
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleCreateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleCreateServiceTest.java
@@ -57,7 +57,7 @@ public class ScheduleCreateServiceTest {
             Trip trip = Trip.builder()
                     .id(tripId)
                     .tripperId(tripperId)
-                    .title("여행 제목")
+                    .tripTitle(TripTitle.of("여행 제목"))
                     .status(TripStatus.DECIDED)
                     .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
                     .build();
@@ -106,7 +106,7 @@ public class ScheduleCreateServiceTest {
             Trip beforeTrip = Trip.builder()
                     .id(tripId)
                     .tripperId(tripperId)
-                    .title("여행 제목")
+                    .tripTitle(TripTitle.of("여행 제목"))
                     .status(TripStatus.DECIDED)
                     .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
                     .build();
@@ -135,7 +135,7 @@ public class ScheduleCreateServiceTest {
             Trip rediscoveredTrip = Trip.builder()
                     .id(tripId)
                     .tripperId(tripperId)
-                    .title("여행 제목")
+                    .tripTitle(TripTitle.of("여행 제목"))
                     .status(TripStatus.DECIDED)
                     .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
                     .build();
@@ -203,7 +203,7 @@ public class ScheduleCreateServiceTest {
             Trip trip = Trip.builder()
                     .id(tripId)
                     .tripperId(tripperId)
-                    .title("여행 제목")
+                    .tripTitle(TripTitle.of("여행 제목"))
                     .status(TripStatus.DECIDED)
                     .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
                     .build();
@@ -296,7 +296,7 @@ public class ScheduleCreateServiceTest {
         // given
         Long noAuthorityTripperId = 2L;
 
-        Trip trip = Trip.create("제목", 1L);
+        Trip trip = Trip.create(TripTitle.of("제목"), 1L);
         Day day = Day.of(LocalDate.of(2023, 4, 5), trip);
 
         ScheduleCreateCommand scheduleCreateCommand = ScheduleCreateCommand.of(1L, 1L, "제목", "내용", "장소 식별자", 23.21, 23.24);

--- a/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleDeleteServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleDeleteServiceTest.java
@@ -9,6 +9,7 @@ import com.cosain.trilo.trip.domain.entity.Trip;
 import com.cosain.trilo.trip.domain.repository.ScheduleRepository;
 import com.cosain.trilo.trip.domain.vo.Coordinate;
 import com.cosain.trilo.trip.domain.vo.Place;
+import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -71,7 +72,7 @@ public class ScheduleDeleteServiceTest {
             Day day = Day.of(LocalDate.of(2023,3,1),trip);
             Schedule schedule = Schedule.builder()
                             .id(scheduleId)
-                            .title("일정")
+                            .scheduleTitle(ScheduleTitle.of("일정"))
                             .day(day)
                             .trip(trip)
                             .place(Place.of("place-id", "광안리 해수욕장", Coordinate.of(35.1551, 129.1220)))
@@ -100,7 +101,7 @@ public class ScheduleDeleteServiceTest {
         Day day = Day.of(LocalDate.of(2023,3,1),trip);
         Schedule schedule = Schedule.builder()
                 .id(scheduleId)
-                .title("일정")
+                .scheduleTitle(ScheduleTitle.of("일정"))
                 .day(day)
                 .trip(trip)
                 .place(Place.of("place-id", "광안리 해수욕장", Coordinate.of(35.1551, 129.1220)))

--- a/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleMoveServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleMoveServiceTest.java
@@ -76,7 +76,7 @@ public class ScheduleMoveServiceTest {
         Trip trip = Trip.builder()
                 .id(tripId)
                 .tripperId(tripperId)
-                .title("여행 제목")
+                .tripTitle(TripTitle.of("여행 제목"))
                 .status(TripStatus.DECIDED)
                 .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
                 .build();
@@ -120,7 +120,7 @@ public class ScheduleMoveServiceTest {
         Trip trip = Trip.builder()
                 .id(tripId)
                 .tripperId(tripperId)
-                .title("여행 제목")
+                .tripTitle(TripTitle.of("여행 제목"))
                 .status(TripStatus.DECIDED)
                 .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
                 .build();
@@ -170,7 +170,7 @@ public class ScheduleMoveServiceTest {
         Trip trip = Trip.builder()
                 .id(tripId)
                 .tripperId(tripperId)
-                .title("여행 제목")
+                .tripTitle(TripTitle.of("여행 제목"))
                 .status(TripStatus.DECIDED)
                 .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
                 .build();
@@ -224,7 +224,7 @@ public class ScheduleMoveServiceTest {
         Trip beforeTrip = Trip.builder()
                 .id(tripId)
                 .tripperId(tripperId)
-                .title("여행 제목")
+                .tripTitle(TripTitle.of("여행 제목"))
                 .status(TripStatus.DECIDED)
                 .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
                 .build();
@@ -256,7 +256,7 @@ public class ScheduleMoveServiceTest {
         Trip rediscoveredTrip = Trip.builder()
                 .id(tripId)
                 .tripperId(tripperId)
-                .title("여행 제목")
+                .tripTitle(TripTitle.of("여행 제목"))
                 .status(TripStatus.DECIDED)
                 .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
                 .build();
@@ -323,7 +323,7 @@ public class ScheduleMoveServiceTest {
         Trip beforeTrip = Trip.builder()
                 .id(tripId)
                 .tripperId(tripperId)
-                .title("여행 제목")
+                .tripTitle(TripTitle.of("여행 제목"))
                 .status(TripStatus.DECIDED)
                 .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
                 .build();
@@ -355,7 +355,7 @@ public class ScheduleMoveServiceTest {
         Trip rediscoveredTrip = Trip.builder()
                 .id(tripId)
                 .tripperId(tripperId)
-                .title("여행 제목")
+                .tripTitle(TripTitle.of("여행 제목"))
                 .status(TripStatus.DECIDED)
                 .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
                 .build();
@@ -422,7 +422,7 @@ public class ScheduleMoveServiceTest {
         Trip beforeTrip = Trip.builder()
                 .id(tripId)
                 .tripperId(tripperId)
-                .title("여행 제목")
+                .tripTitle(TripTitle.of("여행 제목"))
                 .status(TripStatus.DECIDED)
                 .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
                 .build();
@@ -463,7 +463,7 @@ public class ScheduleMoveServiceTest {
         Trip rediscoveredTrip = Trip.builder()
                 .id(tripId)
                 .tripperId(tripperId)
-                .title("여행 제목")
+                .tripTitle(TripTitle.of("여행 제목"))
                 .status(TripStatus.DECIDED)
                 .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
                 .build();

--- a/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleMoveServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleMoveServiceTest.java
@@ -52,7 +52,7 @@ public class ScheduleMoveServiceTest {
         Long targetDayId = 2L;
         int targetOrder = 3;
 
-        ScheduleMoveCommand moveCommand = ScheduleMoveCommand.of(targetDayId, targetOrder);
+        ScheduleMoveCommand moveCommand = new ScheduleMoveCommand(targetDayId, targetOrder);
         given(scheduleRepository.findByIdWithTrip(eq(notExistScheduleId))).willReturn(Optional.empty());
 
 
@@ -91,8 +91,7 @@ public class ScheduleMoveServiceTest {
                 .build();
         trip.getTemporaryStorage().add(schedule);
 
-        ScheduleMoveCommand moveCommand = ScheduleMoveCommand.of(notExistTargetDayId, targetOrder);
-
+        ScheduleMoveCommand moveCommand = new ScheduleMoveCommand(notExistTargetDayId, targetOrder);
         given(scheduleRepository.findByIdWithTrip(eq(scheduleId))).willReturn(Optional.of(schedule));
         given(dayRepository.findByIdWithTrip(eq(notExistTargetDayId))).willReturn(Optional.empty());
 
@@ -142,7 +141,7 @@ public class ScheduleMoveServiceTest {
                 .build();
         trip.getTemporaryStorage().add(schedule);
 
-        ScheduleMoveCommand moveCommand = ScheduleMoveCommand.of(targetDayId, targetOrder);
+        ScheduleMoveCommand moveCommand = new ScheduleMoveCommand(targetDayId, targetOrder);
 
         given(scheduleRepository.findByIdWithTrip(eq(scheduleId))).willReturn(Optional.of(schedule));
         given(dayRepository.findByIdWithTrip(eq(targetDayId))).willReturn(Optional.of(day));
@@ -192,7 +191,7 @@ public class ScheduleMoveServiceTest {
                 .build();
         trip.getTemporaryStorage().add(schedule);
 
-        ScheduleMoveCommand moveCommand = ScheduleMoveCommand.of(targetDayId, targetOrder);
+        ScheduleMoveCommand moveCommand = new ScheduleMoveCommand(targetDayId, targetOrder);
 
         given(scheduleRepository.findByIdWithTrip(eq(scheduleId))).willReturn(Optional.of(schedule));
         given(dayRepository.findByIdWithTrip(eq(targetDayId))).willReturn(Optional.of(day));
@@ -285,7 +284,8 @@ public class ScheduleMoveServiceTest {
         rediscoveredTargetDay.getSchedules().add(rediscoveredTargetDaySchedule);
         rediscoveredTrip.getTemporaryStorage().add(rediscoveredMoveSchedule);
 
-        ScheduleMoveCommand moveCommand = ScheduleMoveCommand.of(targetDayId, targetOrder);
+        ScheduleMoveCommand moveCommand = new ScheduleMoveCommand(targetDayId, targetOrder);
+
 
         when(scheduleRepository.findByIdWithTrip(eq(scheduleId)))
                 .thenReturn(Optional.of(beforeMoveSchedule))
@@ -384,7 +384,7 @@ public class ScheduleMoveServiceTest {
         rediscoveredTargetDay.getSchedules().add(rediscoveredTargetDaySchedule);
         rediscoveredTrip.getTemporaryStorage().add(rediscoveredMoveSchedule);
 
-        ScheduleMoveCommand moveCommand = ScheduleMoveCommand.of(targetDayId, targetOrder);
+        ScheduleMoveCommand moveCommand = new ScheduleMoveCommand(targetDayId, targetOrder);
 
         when(scheduleRepository.findByIdWithTrip(eq(scheduleId)))
                 .thenReturn(Optional.of(beforeMoveSchedule))
@@ -501,7 +501,7 @@ public class ScheduleMoveServiceTest {
         rediscoveredTargetDay.getSchedules().add(rediscoveredTargetDaySchedule2);
         rediscoveredTrip.getTemporaryStorage().add(rediscoveredMoveSchedule);
 
-        ScheduleMoveCommand moveCommand = ScheduleMoveCommand.of(targetDayId, targetOrder);
+        ScheduleMoveCommand moveCommand = new ScheduleMoveCommand(targetDayId, targetOrder);
 
         when(scheduleRepository.findByIdWithTrip(eq(scheduleId)))
                 .thenReturn(Optional.of(beforeMoveSchedule))

--- a/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleMoveServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleMoveServiceTest.java
@@ -85,7 +85,7 @@ public class ScheduleMoveServiceTest {
                 .id(scheduleId)
                 .day(null)
                 .trip(trip)
-                .title("일정 제목")
+                .scheduleTitle(ScheduleTitle.of("일정 제목"))
                 .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
                 .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                 .build();
@@ -136,7 +136,7 @@ public class ScheduleMoveServiceTest {
                 .id(scheduleId)
                 .day(null)
                 .trip(trip)
-                .title("일정 제목")
+                .scheduleTitle(ScheduleTitle.of("일정 제목"))
                 .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
                 .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                 .build();
@@ -186,7 +186,7 @@ public class ScheduleMoveServiceTest {
                 .id(scheduleId)
                 .day(null)
                 .trip(trip)
-                .title("일정 제목")
+                .scheduleTitle(ScheduleTitle.of("일정 제목"))
                 .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
                 .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                 .build();
@@ -237,7 +237,7 @@ public class ScheduleMoveServiceTest {
                 .id(scheduleId)
                 .day(beforeTargetDay)
                 .trip(beforeTrip)
-                .title("일정 제목1")
+                .scheduleTitle(ScheduleTitle.of("일정 제목1"))
                 .place(Place.of("장소 식별자1", "장소명2", Coordinate.of(23.21, 23.24)))
                 .scheduleIndex(ScheduleIndex.of(ScheduleIndex.MAX_INDEX_VALUE))
                 .build();
@@ -245,7 +245,7 @@ public class ScheduleMoveServiceTest {
                 .id(scheduleId)
                 .day(null)
                 .trip(beforeTrip)
-                .title("일정 제목2")
+                .scheduleTitle(ScheduleTitle.of("일정 제목2"))
                 .place(Place.of("장소 식별자2", "장소명2", Coordinate.of(23.21, 23.24)))
                 .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                 .build();
@@ -269,7 +269,7 @@ public class ScheduleMoveServiceTest {
                 .id(scheduleId)
                 .day(rediscoveredTargetDay)
                 .trip(rediscoveredTrip)
-                .title("일정 제목1")
+                .scheduleTitle(ScheduleTitle.of("일정 제목1"))
                 .place(Place.of("장소 식별자1", "장소명2", Coordinate.of(23.21, 23.24)))
                 .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                 .build();
@@ -277,7 +277,7 @@ public class ScheduleMoveServiceTest {
                 .id(scheduleId)
                 .day(null)
                 .trip(rediscoveredTrip)
-                .title("일정 제목")
+                .scheduleTitle(ScheduleTitle.of("일정 제목"))
                 .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
                 .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                 .build();
@@ -336,7 +336,7 @@ public class ScheduleMoveServiceTest {
                 .id(scheduleId)
                 .day(beforeTargetDay)
                 .trip(beforeTrip)
-                .title("일정 제목1")
+                .scheduleTitle(ScheduleTitle.of("일정 제목1"))
                 .place(Place.of("장소 식별자1", "장소명2", Coordinate.of(23.21, 23.24)))
                 .scheduleIndex(ScheduleIndex.of(ScheduleIndex.MIN_INDEX_VALUE))
                 .build();
@@ -344,7 +344,7 @@ public class ScheduleMoveServiceTest {
                 .id(scheduleId)
                 .day(null)
                 .trip(beforeTrip)
-                .title("일정 제목2")
+                .scheduleTitle(ScheduleTitle.of("일정 제목2"))
                 .place(Place.of("장소 식별자2", "장소명2", Coordinate.of(23.21, 23.24)))
                 .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                 .build();
@@ -368,7 +368,7 @@ public class ScheduleMoveServiceTest {
                 .id(scheduleId)
                 .day(rediscoveredTargetDay)
                 .trip(rediscoveredTrip)
-                .title("일정 제목1")
+                .scheduleTitle(ScheduleTitle.of("일정 제목1"))
                 .place(Place.of("장소 식별자1", "장소명2", Coordinate.of(23.21, 23.24)))
                 .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                 .build();
@@ -376,7 +376,7 @@ public class ScheduleMoveServiceTest {
                 .id(scheduleId)
                 .day(null)
                 .trip(rediscoveredTrip)
-                .title("일정 제목")
+                .scheduleTitle(ScheduleTitle.of("일정 제목"))
                 .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
                 .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                 .build();
@@ -435,7 +435,7 @@ public class ScheduleMoveServiceTest {
                 .id(scheduleId)
                 .day(beforeTargetDay)
                 .trip(beforeTrip)
-                .title("일정 제목1")
+                .scheduleTitle(ScheduleTitle.of("일정 제목1"))
                 .place(Place.of("장소 식별자1", "장소명1", Coordinate.of(23.21, 23.24)))
                 .scheduleIndex(ScheduleIndex.of(10))
                 .build();
@@ -443,7 +443,7 @@ public class ScheduleMoveServiceTest {
                 .id(scheduleId)
                 .day(beforeTargetDay)
                 .trip(beforeTrip)
-                .title("일정 제목2")
+                .scheduleTitle(ScheduleTitle.of("일정 제목2"))
                 .place(Place.of("장소 식별자2", "장소명2", Coordinate.of(23.21, 23.24)))
                 .scheduleIndex(ScheduleIndex.of(11))
                 .build();
@@ -451,7 +451,7 @@ public class ScheduleMoveServiceTest {
                 .id(scheduleId)
                 .day(null)
                 .trip(beforeTrip)
-                .title("일정 제목3")
+                .scheduleTitle(ScheduleTitle.of("일정 제목3"))
                 .place(Place.of("장소 식별자3", "장소명3", Coordinate.of(23.21, 23.24)))
                 .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                 .build();
@@ -476,7 +476,7 @@ public class ScheduleMoveServiceTest {
                 .id(scheduleId)
                 .day(rediscoveredTargetDay)
                 .trip(rediscoveredTrip)
-                .title("일정 제목1")
+                .scheduleTitle(ScheduleTitle.of("일정 제목1"))
                 .place(Place.of("장소 식별자1", "장소명1", Coordinate.of(23.21, 23.24)))
                 .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                 .build();
@@ -484,7 +484,7 @@ public class ScheduleMoveServiceTest {
                 .id(scheduleId)
                 .day(rediscoveredTargetDay)
                 .trip(rediscoveredTrip)
-                .title("일정 제목2")
+                .scheduleTitle(ScheduleTitle.of("일정 제목2"))
                 .place(Place.of("장소 식별자2", "장소명2", Coordinate.of(23.21, 23.24)))
                 .scheduleIndex(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP))
                 .build();
@@ -492,7 +492,7 @@ public class ScheduleMoveServiceTest {
                 .id(scheduleId)
                 .day(null)
                 .trip(rediscoveredTrip)
-                .title("일정 제목")
+                .scheduleTitle(ScheduleTitle.of("일정 제목"))
                 .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
                 .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                 .build();

--- a/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleUpdateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleUpdateServiceTest.java
@@ -1,12 +1,13 @@
 package com.cosain.trilo.unit.trip.application.schedule.command.service;
 
-import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleUpdateCommand;
 import com.cosain.trilo.trip.application.exception.NoScheduleUpdateAuthorityException;
 import com.cosain.trilo.trip.application.exception.ScheduleNotFoundException;
 import com.cosain.trilo.trip.application.schedule.command.service.ScheduleUpdateService;
+import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleUpdateCommand;
 import com.cosain.trilo.trip.domain.entity.Schedule;
 import com.cosain.trilo.trip.domain.entity.Trip;
 import com.cosain.trilo.trip.domain.repository.ScheduleRepository;
+import com.cosain.trilo.trip.domain.vo.TripTitle;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,7 +18,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -38,7 +38,7 @@ public class ScheduleUpdateServiceTest {
         ScheduleUpdateCommand command = ScheduleUpdateCommand.of("변경할 제목", "변경할 내용");
 
         Schedule schedule = Schedule.builder()
-                .trip(Trip.create("여행 제목", 1L))
+                .trip(Trip.create(TripTitle.of("여행 제목"), 1L))
                 .title("원래 제목")
                 .content("원래 내용")
                 .build();
@@ -58,7 +58,7 @@ public class ScheduleUpdateServiceTest {
         ScheduleUpdateCommand command = ScheduleUpdateCommand.of("변경할 제목", "변경할 내용");
 
         Schedule schedule = Schedule.builder()
-                .trip(Trip.create("여행 제목", 2L))
+                .trip(Trip.create(TripTitle.of("여행 제목"), 2L))
                 .title("원래 제목")
                 .content("원래 내용")
                 .build();

--- a/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleUpdateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleUpdateServiceTest.java
@@ -37,7 +37,7 @@ public class ScheduleUpdateServiceTest {
     @DisplayName("호출이 제대로 이루어 지는지 테스트")
     public void update_schedule_test(){
         // given
-        ScheduleUpdateCommand command = ScheduleUpdateCommand.of("변경할 제목", "변경할 내용");
+        ScheduleUpdateCommand command = new ScheduleUpdateCommand(ScheduleTitle.of("변경할 제목"), ScheduleContent.of("변경할 내용"));
 
         Schedule schedule = Schedule.builder()
                 .trip(Trip.create(TripTitle.of("여행 제목"), 1L))
@@ -57,7 +57,7 @@ public class ScheduleUpdateServiceTest {
     @DisplayName("권한이 없는 사람이 Schedule 을 변경하려고 하면, NoScheduleUpdateAuthorityException 이 발생한다")
     public void when_no_authority_user_try_update_test(){
         // given
-        ScheduleUpdateCommand command = ScheduleUpdateCommand.of("변경할 제목", "변경할 내용");
+        ScheduleUpdateCommand command = new ScheduleUpdateCommand(ScheduleTitle.of("변경할 제목"), ScheduleContent.of("변경할 내용"));
 
         Schedule schedule = Schedule.builder()
                 .trip(Trip.create(TripTitle.of("여행 제목"), 2L))
@@ -75,7 +75,7 @@ public class ScheduleUpdateServiceTest {
     @DisplayName("일정이 존재하지 않는다면, ScheduleNotFoundException 이 발생한다")
     public void when_no_schedule_test(){
         // given
-        ScheduleUpdateCommand command = ScheduleUpdateCommand.of("변경할 제목", "변경할 내용");
+        ScheduleUpdateCommand command = new ScheduleUpdateCommand(ScheduleTitle.of("변경할 제목"), ScheduleContent.of("변경할 내용"));
         given(scheduleRepository.findByIdWithTrip(anyLong())).willReturn(Optional.empty());
 
         // when & then

--- a/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleUpdateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleUpdateServiceTest.java
@@ -7,6 +7,7 @@ import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleUp
 import com.cosain.trilo.trip.domain.entity.Schedule;
 import com.cosain.trilo.trip.domain.entity.Trip;
 import com.cosain.trilo.trip.domain.repository.ScheduleRepository;
+import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
 import com.cosain.trilo.trip.domain.vo.TripTitle;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -39,7 +40,7 @@ public class ScheduleUpdateServiceTest {
 
         Schedule schedule = Schedule.builder()
                 .trip(Trip.create(TripTitle.of("여행 제목"), 1L))
-                .title("원래 제목")
+                .scheduleTitle(ScheduleTitle.of("원래 제목"))
                 .content("원래 내용")
                 .build();
 
@@ -59,7 +60,7 @@ public class ScheduleUpdateServiceTest {
 
         Schedule schedule = Schedule.builder()
                 .trip(Trip.create(TripTitle.of("여행 제목"), 2L))
-                .title("원래 제목")
+                .scheduleTitle(ScheduleTitle.of("원래 제목"))
                 .content("원래 내용")
                 .build();
 

--- a/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleUpdateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleUpdateServiceTest.java
@@ -7,6 +7,7 @@ import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleUp
 import com.cosain.trilo.trip.domain.entity.Schedule;
 import com.cosain.trilo.trip.domain.entity.Trip;
 import com.cosain.trilo.trip.domain.repository.ScheduleRepository;
+import com.cosain.trilo.trip.domain.vo.ScheduleContent;
 import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
 import com.cosain.trilo.trip.domain.vo.TripTitle;
 import org.assertj.core.api.Assertions;
@@ -41,7 +42,7 @@ public class ScheduleUpdateServiceTest {
         Schedule schedule = Schedule.builder()
                 .trip(Trip.create(TripTitle.of("여행 제목"), 1L))
                 .scheduleTitle(ScheduleTitle.of("원래 제목"))
-                .content("원래 내용")
+                .scheduleContent(ScheduleContent.of("원래 내용"))
                 .build();
 
         given(scheduleRepository.findByIdWithTrip(anyLong())).willReturn(Optional.of(schedule));
@@ -61,7 +62,7 @@ public class ScheduleUpdateServiceTest {
         Schedule schedule = Schedule.builder()
                 .trip(Trip.create(TripTitle.of("여행 제목"), 2L))
                 .scheduleTitle(ScheduleTitle.of("원래 제목"))
-                .content("원래 내용")
+                .scheduleContent(ScheduleContent.of("원래 내용"))
                 .build();
 
         given(scheduleRepository.findByIdWithTrip(anyLong())).willReturn(Optional.of(schedule));

--- a/src/test/java/com/cosain/trilo/unit/trip/application/trip/command/dto/factory/TripCreateCommandFactoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/trip/command/dto/factory/TripCreateCommandFactoryTest.java
@@ -1,0 +1,102 @@
+package com.cosain.trilo.unit.trip.application.trip.command.dto.factory;
+
+import com.cosain.trilo.common.exception.CustomValidationException;
+import com.cosain.trilo.trip.application.trip.command.usecase.dto.TripCreateCommand;
+import com.cosain.trilo.trip.application.trip.command.usecase.dto.factory.TripCreateCommandFactory;
+import com.cosain.trilo.trip.domain.exception.InvalidTripTitleException;
+import com.cosain.trilo.trip.domain.vo.TripTitle;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+
+@Slf4j
+@DisplayName("TripCreateCommandFactory 테스트")
+public class TripCreateCommandFactoryTest {
+
+    private TripCreateCommandFactory tripCreateCommandFactory = new TripCreateCommandFactory();
+
+    @DisplayName("제목 null -> 검증예외 발생")
+    @Test
+    public void testNullTitle() {
+        // given
+        String nullTitle = null;
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> tripCreateCommandFactory.createCommand(nullTitle),
+                CustomValidationException.class);
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidTripTitleException.class);
+    }
+
+    @DisplayName("제목 빈문자열 -> 검증예외 발생")
+    @Test
+    public void emptyTitle() {
+        // given
+        String emptyTitle = "";
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> tripCreateCommandFactory.createCommand(emptyTitle),
+                CustomValidationException.class);
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidTripTitleException.class);
+    }
+
+    @DisplayName("제목 공백으로만 구성 -> 검증예외 발생")
+    @Test
+    public void whiteSpaceTitle() {
+        // given
+        String whiteSpaceTitle = "    ";
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> tripCreateCommandFactory.createCommand(whiteSpaceTitle),
+                CustomValidationException.class);
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidTripTitleException.class);
+    }
+
+    @DisplayName("제한보다 긴 제목 -> 검증예외 발생")
+    @Test
+    public void tooLongTitle() {
+        // given
+        String tooLongTitle = "가".repeat(TripTitle.MAX_LENGTH + 1);
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> tripCreateCommandFactory.createCommand(tooLongTitle),
+                CustomValidationException.class);
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidTripTitleException.class);
+    }
+
+    @DisplayName("제목이 올바른 길이 -> 정상 생성")
+    @Test
+    public void createSuccessTest() {
+        // given
+        String normalTitle = "제목";
+
+        // when
+        TripCreateCommand createCommand = tripCreateCommandFactory.createCommand(normalTitle);
+
+        // then
+        assertThat(createCommand).isNotNull();
+        assertThat(createCommand.getTripTitle()).isEqualTo(TripTitle.of(normalTitle));
+    }
+}

--- a/src/test/java/com/cosain/trilo/unit/trip/application/trip/command/dto/factory/TripUpdateCommandFactoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/trip/command/dto/factory/TripUpdateCommandFactoryTest.java
@@ -1,0 +1,175 @@
+package com.cosain.trilo.unit.trip.application.trip.command.dto.factory;
+
+import com.cosain.trilo.common.exception.CustomValidationException;
+import com.cosain.trilo.trip.application.trip.command.usecase.dto.TripUpdateCommand;
+import com.cosain.trilo.trip.application.trip.command.usecase.dto.factory.TripUpdateCommandFactory;
+import com.cosain.trilo.trip.domain.exception.InvalidPeriodException;
+import com.cosain.trilo.trip.domain.exception.InvalidTripTitleException;
+import com.cosain.trilo.trip.domain.vo.TripPeriod;
+import com.cosain.trilo.trip.domain.vo.TripTitle;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+
+@Slf4j
+@DisplayName("TripUpdateCommandFactory 테스트")
+public class TripUpdateCommandFactoryTest {
+
+    private TripUpdateCommandFactory tripUpdateCommandFactory = new TripUpdateCommandFactory();
+
+    @DisplayName("제목 null -> 검증예외 발생")
+    @Test
+    public void testNullTitle() {
+        // given
+        String nullTitle = null;
+        LocalDate startDate = null;
+        LocalDate endDate = null;
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> tripUpdateCommandFactory.createCommand(nullTitle, startDate, endDate),
+                CustomValidationException.class);
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidTripTitleException.class);
+    }
+
+    @DisplayName("제목 빈문자열 -> 검증예외 발생")
+    @Test
+    public void emptyTitle() {
+        // given
+        String emptyTitle = "";
+        LocalDate startDate = null;
+        LocalDate endDate = null;
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> tripUpdateCommandFactory.createCommand(emptyTitle, startDate, endDate),
+                CustomValidationException.class);
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidTripTitleException.class);
+    }
+
+    @DisplayName("제목 공백으로만 구성 -> 검증예외 발생")
+    @Test
+    public void whiteSpaceTitle() {
+        // given
+        String whiteSpaceTitle = "    ";
+        LocalDate startDate = null;
+        LocalDate endDate = null;
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> tripUpdateCommandFactory.createCommand(whiteSpaceTitle, startDate, endDate),
+                CustomValidationException.class);
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidTripTitleException.class);
+    }
+
+    @DisplayName("제한보다 긴 제목 -> 검증예외 발생")
+    @Test
+    public void tooLongTitle() {
+        // given
+        String tooLongTitle = "가".repeat(TripTitle.MAX_LENGTH + 1);
+        LocalDate startDate = null;
+        LocalDate endDate = null;
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> tripUpdateCommandFactory.createCommand(tooLongTitle, startDate, endDate),
+                CustomValidationException.class);
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidTripTitleException.class);
+    }
+
+
+    @DisplayName("시작일만 Null -> 검증예외 발생")
+    @Test
+    public void onlyStartDateNullTest() {
+        // given
+        String title = "제목";
+        LocalDate startDate = null;
+        LocalDate endDate = LocalDate.of(2023,3,1);
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> tripUpdateCommandFactory.createCommand(title, startDate, endDate),
+                CustomValidationException.class);
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidPeriodException.class);
+    }
+
+    @DisplayName("종료일만 Null -> 검증예외 발생")
+    @Test
+    public void onlyEndDateNullTest() {
+        // given
+        String title = "제목";
+        LocalDate startDate = null;
+        LocalDate endDate = LocalDate.of(2023,3,1);
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> tripUpdateCommandFactory.createCommand(title, startDate, endDate),
+                CustomValidationException.class);
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidPeriodException.class);
+    }
+
+    @DisplayName("종료일이 시작일보다 앞설 때 -> 검증예외 발생")
+    @Test
+    public void fastEndDateTest() {
+        // given
+        String title = "제목";
+        LocalDate startDate = LocalDate.of(2023,3,2);
+        LocalDate endDate = LocalDate.of(2023,3,1);
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> tripUpdateCommandFactory.createCommand(title, startDate, endDate),
+                CustomValidationException.class);
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidPeriodException.class);
+    }
+
+    @DisplayName("제목이 올바른 길이이고 날짜가 모두 null -> 정상 생성")
+    @Test
+    public void createSuccessTest1() {
+        // given
+        String normalTitle = "제목";
+        LocalDate startDate = null;
+        LocalDate endDate = null;
+
+        // when
+        TripUpdateCommand command = tripUpdateCommandFactory.createCommand(normalTitle, startDate, endDate);
+
+        // then
+        assertThat(command).isNotNull();
+        assertThat(command.getTripTitle()).isEqualTo(TripTitle.of(normalTitle));
+        assertThat(command.getTripPeriod()).isEqualTo(TripPeriod.of(startDate, endDate));
+    }
+}

--- a/src/test/java/com/cosain/trilo/unit/trip/application/trip/command/service/TripCreateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/trip/command/service/TripCreateServiceTest.java
@@ -4,6 +4,7 @@ import com.cosain.trilo.trip.application.trip.command.usecase.dto.TripCreateComm
 import com.cosain.trilo.trip.application.trip.command.service.TripCreateService;
 import com.cosain.trilo.trip.domain.entity.Trip;
 import com.cosain.trilo.trip.domain.repository.TripRepository;
+import com.cosain.trilo.trip.domain.vo.TripTitle;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,11 +35,11 @@ public class TripCreateServiceTest {
     @DisplayName("create 하면, 내부적으로 repository가 호출된다.")
     public void create_and_repository_called() throws Exception {
         // given
-        TripCreateCommand createCommand = new TripCreateCommand("제목");
+        TripCreateCommand createCommand = TripCreateCommand.from("제목");
         Long tripperId = 1L;
 
         // mocking
-        Trip trip = Trip.create("제목", tripperId);
+        Trip trip = Trip.create(TripTitle.of("제목"), tripperId);
         injectFakeTripId(trip, 1L);
 
         given(tripRepository.save(any(Trip.class))).willReturn(trip);

--- a/src/test/java/com/cosain/trilo/unit/trip/application/trip/command/service/TripCreateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/trip/command/service/TripCreateServiceTest.java
@@ -35,7 +35,7 @@ public class TripCreateServiceTest {
     @DisplayName("create 하면, 내부적으로 repository가 호출된다.")
     public void create_and_repository_called() throws Exception {
         // given
-        TripCreateCommand createCommand = TripCreateCommand.from("제목");
+        TripCreateCommand createCommand = new TripCreateCommand(TripTitle.of("제목"));
         Long tripperId = 1L;
 
         // mocking

--- a/src/test/java/com/cosain/trilo/unit/trip/application/trip/command/service/TripUpdateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/trip/command/service/TripUpdateServiceTest.java
@@ -8,6 +8,8 @@ import com.cosain.trilo.trip.domain.entity.Trip;
 import com.cosain.trilo.trip.domain.repository.DayRepository;
 import com.cosain.trilo.trip.domain.repository.ScheduleRepository;
 import com.cosain.trilo.trip.domain.repository.TripRepository;
+import com.cosain.trilo.trip.domain.vo.TripPeriod;
+import com.cosain.trilo.trip.domain.vo.TripTitle;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -49,7 +51,10 @@ public class TripUpdateServiceTest {
         // given
         Long tripId = 1L;
         Long tripperId = 2L;
-        TripUpdateCommand updateCommand = TripUpdateCommand.of("수정할 제목", LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 3));
+        TripUpdateCommand updateCommand = new TripUpdateCommand(
+                TripTitle.of("수정할 제목"),
+                TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 3))
+        );
         given(tripRepository.findByIdWithDays(eq(tripId))).willReturn(Optional.empty());
 
         // when & then
@@ -63,8 +68,10 @@ public class TripUpdateServiceTest {
         // given
         Long tripId = 1L;
         Long tripperId = 2L;
-        TripUpdateCommand updateCommand = TripUpdateCommand.of("수정할 제목",
-                LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 3));
+        TripUpdateCommand updateCommand = new TripUpdateCommand(
+                TripTitle.of("수정할 제목"),
+                TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 3))
+        );
 
         Trip trip = UNDECIDED_TRIP.createUndecided(tripId, tripperId, "여행 제목");
         given(tripRepository.findByIdWithDays(eq(tripId))).willReturn(Optional.of(trip));
@@ -86,8 +93,10 @@ public class TripUpdateServiceTest {
         Long tripId = 1L;
         Long tripperId = 2L;
 
-        TripUpdateCommand updateCommand = TripUpdateCommand.of("수정할 제목",
-                LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 5));
+        TripUpdateCommand updateCommand = new TripUpdateCommand(
+                TripTitle.of("수정할 제목"),
+                TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 5))
+        );
         Trip trip = DECIDED_TRIP.createDecided(tripId, tripperId, "여행 제목", LocalDate.of(2023, 3, 3), LocalDate.of(2023, 3, 7));
         given(tripRepository.findByIdWithDays(eq(tripId))).willReturn(Optional.of(trip));
         given(scheduleRepository.relocateDaySchedules(eq(tripId), isNull())).willReturn(0);
@@ -117,8 +126,10 @@ public class TripUpdateServiceTest {
             Long tripperId = 2L;
             Long noAuthorityTripperId = 3L;
 
-            TripUpdateCommand updateCommand = TripUpdateCommand.of("수정할 제목",
-                    LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 3));
+            TripUpdateCommand updateCommand = new TripUpdateCommand(
+                    TripTitle.of("수정할 제목"),
+                    TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 3))
+            );
             Trip trip = UNDECIDED_TRIP.createUndecided(tripId, tripperId, "여행 제목");
             given(tripRepository.findByIdWithDays(eq(tripId))).willReturn(Optional.of(trip));
 

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/entity/TripTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/entity/TripTest.java
@@ -26,7 +26,7 @@ public class TripTest {
     class When_Create {
 
         // given
-        private final String title = "제목";
+        private final TripTitle title = TripTitle.of("제목");
         private final Long tripperId = 1L;
 
         @Test
@@ -36,7 +36,7 @@ public class TripTest {
             Trip trip = Trip.create(title, tripperId);
 
             // then
-            assertThat(trip.getTitle()).isEqualTo("제목");
+            assertThat(trip.getTripTitle().getValue()).isEqualTo("제목");
         }
 
         @Test
@@ -58,16 +58,16 @@ public class TripTest {
         @DisplayName("새로운 title이 변경되어 적용된다.")
         public void trip_has_changed_title() {
             // given
-            String beforeTitle = "변경 전 제목";
+            TripTitle beforeTitle = TripTitle.of("변경 전 제목");
             Long tripperId = 1L;
             Trip trip = Trip.create(beforeTitle, tripperId);
 
             // when
-            String newTitle = "변경 후 제목";
+            TripTitle newTitle = TripTitle.of("변경 후 제목");
             trip.changeTitle(newTitle);
 
             // then
-            assertThat(trip.getTitle()).isEqualTo("변경 후 제목");
+            assertThat(trip.getTripTitle()).isEqualTo(newTitle);
         }
 
     }
@@ -220,7 +220,7 @@ public class TripTest {
                 decidedTrip = Trip.builder()
                         .id(tripId)
                         .tripperId(tripperId)
-                        .title("여행 제목")
+                        .tripTitle(TripTitle.of("여행 제목"))
                         .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 5)))
                         .status(TripStatus.DECIDED)
                         .build();
@@ -606,7 +606,7 @@ public class TripTest {
             @DisplayName("인덱스가 최대 범위를 벗어나면, ScheduleIndexRangeException 발생")
             @Test
             public void when_new_index_range_is_over_max_index_value_then_it_throws_ScheduleIndexRangeException() {
-                Trip trip = Trip.create("여행 제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행 제목"), 1L);
 
                 Schedule schedule1 = Schedule.builder()
                         .day(null)
@@ -627,7 +627,7 @@ public class TripTest {
             @DisplayName("인덱스가 최대 범위를 벗어나지 않으면, 정상적으로 다음 순서의 Schedule 생성됨")
             @Test
             public void successTest() {
-                Trip trip = Trip.create("여행 제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행 제목"), 1L);
 
                 Schedule schedule1 = trip.createSchedule(null, "일정 제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
                 Schedule schedule2 = trip.createSchedule(null, "일정 제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
@@ -648,7 +648,7 @@ public class TripTest {
                 Trip trip = Trip.builder()
                         .id(1L)
                         .tripperId(1L)
-                        .title("여행 제목1")
+                        .tripTitle(TripTitle.of("여행 제목1"))
                         .status(TripStatus.DECIDED)
                         .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
                         .build();
@@ -664,7 +664,7 @@ public class TripTest {
                 Trip otherTrip = Trip.builder()
                         .id(2L)
                         .tripperId(2L)
-                        .title("여행제목2")
+                        .tripTitle(TripTitle.of("여행제목2"))
                         .status(TripStatus.DECIDED)
                         .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 2), LocalDate.of(2023, 3, 2)))
                         .build();
@@ -687,7 +687,7 @@ public class TripTest {
                 Trip trip = Trip.builder()
                         .id(1L)
                         .tripperId(1L)
-                        .title("여행 제목1")
+                        .tripTitle(TripTitle.of("여행 제목1"))
                         .status(TripStatus.DECIDED)
                         .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
                         .build();
@@ -725,7 +725,7 @@ public class TripTest {
                 Trip trip = Trip.builder()
                         .id(1L)
                         .tripperId(1L)
-                        .title("여행 제목1")
+                        .tripTitle(TripTitle.of("여행 제목1"))
                         .status(TripStatus.DECIDED)
                         .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
                         .build();
@@ -759,7 +759,7 @@ public class TripTest {
             @Test
             public void when_targetOrder_is_under_zero_then_it_throws_InvalidScheduleMoveTargetOrderException() {
                 // given
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 Day day = null;
                 Schedule schedule = trip.createSchedule(day, "일정제목", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
 
@@ -771,7 +771,7 @@ public class TripTest {
             @DisplayName("targetOrder가 임시보관함 크기를 넘어가는 경우 InvalidScheduleMoveTargetOrderException 발생")
             @Test
             public void when_targetOrder_is_over_temporary_storage_max_size_then_it_throws_InvalidScheduleMoveTargetOrderException() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 Day day = null;
 
                 Schedule schedule1 = trip.createSchedule(day, "일정제목", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
@@ -785,7 +785,7 @@ public class TripTest {
             @DisplayName("임시보관함 내에서, 자신의 기존 순서로 이동할 경우, 아무런 변화도 일어나지 않는다.")
             @Test
             public void when_move_to_same_position_then_nothing_changed() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 Day day = null;
 
                 Schedule schedule1 = trip.createSchedule(day, "일정제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
@@ -812,7 +812,7 @@ public class TripTest {
             @DisplayName("임시보관함 내에 기존의 순서 다음으로 이동시키려 할 경우, 아무런 변화도 일어나지 않는다.")
             @Test
             public void when_move_to_after_currentOrder_then_nothing_changed() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 Day day = null;
 
                 Schedule schedule1 = trip.createSchedule(day, "일정제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
@@ -839,7 +839,7 @@ public class TripTest {
             @DisplayName("targetOrder가 임시보관함 크기와 똑같은 값이고, 끝 ScheduleIndex 범위가 안전하면 맨 뒤로 이동한다.")
             @Test
             public void when_targetOrder_isEqualTo_TemporaryStorageSize_and_tail_scheduleIndex_isSafe_schedule_move_to_Tail() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 Day day = null;
 
                 Schedule schedule1 = trip.createSchedule(day, "일정제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
@@ -863,7 +863,7 @@ public class TripTest {
             @DisplayName("targetOrder가 임시보관함 크기와 똑같은 값이고, 끝 ScheduleIndex 범위가 안전하지 않으면 ScheduleIndexRangeException 발생")
             @Test
             public void when_targetOrder_isEqualTo_TemporaryStorageSize_and_tail_scheduleIndex_is_unSafe_it_throws_ScheduleIndexRangeException() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 Day day = null;
 
                 Schedule schedule1 = Schedule.builder()
@@ -894,7 +894,7 @@ public class TripTest {
             @DisplayName("targetOrder가 0이고, 맨 앞 ScheduleIndex 범위가 안전하면 맨 앞으로 이동한다.")
             @Test
             public void when_targetOrder_isEqualTo_Zero_and_head_scheduleIndex_is_Safe_then_schedule_move_to_Head() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 Day day = null;
 
                 Schedule schedule1 = trip.createSchedule(day, "일정제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
@@ -918,7 +918,7 @@ public class TripTest {
             @DisplayName("targetOrder가 0이고, 맨 앞 ScheduleIndex 범위가 안전하지 않으면 ScheduleIndexRangeException 발생")
             @Test
             public void when_targetOrder_isEqualTo_Zero_and_head_scheduleIndex_is_unSafe_it_throws_ScheduleIndexRangeException() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 Day day = null;
 
                 Schedule schedule1 = Schedule.builder()
@@ -949,7 +949,7 @@ public class TripTest {
             @DisplayName("targetOrder가 다른 일정의 순서이고, 해당 순서 앞과 간격이 충분하면 중간 인덱스가 부여된다.")
             @Test
             public void testMiddleInsert_Success() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 Day day = null;
 
                 Schedule schedule1 = trip.createSchedule(day, "일정제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
@@ -974,7 +974,7 @@ public class TripTest {
             @DisplayName("targetOrder가 다른 일정의 순서이고, 해당 순서 앞과 간격이 충분하지 않으면 MidScheduleIndexConflictException 발생")
             @Test
             public void testMiddleInsert_Failure() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 Day day = null;
 
                 Schedule schedule1 = Schedule.builder()
@@ -1020,9 +1020,9 @@ public class TripTest {
             @DisplayName("targetDay가 Trip의 Day가 아니면, InvalidTripDayException 발생")
             public void when_targetDay_is_not_in_trip_then_it_throws_InvalidTripDayException() {
                 // given
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
 
-                Trip otherTrip = Trip.create("다른 여행 제목", 1L);
+                Trip otherTrip = Trip.create(TripTitle.of("다른 여행 제목"), 1L);
                 otherTrip.changePeriod(TripPeriod.of(LocalDate.of(2023, 4, 1), LocalDate.of(2023, 4, 1)));
 
                 Day beforeDay = null;
@@ -1040,7 +1040,7 @@ public class TripTest {
             @Test
             public void when_targetOrder_is_under_zero_then_it_throws_InvalidScheduleMoveTargetOrderException() {
                 // given
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
                 Day beforeDay = null;
                 Schedule schedule = trip.createSchedule(beforeDay, "일정제목", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
@@ -1055,7 +1055,7 @@ public class TripTest {
             @DisplayName("targetOrder가 Schedules 크기를 넘어가는 경우 InvalidScheduleMoveTargetOrderException 발생")
             @Test
             public void when_targetOrder_is_over_day_schedules_max_size_then_it_throws_InvalidScheduleMoveTargetOrderException() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
 
                 Day beforeDay = null;
@@ -1073,7 +1073,7 @@ public class TripTest {
             @DisplayName("targetOrder가 Schedules 크기와 똑같은 값이고, 끝 ScheduleIndex 범위가 안전하면 맨 뒤로 이동한다.")
             @Test
             public void when_targetOrder_isEqualTo_SchedulesSize_and_tail_scheduleIndex_isSafe_schedule_move_to_Tail() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
 
                 Day beforeDay = null;
@@ -1102,7 +1102,7 @@ public class TripTest {
             @DisplayName("targetOrder가 Schedules 크기와 똑같은 값이고, 끝 ScheduleIndex 범위가 안전하지 않으면 ScheduleIndexRangeException 발생")
             @Test
             public void when_targetOrder_isEqualTo_SchedulesSize_and_tail_scheduleIndex_is_unSafe_it_throws_ScheduleIndexRangeException() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
 
                 Day beforeDay = null;
@@ -1136,7 +1136,7 @@ public class TripTest {
             @DisplayName("targetOrder가 0이고, 맨 앞 ScheduleIndex 범위가 안전하면 맨 앞로 이동한다.")
             @Test
             public void when_targetOrder_isEqualTo_Zero_and_head_scheduleIndex_isSafe_schedule_move_to_Head() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
 
                 Day beforeDay = null;
@@ -1165,7 +1165,7 @@ public class TripTest {
             @DisplayName("targetOrder가 0이고, 맨 앞 ScheduleIndex 범위가 안전하지 않으면 ScheduleIndexRangeException 발생")
             @Test
             public void when_targetOrder_isEqualTo_Zero_and_head_scheduleIndex_is_unSafe_it_throws_ScheduleIndexRangeException() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
 
                 Day beforeDay = null;
@@ -1199,7 +1199,7 @@ public class TripTest {
             @DisplayName("targetOrder가 다른 일정의 순서이고, 해당 순서 앞과 간격이 충분하면 중간 인덱스가 부여된다.")
             @Test
             public void testMiddleInsert_Success() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
 
                 Day beforeDay = null;
@@ -1230,7 +1230,7 @@ public class TripTest {
             @DisplayName("targetOrder가 다른 일정의 순서이고, 해당 순서 앞과 간격이 충분하지 않으면 MidScheduleIndexConflictException 발생")
             @Test
             public void testMiddleInsert_Failure() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
 
                 Day beforeDay = null;
@@ -1279,12 +1279,12 @@ public class TripTest {
             @DisplayName("targetDay가 Trip의 Day가 아니면, InvalidTripDayException 발생")
             public void when_targetDay_is_not_in_trip_then_it_throws_InvalidTripDayException() {
                 // given
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
                 Day beforeDay = trip.getDays().get(0);
                 Schedule schedule = trip.createSchedule(beforeDay, "여행 제목", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
 
-                Trip otherTrip = Trip.create("다른 여행 제목", 1L);
+                Trip otherTrip = Trip.create(TripTitle.of("다른 여행 제목"), 1L);
                 otherTrip.changePeriod(TripPeriod.of(LocalDate.of(2023, 4, 1), LocalDate.of(2023, 4, 1)));
                 Day targetDay = otherTrip.getDays().get(0);
 
@@ -1297,7 +1297,7 @@ public class TripTest {
             @Test
             public void when_targetOrder_is_under_zero_then_it_throws_InvalidScheduleMoveTargetOrderException() {
                 // given
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
                 Day beforeDay = trip.getDays().get(0);
                 Schedule schedule = trip.createSchedule(beforeDay, "일정제목", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
@@ -1312,7 +1312,7 @@ public class TripTest {
             @DisplayName("targetOrder가 Schedules 크기를 넘어가는 경우 InvalidScheduleMoveTargetOrderException 발생")
             @Test
             public void when_targetOrder_is_over_day_schedules_max_size_then_it_throws_InvalidScheduleMoveTargetOrderException() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
 
                 Day beforeDay = trip.getDays().get(0);
@@ -1330,7 +1330,7 @@ public class TripTest {
             @DisplayName("같은 Day의 기존의 순서로 이동할 경우, 아무런 변화도 일어나지 않는다.")
             @Test
             public void when_move_to_same_day_and_same_position_then_nothing_changed() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
                 Day day = trip.getDays().get(0);
 
@@ -1358,7 +1358,7 @@ public class TripTest {
             @DisplayName("같은 Day의 기존의 순서 다음으로 이동시키려 할 경우, 아무런 변화도 일어나지 않는다.")
             @Test
             public void when_move_to_same_day_and_after_currentOrder_then_nothing_changed() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
                 Day day = trip.getDays().get(0);
 
@@ -1387,7 +1387,7 @@ public class TripTest {
             @DisplayName("targetOrder가 Schedules 크기와 똑같은 값이고, 끝 ScheduleIndex 범위가 안전하면 맨 뒤로 이동한다.")
             @Test
             public void when_targetOrder_isEqualTo_SchedulesSize_and_tail_scheduleIndex_isSafe_schedule_move_to_Tail() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
 
                 Day beforeDay = trip.getDays().get(0);
@@ -1416,7 +1416,7 @@ public class TripTest {
             @DisplayName("targetOrder가 Schedules 크기와 똑같은 값이고, 끝 ScheduleIndex 범위가 안전하지 않으면 ScheduleIndexRangeException 발생")
             @Test
             public void when_targetOrder_isEqualTo_SchedulesSize_and_tail_scheduleIndex_is_unSafe_it_throws_ScheduleIndexRangeException() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
 
                 Day beforeDay = trip.getDays().get(0);
@@ -1450,7 +1450,7 @@ public class TripTest {
             @DisplayName("targetOrder가 0이고, 맨 앞 ScheduleIndex 범위가 안전하면 맨 앞으로 이동한다.")
             @Test
             public void when_targetOrder_isEqualTo_Zero_and_head_scheduleIndex_isSafe_schedule_move_to_Head() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
 
                 Day beforeDay = trip.getDays().get(0);
@@ -1479,7 +1479,7 @@ public class TripTest {
             @DisplayName("targetOrder가 0이고, 맨 앞 ScheduleIndex 범위가 안전하지 않으면 ScheduleIndexRangeException 발생")
             @Test
             public void when_targetOrder_isEqualTo_Zero_and_head_scheduleIndex_is_unSafe_it_throws_ScheduleIndexRangeException() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
 
                 Day beforeDay = trip.getDays().get(0);
@@ -1513,7 +1513,7 @@ public class TripTest {
             @DisplayName("targetOrder가 다른 일정의 순서이고, 해당 순서 앞과 간격이 충분하면 중간 인덱스가 부여된다.")
             @Test
             public void testMiddleInsert_Success() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
 
                 Day beforeDay = trip.getDays().get(0);
@@ -1544,7 +1544,7 @@ public class TripTest {
             @DisplayName("targetOrder가 다른 일정의 순서이고, 해당 순서 앞과 간격이 충분하지 않으면 MidScheduleIndexConflictException 발생")
             @Test
             public void testMiddleInsert_Failure() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
 
                 Day beforeDay = trip.getDays().get(0);
@@ -1593,7 +1593,7 @@ public class TripTest {
             @Test
             public void when_targetOrder_is_under_zero_then_it_throws_InvalidScheduleMoveTargetOrderException() {
                 // given
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
                 Day beforeDay = trip.getDays().get(0);
                 Schedule schedule = trip.createSchedule(beforeDay, "일정제목", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
@@ -1608,7 +1608,7 @@ public class TripTest {
             @DisplayName("targetOrder가 임시보관함 크기를 넘어가는 경우 InvalidScheduleMoveTargetOrderException 발생")
             @Test
             public void when_targetOrder_is_over_temporary_storage_max_size_then_it_throws_InvalidScheduleMoveTargetOrderException() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
                 Day beforeDay = trip.getDays().get(0);
                 Day targetDay = null;
@@ -1625,7 +1625,7 @@ public class TripTest {
             @DisplayName("targetOrder가 임시보관함 크기와 똑같은 값이고, 끝 ScheduleIndex 범위가 안전하면 맨 뒤로 이동한다.")
             @Test
             public void when_targetOrder_isEqualTo_temporaryStorageSize_and_tail_scheduleIndex_isSafe_schedule_move_to_Tail() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
 
                 Day beforeDay = trip.getDays().get(0);
@@ -1654,7 +1654,7 @@ public class TripTest {
             @DisplayName("targetOrder가 임시보관함 크기와 똑같은 값이고, 끝 ScheduleIndex 범위가 안전하지 않으면 ScheduleIndexRangeException 발생")
             @Test
             public void when_targetOrder_isEqualTo_temporaryStorageSize_and_tail_scheduleIndex_is_unSafe_it_throws_ScheduleIndexRangeException() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
 
                 Day beforeDay = trip.getDays().get(0);
@@ -1689,7 +1689,7 @@ public class TripTest {
             @DisplayName("targetOrder가 0이고, 맨 앞 ScheduleIndex 범위가 안전하면 맨 앞으로 이동한다.")
             @Test
             public void when_targetOrder_isEqualTo_Zero_and_Head_scheduleIndex_isSafe_schedule_move_to_Head() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 21L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
 
                 Day beforeDay = trip.getDays().get(0);
@@ -1718,7 +1718,7 @@ public class TripTest {
             @DisplayName("targetOrder가 0이고, 끝 ScheduleIndex 범위가 안전하지 않으면 ScheduleIndexRangeException 발생")
             @Test
             public void when_targetOrder_isEqualTo_Zero_and_Head_scheduleIndex_is_unSafe_it_throws_ScheduleIndexRangeException() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
 
                 Day beforeDay = trip.getDays().get(0);
@@ -1752,7 +1752,7 @@ public class TripTest {
             @DisplayName("targetOrder가 다른 일정의 순서이고, 해당 순서 앞과 간격이 충분하면 중간 인덱스가 부여된다.")
             @Test
             public void testMiddleInsert_Success() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
 
                 Day beforeDay = trip.getDays().get(0);
@@ -1783,7 +1783,7 @@ public class TripTest {
             @DisplayName("targetOrder가 다른 일정의 순서이고, 해당 순서 앞과 간격이 충분하지 않으면 MidScheduleIndexConflictException 발생")
             @Test
             public void testMiddleInsert_Failure() {
-                Trip trip = Trip.create("여행제목", 1L);
+                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
 
                 Day beforeDay = trip.getDays().get(0);

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/entity/TripTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/entity/TripTest.java
@@ -611,7 +611,7 @@ public class TripTest {
                 Schedule schedule1 = Schedule.builder()
                         .day(null)
                         .trip(trip)
-                        .title("일정 제목1")
+                        .scheduleTitle(ScheduleTitle.of("일정 제목1"))
                         .place(Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.of(ScheduleIndex.MAX_INDEX_VALUE))
                         .build();
@@ -620,7 +620,7 @@ public class TripTest {
 
                 // when & then
                 assertThatThrownBy(() ->
-                        trip.createSchedule(null, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523))))
+                        trip.createSchedule(null, ScheduleTitle.of("일정제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523))))
                         .isInstanceOf(ScheduleIndexRangeException.class);
             }
 
@@ -629,8 +629,8 @@ public class TripTest {
             public void successTest() {
                 Trip trip = Trip.create(TripTitle.of("여행 제목"), 1L);
 
-                Schedule schedule1 = trip.createSchedule(null, "일정 제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule2 = trip.createSchedule(null, "일정 제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(null, ScheduleTitle.of("일정 제목1"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(null, ScheduleTitle.of("일정 제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 assertThat(schedule1.getScheduleIndex()).isEqualTo(ScheduleIndex.ZERO_INDEX);
                 assertThat(schedule2.getScheduleIndex()).isEqualTo(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP));
@@ -677,7 +677,7 @@ public class TripTest {
                 otherTrip.getDays().add(otherTripDay);
 
                 // when & then
-                assertThatThrownBy(() -> trip.createSchedule(otherTripDay, "일정 제목", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523))))
+                assertThatThrownBy(() -> trip.createSchedule(otherTripDay, ScheduleTitle.of("일정 제목"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523))))
                         .isInstanceOf(InvalidTripDayException.class);
             }
 
@@ -706,7 +706,7 @@ public class TripTest {
                 Schedule schedule1 = Schedule.builder()
                         .day(day)
                         .trip(trip)
-                        .title("일정 제목1")
+                        .scheduleTitle(ScheduleTitle.of("일정 제목1"))
                         .place(Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.of(ScheduleIndex.MAX_INDEX_VALUE))
                         .build();
@@ -715,7 +715,7 @@ public class TripTest {
 
                 // when & then
                 assertThatThrownBy(() ->
-                        trip.createSchedule(day, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523))))
+                        trip.createSchedule(day, ScheduleTitle.of("일정제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523))))
                         .isInstanceOf(ScheduleIndexRangeException.class);
             }
 
@@ -738,8 +738,8 @@ public class TripTest {
 
                 trip.getDays().add(day);
 
-                Schedule schedule1 = trip.createSchedule(day, "일정 제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule2 = trip.createSchedule(day, "일정 제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(day, ScheduleTitle.of("일정 제목1"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(day, ScheduleTitle.of("일정 제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 assertThat(schedule1.getScheduleIndex()).isEqualTo(ScheduleIndex.ZERO_INDEX);
                 assertThat(schedule2.getScheduleIndex()).isEqualTo(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP));
@@ -761,7 +761,7 @@ public class TripTest {
                 // given
                 Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 Day day = null;
-                Schedule schedule = trip.createSchedule(day, "일정제목", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule = trip.createSchedule(day, ScheduleTitle.of("일정제목"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
 
                 // when & then
                 assertThatThrownBy(() -> trip.moveSchedule(schedule, day, -1))
@@ -774,8 +774,8 @@ public class TripTest {
                 Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 Day day = null;
 
-                Schedule schedule1 = trip.createSchedule(day, "일정제목", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule2 = trip.createSchedule(day, "일정제목", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(day, ScheduleTitle.of("일정제목"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(day, ScheduleTitle.of("일정제목"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when & then
                 assertThatThrownBy(() -> trip.moveSchedule(schedule1, day, 3))
@@ -788,8 +788,8 @@ public class TripTest {
                 Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 Day day = null;
 
-                Schedule schedule1 = trip.createSchedule(day, "일정제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule2 = trip.createSchedule(day, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(day, ScheduleTitle.of("일정제목1"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(day, ScheduleTitle.of("일정제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when
                 ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule2, day, 1);
@@ -815,8 +815,8 @@ public class TripTest {
                 Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 Day day = null;
 
-                Schedule schedule1 = trip.createSchedule(day, "일정제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule2 = trip.createSchedule(day, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(day, ScheduleTitle.of("일정제목1"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(day, ScheduleTitle.of("일정제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when
                 ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule2, day, 2);
@@ -842,8 +842,8 @@ public class TripTest {
                 Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 Day day = null;
 
-                Schedule schedule1 = trip.createSchedule(day, "일정제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule2 = trip.createSchedule(day, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(day, ScheduleTitle.of("일정제목1"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(day, ScheduleTitle.of("일정제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when
                 ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule1, day, 2);
@@ -869,7 +869,7 @@ public class TripTest {
                 Schedule schedule1 = Schedule.builder()
                         .day(day)
                         .trip(trip)
-                        .title("일정제목1")
+                        .scheduleTitle(ScheduleTitle.of("일정제목1"))
                         .place(Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                         .build();
@@ -877,7 +877,7 @@ public class TripTest {
                 Schedule schedule2 = Schedule.builder()
                         .day(day)
                         .trip(trip)
-                        .title("일정제목2")
+                        .scheduleTitle(ScheduleTitle.of("일정제목2"))
                         .place(Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.of(ScheduleIndex.MAX_INDEX_VALUE))
                         .build();
@@ -897,8 +897,8 @@ public class TripTest {
                 Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 Day day = null;
 
-                Schedule schedule1 = trip.createSchedule(day, "일정제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule2 = trip.createSchedule(day, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(day, ScheduleTitle.of("일정제목1"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(day, ScheduleTitle.of("일정제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when
                 ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule2, day, 0);
@@ -924,7 +924,7 @@ public class TripTest {
                 Schedule schedule1 = Schedule.builder()
                         .day(day)
                         .trip(trip)
-                        .title("일정제목1")
+                        .scheduleTitle(ScheduleTitle.of("일정제목1"))
                         .place(Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.of(ScheduleIndex.MIN_INDEX_VALUE))
                         .build();
@@ -932,7 +932,7 @@ public class TripTest {
                 Schedule schedule2 = Schedule.builder()
                         .day(day)
                         .trip(trip)
-                        .title("일정제목2")
+                        .scheduleTitle(ScheduleTitle.of("일정제목2"))
                         .place(Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                         .build();
@@ -952,9 +952,9 @@ public class TripTest {
                 Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 Day day = null;
 
-                Schedule schedule1 = trip.createSchedule(day, "일정제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule2 = trip.createSchedule(day, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule3 = trip.createSchedule(day, "일정제목3", Place.of("place-id333", "place 이름333", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(day, ScheduleTitle.of("일정제목1"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(day, ScheduleTitle.of("일정제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule3 = trip.createSchedule(day, ScheduleTitle.of("일정제목3"), Place.of("place-id333", "place 이름333", Coordinate.of(37.72221, 137.86523)));
 
                 // when
                 ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule1, day, 2);
@@ -980,7 +980,7 @@ public class TripTest {
                 Schedule schedule1 = Schedule.builder()
                         .day(day)
                         .trip(trip)
-                        .title("일정제목1")
+                        .scheduleTitle(ScheduleTitle.of("일정제목1"))
                         .place(Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                         .build();
@@ -988,7 +988,7 @@ public class TripTest {
                 Schedule schedule2 = Schedule.builder()
                         .day(day)
                         .trip(trip)
-                        .title("일정제목2")
+                        .scheduleTitle(ScheduleTitle.of("일정제목2"))
                         .place(Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.of(10))
                         .build();
@@ -996,7 +996,7 @@ public class TripTest {
                 Schedule schedule3 = Schedule.builder()
                         .day(day)
                         .trip(trip)
-                        .title("일정제목3")
+                        .scheduleTitle(ScheduleTitle.of("일정제목3"))
                         .place(Place.of("place-id333", "place 이름333", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.of(11))
                         .build();
@@ -1026,7 +1026,7 @@ public class TripTest {
                 otherTrip.changePeriod(TripPeriod.of(LocalDate.of(2023, 4, 1), LocalDate.of(2023, 4, 1)));
 
                 Day beforeDay = null;
-                Schedule schedule = trip.createSchedule(beforeDay, "일정제목", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule = trip.createSchedule(beforeDay, ScheduleTitle.of("일정제목"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
 
                 Day targetDay = otherTrip.getDays().get(0);
 
@@ -1043,7 +1043,7 @@ public class TripTest {
                 Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
                 Day beforeDay = null;
-                Schedule schedule = trip.createSchedule(beforeDay, "일정제목", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule = trip.createSchedule(beforeDay, ScheduleTitle.of("일정제목"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
 
                 Day targetDay = trip.getDays().get(0);
 
@@ -1059,10 +1059,10 @@ public class TripTest {
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
 
                 Day beforeDay = null;
-                Schedule schedule1 = trip.createSchedule(beforeDay, "일정제목", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(beforeDay, ScheduleTitle.of("일정제목"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
 
                 Day targetDay = trip.getDays().get(0);
-                Schedule schedule2 = trip.createSchedule(targetDay, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(targetDay, ScheduleTitle.of("일정제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when & then
                 assertThatThrownBy(() -> trip.moveSchedule(schedule1, targetDay, 2))
@@ -1079,8 +1079,8 @@ public class TripTest {
                 Day beforeDay = null;
                 Day targetDay = trip.getDays().get(0);
 
-                Schedule schedule1 = trip.createSchedule(beforeDay, "일정제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule2 = trip.createSchedule(targetDay, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(beforeDay, ScheduleTitle.of("일정제목1"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(targetDay, ScheduleTitle.of("일정제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when
                 ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule1, targetDay, 1);
@@ -1111,7 +1111,7 @@ public class TripTest {
                 Schedule schedule1 = Schedule.builder()
                         .day(beforeDay)
                         .trip(trip)
-                        .title("일정제목1")
+                        .scheduleTitle(ScheduleTitle.of("일정제목1"))
                         .place(Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                         .build();
@@ -1119,7 +1119,7 @@ public class TripTest {
                 Schedule schedule2 = Schedule.builder()
                         .day(targetDay)
                         .trip(trip)
-                        .title("일정제목2")
+                        .scheduleTitle(ScheduleTitle.of("일정제목2"))
                         .place(Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.of(ScheduleIndex.MAX_INDEX_VALUE))
                         .build();
@@ -1142,8 +1142,8 @@ public class TripTest {
                 Day beforeDay = null;
                 Day targetDay = trip.getDays().get(0);
 
-                Schedule schedule1 = trip.createSchedule(beforeDay, "일정제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule2 = trip.createSchedule(targetDay, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(beforeDay, ScheduleTitle.of("일정제목1"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(targetDay, ScheduleTitle.of("일정제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when
                 ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule1, targetDay, 0);
@@ -1174,7 +1174,7 @@ public class TripTest {
                 Schedule schedule1 = Schedule.builder()
                         .day(beforeDay)
                         .trip(trip)
-                        .title("일정제목1")
+                        .scheduleTitle(ScheduleTitle.of("일정제목1"))
                         .place(Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                         .build();
@@ -1182,7 +1182,7 @@ public class TripTest {
                 Schedule schedule2 = Schedule.builder()
                         .day(targetDay)
                         .trip(trip)
-                        .title("일정제목2")
+                        .scheduleTitle(ScheduleTitle.of("일정제목2"))
                         .place(Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.of(ScheduleIndex.MIN_INDEX_VALUE))
                         .build();
@@ -1205,9 +1205,9 @@ public class TripTest {
                 Day beforeDay = null;
                 Day targetDay = trip.getDays().get(0);
 
-                Schedule schedule1 = trip.createSchedule(beforeDay, "일정제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule2 = trip.createSchedule(targetDay, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule3 = trip.createSchedule(targetDay, "일정제목3", Place.of("place-id333", "place 이름333", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(beforeDay, ScheduleTitle.of("일정제목1"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(targetDay, ScheduleTitle.of("일정제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule3 = trip.createSchedule(targetDay, ScheduleTitle.of("일정제목3"), Place.of("place-id333", "place 이름333", Coordinate.of(37.72221, 137.86523)));
 
                 // when
                 ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule1, targetDay, 1);
@@ -1239,7 +1239,7 @@ public class TripTest {
                 Schedule schedule1 = Schedule.builder()
                         .day(beforeDay)
                         .trip(trip)
-                        .title("일정제목1")
+                        .scheduleTitle(ScheduleTitle.of("일정제목1"))
                         .place(Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                         .build();
@@ -1247,7 +1247,7 @@ public class TripTest {
                 Schedule schedule2 = Schedule.builder()
                         .day(targetDay)
                         .trip(trip)
-                        .title("일정제목2")
+                        .scheduleTitle(ScheduleTitle.of("일정제목2"))
                         .place(Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.of(10))
                         .build();
@@ -1255,7 +1255,7 @@ public class TripTest {
                 Schedule schedule3 = Schedule.builder()
                         .day(targetDay)
                         .trip(trip)
-                        .title("일정제목3")
+                        .scheduleTitle(ScheduleTitle.of("일정제목3"))
                         .place(Place.of("place-id333", "place 이름333", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.of(11))
                         .build();
@@ -1282,7 +1282,7 @@ public class TripTest {
                 Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
                 Day beforeDay = trip.getDays().get(0);
-                Schedule schedule = trip.createSchedule(beforeDay, "여행 제목", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule = trip.createSchedule(beforeDay, ScheduleTitle.of("여행 제목"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
 
                 Trip otherTrip = Trip.create(TripTitle.of("다른 여행 제목"), 1L);
                 otherTrip.changePeriod(TripPeriod.of(LocalDate.of(2023, 4, 1), LocalDate.of(2023, 4, 1)));
@@ -1300,7 +1300,7 @@ public class TripTest {
                 Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
                 Day beforeDay = trip.getDays().get(0);
-                Schedule schedule = trip.createSchedule(beforeDay, "일정제목", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule = trip.createSchedule(beforeDay, ScheduleTitle.of("일정제목"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
 
                 Day targetDay = trip.getDays().get(1);
 
@@ -1316,11 +1316,11 @@ public class TripTest {
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
 
                 Day beforeDay = trip.getDays().get(0);
-                Schedule schedule1 = trip.createSchedule(beforeDay, "일정제목", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(beforeDay, ScheduleTitle.of("일정제목"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
 
 
                 Day targetDay = trip.getDays().get(1);
-                Schedule schedule2 = trip.createSchedule(targetDay, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(targetDay, ScheduleTitle.of("일정제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when & then
                 assertThatThrownBy(() -> trip.moveSchedule(schedule1, targetDay, 2))
@@ -1334,8 +1334,8 @@ public class TripTest {
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
                 Day day = trip.getDays().get(0);
 
-                Schedule schedule1 = trip.createSchedule(day, "일정제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule2 = trip.createSchedule(day, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(day, ScheduleTitle.of("일정제목1"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(day, ScheduleTitle.of("일정제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when
                 ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule2, day, 1);
@@ -1362,8 +1362,8 @@ public class TripTest {
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
                 Day day = trip.getDays().get(0);
 
-                Schedule schedule1 = trip.createSchedule(day, "일정제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule2 = trip.createSchedule(day, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(day, ScheduleTitle.of("일정제목1"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(day, ScheduleTitle.of("일정제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when
                 ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule2, day, 2);
@@ -1393,8 +1393,8 @@ public class TripTest {
                 Day beforeDay = trip.getDays().get(0);
                 Day targetDay = trip.getDays().get(1);
 
-                Schedule schedule1 = trip.createSchedule(beforeDay, "일정제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule2 = trip.createSchedule(targetDay, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(beforeDay, ScheduleTitle.of("일정제목1"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(targetDay, ScheduleTitle.of("일정제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when
                 ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule1, targetDay, 1);
@@ -1425,7 +1425,7 @@ public class TripTest {
                 Schedule schedule1 = Schedule.builder()
                         .day(beforeDay)
                         .trip(trip)
-                        .title("일정제목1")
+                        .scheduleTitle(ScheduleTitle.of("일정제목1"))
                         .place(Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                         .build();
@@ -1433,7 +1433,7 @@ public class TripTest {
                 Schedule schedule2 = Schedule.builder()
                         .day(targetDay)
                         .trip(trip)
-                        .title("일정제목2")
+                        .scheduleTitle(ScheduleTitle.of("일정제목2"))
                         .place(Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.of(ScheduleIndex.MAX_INDEX_VALUE))
                         .build();
@@ -1456,8 +1456,8 @@ public class TripTest {
                 Day beforeDay = trip.getDays().get(0);
                 Day targetDay = trip.getDays().get(1);
 
-                Schedule schedule1 = trip.createSchedule(beforeDay, "일정제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule2 = trip.createSchedule(targetDay, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(beforeDay, ScheduleTitle.of("일정제목1"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(targetDay, ScheduleTitle.of("일정제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when
                 ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule1, targetDay, 0);
@@ -1488,7 +1488,7 @@ public class TripTest {
                 Schedule schedule1 = Schedule.builder()
                         .day(beforeDay)
                         .trip(trip)
-                        .title("일정제목1")
+                        .scheduleTitle(ScheduleTitle.of("일정제목1"))
                         .place(Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                         .build();
@@ -1496,7 +1496,7 @@ public class TripTest {
                 Schedule schedule2 = Schedule.builder()
                         .day(targetDay)
                         .trip(trip)
-                        .title("일정제목2")
+                        .scheduleTitle(ScheduleTitle.of("일정제목2"))
                         .place(Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.of(ScheduleIndex.MIN_INDEX_VALUE))
                         .build();
@@ -1519,9 +1519,9 @@ public class TripTest {
                 Day beforeDay = trip.getDays().get(0);
                 Day targetDay = trip.getDays().get(1);
 
-                Schedule schedule1 = trip.createSchedule(beforeDay, "일정제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule2 = trip.createSchedule(targetDay, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule3 = trip.createSchedule(targetDay, "일정제목3", Place.of("place-id333", "place 이름333", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(beforeDay, ScheduleTitle.of("일정제목1"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(targetDay, ScheduleTitle.of("일정제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule3 = trip.createSchedule(targetDay, ScheduleTitle.of("일정제목3"), Place.of("place-id333", "place 이름333", Coordinate.of(37.72221, 137.86523)));
 
                 // when
                 ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule1, targetDay, 1);
@@ -1553,7 +1553,7 @@ public class TripTest {
                 Schedule schedule1 = Schedule.builder()
                         .day(beforeDay)
                         .trip(trip)
-                        .title("일정제목1")
+                        .scheduleTitle(ScheduleTitle.of("일정제목1"))
                         .place(Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                         .build();
@@ -1561,7 +1561,7 @@ public class TripTest {
                 Schedule schedule2 = Schedule.builder()
                         .day(targetDay)
                         .trip(trip)
-                        .title("일정제목2")
+                        .scheduleTitle(ScheduleTitle.of("일정제목2"))
                         .place(Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.of(10))
                         .build();
@@ -1569,7 +1569,7 @@ public class TripTest {
                 Schedule schedule3 = Schedule.builder()
                         .day(targetDay)
                         .trip(trip)
-                        .title("일정제목3")
+                        .scheduleTitle(ScheduleTitle.of("일정제목3"))
                         .place(Place.of("place-id333", "place 이름333", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.of(11))
                         .build();
@@ -1596,7 +1596,7 @@ public class TripTest {
                 Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
                 trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
                 Day beforeDay = trip.getDays().get(0);
-                Schedule schedule = trip.createSchedule(beforeDay, "일정제목", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule = trip.createSchedule(beforeDay, ScheduleTitle.of("일정제목"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
 
                 Day targetDay = null;
 
@@ -1613,8 +1613,8 @@ public class TripTest {
                 Day beforeDay = trip.getDays().get(0);
                 Day targetDay = null;
 
-                Schedule schedule1 = trip.createSchedule(beforeDay, "일정제목", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule2 = trip.createSchedule(targetDay, "일정제목", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(beforeDay, ScheduleTitle.of("일정제목"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(targetDay, ScheduleTitle.of("일정제목"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when & then
                 assertThatThrownBy(() -> trip.moveSchedule(schedule1, targetDay, 2))
@@ -1631,8 +1631,8 @@ public class TripTest {
                 Day beforeDay = trip.getDays().get(0);
                 Day targetDay = null;
 
-                Schedule schedule1 = trip.createSchedule(beforeDay, "일정제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule2 = trip.createSchedule(targetDay, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(beforeDay, ScheduleTitle.of("일정제목1"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(targetDay, ScheduleTitle.of("일정제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when
                 ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule1, targetDay, 1);
@@ -1663,7 +1663,7 @@ public class TripTest {
                 Schedule schedule1 = Schedule.builder()
                         .day(beforeDay)
                         .trip(trip)
-                        .title("일정제목1")
+                        .scheduleTitle(ScheduleTitle.of("일정제목1"))
                         .place(Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                         .build();
@@ -1671,7 +1671,7 @@ public class TripTest {
                 Schedule schedule2 = Schedule.builder()
                         .day(targetDay)
                         .trip(trip)
-                        .title("일정제목2")
+                        .scheduleTitle(ScheduleTitle.of("일정제목2"))
                         .place(Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.of(ScheduleIndex.MAX_INDEX_VALUE))
                         .build();
@@ -1695,8 +1695,8 @@ public class TripTest {
                 Day beforeDay = trip.getDays().get(0);
                 Day targetDay = null;
 
-                Schedule schedule1 = trip.createSchedule(beforeDay, "일정제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule2 = trip.createSchedule(targetDay, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(beforeDay, ScheduleTitle.of("일정제목1"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(targetDay, ScheduleTitle.of("일정제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when
                 ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule1, targetDay, 0);
@@ -1727,7 +1727,7 @@ public class TripTest {
                 Schedule schedule1 = Schedule.builder()
                         .day(beforeDay)
                         .trip(trip)
-                        .title("일정제목1")
+                        .scheduleTitle(ScheduleTitle.of("일정제목1"))
                         .place(Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                         .build();
@@ -1735,7 +1735,7 @@ public class TripTest {
                 Schedule schedule2 = Schedule.builder()
                         .day(targetDay)
                         .trip(trip)
-                        .title("일정제목2")
+                        .scheduleTitle(ScheduleTitle.of("일정제목2"))
                         .place(Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.of(ScheduleIndex.MIN_INDEX_VALUE))
                         .build();
@@ -1758,9 +1758,9 @@ public class TripTest {
                 Day beforeDay = trip.getDays().get(0);
                 Day targetDay = null;
 
-                Schedule schedule1 = trip.createSchedule(beforeDay, "일정제목1", Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule2 = trip.createSchedule(targetDay, "일정제목2", Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule3 = trip.createSchedule(targetDay, "일정제목3", Place.of("place-id333", "place 이름333", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(beforeDay, ScheduleTitle.of("일정제목1"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(targetDay, ScheduleTitle.of("일정제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule3 = trip.createSchedule(targetDay, ScheduleTitle.of("일정제목3"), Place.of("place-id333", "place 이름333", Coordinate.of(37.72221, 137.86523)));
 
                 // when
                 ScheduleMoveDto scheduleMoveDto = trip.moveSchedule(schedule1, targetDay, 1);
@@ -1793,7 +1793,7 @@ public class TripTest {
                 Schedule schedule1 = Schedule.builder()
                         .day(beforeDay)
                         .trip(trip)
-                        .title("일정제목1")
+                        .scheduleTitle(ScheduleTitle.of("일정제목1"))
                         .place(Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                         .build();
@@ -1801,7 +1801,7 @@ public class TripTest {
                 Schedule schedule2 = Schedule.builder()
                         .day(targetDay)
                         .trip(trip)
-                        .title("일정제목2")
+                        .scheduleTitle(ScheduleTitle.of("일정제목2"))
                         .place(Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.of(10))
                         .build();
@@ -1809,7 +1809,7 @@ public class TripTest {
                 Schedule schedule3 = Schedule.builder()
                         .day(targetDay)
                         .trip(trip)
-                        .title("일정제목3")
+                        .scheduleTitle(ScheduleTitle.of("일정제목3"))
                         .place(Place.of("place-id333", "place 이름333", Coordinate.of(37.72221, 137.86523)))
                         .scheduleIndex(ScheduleIndex.of(11))
                         .build();

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/repository/DayRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/repository/DayRepositoryTest.java
@@ -6,6 +6,7 @@ import com.cosain.trilo.trip.domain.entity.Trip;
 import com.cosain.trilo.trip.domain.repository.DayRepository;
 import com.cosain.trilo.trip.domain.vo.TripPeriod;
 import com.cosain.trilo.trip.domain.vo.TripStatus;
+import com.cosain.trilo.trip.domain.vo.TripTitle;
 import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
@@ -34,7 +35,7 @@ public class DayRepositoryTest {
         // given
         Trip trip = Trip.builder()
                 .tripperId(1L)
-                .title("여행 제목")
+                .tripTitle(TripTitle.of("여행 제목"))
                 .status(TripStatus.DECIDED)
                 .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
                 .build();
@@ -63,7 +64,7 @@ public class DayRepositoryTest {
     void deleteAllByIdsTest() {
 
         // given
-        Trip trip = Trip.create("제목", 1L);
+        Trip trip = Trip.create(TripTitle.of("제목"), 1L);
         em.persist(trip);
 
         Day day1 = Day.of(LocalDate.of(2023, 5, 1), trip);
@@ -92,7 +93,7 @@ public class DayRepositoryTest {
         // given
         Trip trip = Trip.builder()
                 .tripperId(1L)
-                .title("여행 제목")
+                .tripTitle(TripTitle.of("여행 제목"))
                 .status(TripStatus.DECIDED)
                 .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 3)))
                 .build();

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/repository/ScheduleRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/repository/ScheduleRepositoryTest.java
@@ -49,7 +49,7 @@ public class ScheduleRepositoryTest {
         Schedule schedule = Schedule.builder()
                 .day(day)
                 .trip(trip)
-                .title("제목")
+                .scheduleTitle(ScheduleTitle.of("제목"))
                 .content("본문")
                 .place(Place.of("place-id", "광안리 해수욕장", Coordinate.of(43.1275, 132.127)))
                 .build();
@@ -61,7 +61,7 @@ public class ScheduleRepositoryTest {
         // then
         Schedule findSchedule = scheduleRepository.findById(schedule.getId()).get();
         assertThat(findSchedule.getId()).isEqualTo(schedule.getId());
-        assertThat(findSchedule.getTitle()).isEqualTo(schedule.getTitle());
+        assertThat(findSchedule.getScheduleTitle()).isEqualTo(schedule.getScheduleTitle());
         assertThat(findSchedule.getContent()).isEqualTo(schedule.getContent());
         assertThat(findSchedule.getPlace()).isEqualTo(schedule.getPlace());
     }
@@ -84,7 +84,7 @@ public class ScheduleRepositoryTest {
         Day day = Day.of(LocalDate.of(2023, 3, 1), trip);
         em.persist(day);
 
-        Schedule schedule = trip.createSchedule(day, "일정1", Place.of("place-id1", "광안리 해수욕장", Coordinate.of(35.1551, 129.1220)));
+        Schedule schedule = trip.createSchedule(day, ScheduleTitle.of("일정1"), Place.of("place-id1", "광안리 해수욕장", Coordinate.of(35.1551, 129.1220)));
         em.persist(schedule);
 
         // when
@@ -120,9 +120,9 @@ public class ScheduleRepositoryTest {
         em.persist(day2);
         em.persist(day3);
 
-        Schedule schedule1 = trip.createSchedule(day1, "일정1", Place.of("place-id1", "광안리 해수욕장", Coordinate.of(35.1551, 129.1220)));
-        Schedule schedule2 = trip.createSchedule(day2, "일정2", Place.of("place-id2", "광화문 광장", Coordinate.of(37.5748, 126.9767)));
-        Schedule schedule3 = trip.createSchedule(day3, "일정3", Place.of("place-id3", "도쿄 타워", Coordinate.of(35.3931, 139.4443)));
+        Schedule schedule1 = trip.createSchedule(day1, ScheduleTitle.of("일정1"), Place.of("place-id1", "광안리 해수욕장", Coordinate.of(35.1551, 129.1220)));
+        Schedule schedule2 = trip.createSchedule(day2, ScheduleTitle.of("일정2"), Place.of("place-id2", "광화문 광장", Coordinate.of(37.5748, 126.9767)));
+        Schedule schedule3 = trip.createSchedule(day3, ScheduleTitle.of("일정3"), Place.of("place-id3", "도쿄 타워", Coordinate.of(35.3931, 139.4443)));
 
         em.persist(schedule1);
         em.persist(schedule2);
@@ -154,9 +154,9 @@ public class ScheduleRepositoryTest {
         Day day = Day.of(LocalDate.of(2023, 3, 1), trip);
         em.persist(day);
 
-        Schedule schedule1 = trip.createSchedule(day, "일정1", Place.of("place-id1", "광안리 해수욕장1", Coordinate.of(35.1551, 129.1220)));
-        Schedule schedule2 = trip.createSchedule(day, "일정2", Place.of("place-id2", "광안리 해수욕장2", Coordinate.of(35.1551, 129.1220)));
-        Schedule schedule3 = trip.createSchedule(day, "일정3", Place.of("place-id3", "광안리 해수욕장3", Coordinate.of(35.1551, 129.1220)));
+        Schedule schedule1 = trip.createSchedule(day, ScheduleTitle.of("일정1"), Place.of("place-id1", "광안리 해수욕장1", Coordinate.of(35.1551, 129.1220)));
+        Schedule schedule2 = trip.createSchedule(day, ScheduleTitle.of("일정2"), Place.of("place-id2", "광안리 해수욕장2", Coordinate.of(35.1551, 129.1220)));
+        Schedule schedule3 = trip.createSchedule(day, ScheduleTitle.of("일정3"), Place.of("place-id3", "광안리 해수욕장3", Coordinate.of(35.1551, 129.1220)));
 
         em.persist(schedule1);
         em.persist(schedule2);
@@ -170,7 +170,7 @@ public class ScheduleRepositoryTest {
         // then
         assertThat(findSchedule.getId()).isEqualTo(schedule2.getId());
         assertThat(findSchedule.getTrip().getId()).isEqualTo(trip.getId());
-        assertThat(findSchedule.getTitle()).isEqualTo(schedule2.getTitle());
+        assertThat(findSchedule.getScheduleTitle()).isEqualTo(schedule2.getScheduleTitle());
         assertThat(findSchedule.getPlace()).isEqualTo(schedule2.getPlace());
     }
 
@@ -435,7 +435,7 @@ public class ScheduleRepositoryTest {
         return Schedule.builder()
                 .day(day)
                 .trip(trip)
-                .title("일정 제목")
+                .scheduleTitle(ScheduleTitle.of("일정 제목"))
                 .place(Place.of("place-id", "더미 제목", Coordinate.of(35.1551, 129.1220)))
                 .scheduleIndex(scheduleIndex)
                 .build();

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/repository/ScheduleRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/repository/ScheduleRepositoryTest.java
@@ -36,7 +36,7 @@ public class ScheduleRepositoryTest {
         // given
         Trip trip = Trip.builder()
                 .tripperId(1L)
-                .title("여행 제목")
+                .tripTitle(TripTitle.of("여행 제목"))
                 .status(TripStatus.DECIDED)
                 .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
                 .build();
@@ -74,7 +74,7 @@ public class ScheduleRepositoryTest {
         // given
         Trip trip = Trip.builder()
                 .tripperId(1L)
-                .title("여행 제목")
+                .tripTitle(TripTitle.of("여행 제목"))
                 .status(TripStatus.DECIDED)
                 .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
                 .build();
@@ -105,7 +105,7 @@ public class ScheduleRepositoryTest {
         // given
         Trip trip = Trip.builder()
                 .tripperId(1L)
-                .title("여행 제목")
+                .tripTitle(TripTitle.of(("여행 제목")))
                 .status(TripStatus.DECIDED)
                 .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 3)))
                 .build();
@@ -145,7 +145,7 @@ public class ScheduleRepositoryTest {
         // given
         Trip trip = Trip.builder()
                 .tripperId(1L)
-                .title("여행 제목")
+                .tripTitle(TripTitle.of("여행 제목"))
                 .status(TripStatus.DECIDED)
                 .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
                 .build();
@@ -185,7 +185,7 @@ public class ScheduleRepositoryTest {
             // given
             Trip trip = Trip.builder()
                     .tripperId(1L)
-                    .title("여행 제목")
+                    .tripTitle(TripTitle.of("여행 제목"))
                     .status(TripStatus.DECIDED)
                     .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
                     .build();
@@ -243,7 +243,7 @@ public class ScheduleRepositoryTest {
             // given
             Trip trip = Trip.builder()
                     .tripperId(1L)
-                    .title("여행 제목")
+                    .tripTitle(TripTitle.of("여행 제목"))
                     .status(TripStatus.DECIDED)
                     .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)))
                     .build();
@@ -307,7 +307,7 @@ public class ScheduleRepositoryTest {
             // given
             Trip trip = Trip.builder()
                     .tripperId(1L)
-                    .title("여행 제목")
+                    .tripTitle(TripTitle.of("여행 제목"))
                     .status(TripStatus.DECIDED)
                     .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 3)))
                     .build();
@@ -376,7 +376,7 @@ public class ScheduleRepositoryTest {
             // given
             Trip trip = Trip.builder()
                     .tripperId(1L)
-                    .title("여행 제목")
+                    .tripTitle(TripTitle.of("여행 제목"))
                     .status(TripStatus.DECIDED)
                     .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 3)))
                     .build();

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/repository/ScheduleRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/repository/ScheduleRepositoryTest.java
@@ -50,7 +50,7 @@ public class ScheduleRepositoryTest {
                 .day(day)
                 .trip(trip)
                 .scheduleTitle(ScheduleTitle.of("제목"))
-                .content("본문")
+                .scheduleContent(ScheduleContent.of("본문"))
                 .place(Place.of("place-id", "광안리 해수욕장", Coordinate.of(43.1275, 132.127)))
                 .build();
 
@@ -62,7 +62,7 @@ public class ScheduleRepositoryTest {
         Schedule findSchedule = scheduleRepository.findById(schedule.getId()).get();
         assertThat(findSchedule.getId()).isEqualTo(schedule.getId());
         assertThat(findSchedule.getScheduleTitle()).isEqualTo(schedule.getScheduleTitle());
-        assertThat(findSchedule.getContent()).isEqualTo(schedule.getContent());
+        assertThat(findSchedule.getScheduleContent()).isEqualTo(schedule.getScheduleContent());
         assertThat(findSchedule.getPlace()).isEqualTo(schedule.getPlace());
     }
 

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/repository/TripRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/repository/TripRepositoryTest.java
@@ -35,7 +35,7 @@ public class TripRepositoryTest {
         @Test
         @DisplayName("같은 id로 조회하면 같은 여행이 찾아진다.")
         void successTest() {
-            Trip trip = Trip.create("제목", 1L);
+            Trip trip = Trip.create(TripTitle.of("제목"), 1L);
             tripRepository.save(trip);
 
             em.clear();
@@ -50,7 +50,7 @@ public class TripRepositoryTest {
         @DisplayName("임시보관함을 지연로딩(기본 양방향 매핑)하여 얻어오면, 순서대로 요소들이 가져와진다.")
         void lazy_loading_TemporaryStorage() {
             // given
-            Trip trip = Trip.create("제목", 1L);
+            Trip trip = Trip.create(TripTitle.of("제목"), 1L);
             tripRepository.save(trip);
 
             Schedule schedule1 = Schedule.builder()
@@ -103,7 +103,7 @@ public class TripRepositoryTest {
         @DisplayName("UnDecided 상태의 Trip을 조회하면 여행만 조회된다.")
         public void findUndecidedTripTest() {
             // given
-            Trip trip = Trip.create("제목", 1L);
+            Trip trip = Trip.create(TripTitle.of("제목"), 1L);
             em.persist(trip);
 
             em.clear();
@@ -112,7 +112,7 @@ public class TripRepositoryTest {
             Trip findTrip = tripRepository.findByIdWithDays(trip.getId()).get();
 
             // then
-            assertThat(findTrip.getTitle()).isEqualTo(trip.getTitle());
+            assertThat(findTrip.getTripTitle()).isEqualTo(trip.getTripTitle());
             assertThat(findTrip.getId()).isEqualTo(trip.getId());
             assertThat(findTrip.getDays()).isEmpty();
         }
@@ -124,6 +124,7 @@ public class TripRepositoryTest {
             // given
             Trip trip = Trip.builder()
                     .tripperId(1L)
+                    .tripTitle(TripTitle.of("여행 제목"))
                     .tripPeriod(TripPeriod.of(LocalDate.of(2023,5,1), LocalDate.of(2023,5,3)))
                     .status(TripStatus.DECIDED)
                     .build();
@@ -144,7 +145,7 @@ public class TripRepositoryTest {
             Trip findTrip = tripRepository.findByIdWithDays(trip.getId()).get();
 
             // then
-            assertThat(findTrip.getTitle()).isEqualTo(trip.getTitle());
+            assertThat(findTrip.getTripTitle()).isEqualTo(trip.getTripTitle());
             assertThat(findTrip.getId()).isEqualTo(trip.getId());
             assertThat(findTrip.getDays()).map(Day::getTripDate).containsExactly(
                     LocalDate.of(2023,5,1), LocalDate.of(2023,5,2), LocalDate.of(2023,5,3));
@@ -158,7 +159,7 @@ public class TripRepositoryTest {
         // given
         Trip trip = Trip.builder()
                 .tripperId(1L)
-                .title("여행 제목")
+                .tripTitle(TripTitle.of("여행 제목"))
                 .status(TripStatus.DECIDED)
                 .tripPeriod(TripPeriod.of(LocalDate.of(2023,3,1), LocalDate.of(2023,3,3)))
                 .build();

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/repository/TripRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/repository/TripRepositoryTest.java
@@ -56,7 +56,7 @@ public class TripRepositoryTest {
             Schedule schedule1 = Schedule.builder()
                     .day(null)
                     .trip(trip)
-                    .title("일정1")
+                    .scheduleTitle(ScheduleTitle.of("일정1"))
                     .place(Place.of("place-id1", "광안리 해수욕장111", Coordinate.of(35.1551, 129.1220)))
                     .scheduleIndex(ScheduleIndex.of(30_000_000L))
                     .build();
@@ -64,7 +64,7 @@ public class TripRepositoryTest {
             Schedule schedule2 = Schedule.builder()
                     .day(null)
                     .trip(trip)
-                    .title("일정2")
+                    .scheduleTitle(ScheduleTitle.of("일정2"))
                     .place(Place.of("place-id2", "광안리 해수욕장222", Coordinate.of(35.1551, 129.1220)))
                     .scheduleIndex(ScheduleIndex.of(50_000_000L))
                     .build();
@@ -73,7 +73,7 @@ public class TripRepositoryTest {
             Schedule schedule3 = Schedule.builder()
                     .day(null)
                     .trip(trip)
-                    .title("일정3")
+                    .scheduleTitle(ScheduleTitle.of("일정3"))
                     .place(Place.of("place-id3", "광안리 해수욕장333", Coordinate.of(35.1551, 129.1220)))
                     .scheduleIndex(ScheduleIndex.of(-10_000_000L))
                     .build();

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/vo/CoordinateTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/vo/CoordinateTest.java
@@ -19,10 +19,45 @@ public class CoordinateTest {
     @DisplayName("Coordinate 생성 테스트")
     class CreateCoordinate_from_of_method {
 
+        @Test
+        @DisplayName("위도가 누락되면 InvalidCoordinateException 발생")
+        public void nullLatitudeTest() {
+            // given
+            Double latitude =  null;
+            Double longitude = 123.771;
+
+            // when & then
+            assertThatThrownBy(() -> Coordinate.of(latitude, longitude))
+                    .isInstanceOf(InvalidCoordinateException.class);
+        }
+
+        @Test
+        @DisplayName("경도가 누락되면 InvalidCoordinateException 발생")
+        public void nullLongitudeTest() {
+            // given
+            Double latitude =  37.1246;
+            Double longitude = null;
+
+            // when & then
+            assertThatThrownBy(() -> Coordinate.of(latitude, longitude))
+                    .isInstanceOf(InvalidCoordinateException.class);
+        }
+
+        @Test
+        @DisplayName("위도, 경도가 모두 누락되면 InvalidCoordinateException 발생")
+        public void nullLatitudeAndLongitudeTest() {
+            // given
+            Double latitude =  null;
+            Double longitude = null;
+
+            // when & then
+            assertThatThrownBy(() -> Coordinate.of(latitude, longitude))
+                    .isInstanceOf(InvalidCoordinateException.class);
+        }
 
         @ParameterizedTest
         @ValueSource(doubles = {-255, -123.12, -91, -90.001, 90.001, 91, 100.123, 255})
-        @DisplayName("위도의 범위가 -90보다 작거나, 90보다 크면 InvalidLatitudeException이 발생한다.")
+        @DisplayName("위도의 범위가 -90보다 작거나, 90보다 크면 InvalidCoordinateException이 발생한다.")
         public void when_invalid_latitude_it_throws_InvalidCoordinateException(double invalidLatitude) {
             // given
             double longitude = 135.172;
@@ -50,7 +85,6 @@ public class CoordinateTest {
         public void createSuccess() {
             // given
             double latitude = 37.72221;
-
             double longitude = 137.86523;
 
             // when

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/vo/ScheduleTitleTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/vo/ScheduleTitleTest.java
@@ -1,0 +1,86 @@
+package com.cosain.trilo.unit.trip.domain.vo;
+
+import com.cosain.trilo.trip.domain.exception.InvalidScheduleTitleException;
+import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("ScheduleTitle 테스트")
+public class ScheduleTitleTest {
+
+    @Test
+    @DisplayName("null 제목 -> InvalidScheduleTitleException 발생")
+    void nullScheduleTitleTest() {
+        // given
+        String nullTitle = null;
+
+        // when
+        assertThatThrownBy(() -> ScheduleTitle.of(nullTitle))
+                .isInstanceOf(InvalidScheduleTitleException.class);
+    }
+
+    @Test
+    @DisplayName("빈 문자열 제목 -> InvalidScheduleTitleException 발생")
+    void emptyScheduleTitleTest() {
+        // given
+        String emptyTitle = "";
+
+        // when
+        assertThatThrownBy(() -> ScheduleTitle.of(emptyTitle))
+                .isInstanceOf(InvalidScheduleTitleException.class);
+    }
+
+    @Test
+    @DisplayName("공백만으로 구성된 제목 -> InvalidScheduleTitleException 발생")
+    void whiteSpaceScheduleTitleTest() {
+        // given
+        String whiteSpaceTitle = "   ";
+
+        // when
+        assertThatThrownBy(() -> ScheduleTitle.of(whiteSpaceTitle))
+                .isInstanceOf(InvalidScheduleTitleException.class);
+    }
+
+    @Test
+    @DisplayName("제한 길이보다 긴 제목 -> InvalidScheduleTitleException 발생")
+    void tooLongScheduleTitleTest() {
+        // given
+        String tooLongTitle = "A".repeat(ScheduleTitle.MAX_LENGTH + 1);
+
+        // when
+        assertThatThrownBy(() -> ScheduleTitle.of(tooLongTitle))
+                .isInstanceOf(InvalidScheduleTitleException.class);
+    }
+
+    @Test
+    @DisplayName("정상적인 길이의 비어있지 않은 여행제목 -> 생성 성공")
+    void createScheduleTitleSuccessTest() {
+        // given
+        String normalTitle = "정상적인 제목";
+
+        // when
+        ScheduleTitle title = ScheduleTitle.of(normalTitle);
+
+        // then
+        assertThat(title.getValue()).isEqualTo(normalTitle);
+    }
+
+    @Test
+    @DisplayName("같은 제목일 때 동등하다")
+    void equalsTest() {
+        // given
+        String normalTitle = "정상적인 제목";
+        ScheduleTitle title1 = ScheduleTitle.of(normalTitle);
+        ScheduleTitle title2 = ScheduleTitle.of(normalTitle);
+
+        // when
+        boolean equality = title1.equals(title2);
+
+        // then
+        assertTrue(equality);
+    }
+}

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/vo/TripPeriodTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/vo/TripPeriodTest.java
@@ -1,6 +1,7 @@
 package com.cosain.trilo.unit.trip.domain.vo;
 
 import com.cosain.trilo.trip.domain.exception.InvalidPeriodException;
+import com.cosain.trilo.trip.domain.exception.TooLongPeriodException;
 import com.cosain.trilo.trip.domain.vo.TripPeriod;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -126,6 +127,43 @@ public class TripPeriodTest {
                 // then
                 assertThat(period.getStartDate()).isEqualTo(startDate);
                 assertThat(period.getEndDate()).isEqualTo(endDate);
+            }
+        }
+
+        @Nested
+        @DisplayName("일수가 10일일 경우")
+        class If_numberOfDays_is_10 {
+
+            @Test
+            @DisplayName("정상적으로 TripPeriod가 생성된다.")
+            public void it_returns_TripPeriod_successfully() {
+                // given
+                LocalDate startDate = LocalDate.of(2023, 5, 1);
+                LocalDate endDate = LocalDate.of(2023, 5, 10);
+
+                // when
+                TripPeriod period = TripPeriod.of(startDate, endDate);
+
+                // then
+                assertThat(period.getStartDate()).isEqualTo(startDate);
+                assertThat(period.getEndDate()).isEqualTo(endDate);
+            }
+        }
+
+        @Nested
+        @DisplayName("일수가 10일을 넘을 경우")
+        class If_numberOfDays_is_over_10 {
+
+            @Test
+            @DisplayName("TooLongPeriodException이 발생한다.")
+            public void it_throws_TooLongPeriodException() {
+                // given
+                LocalDate startDate = LocalDate.of(2023, 5, 1);
+                LocalDate endDate = LocalDate.of(2023, 5, 11);
+
+                // when & then
+                assertThatThrownBy(() -> TripPeriod.of(startDate, endDate))
+                        .isInstanceOf(TooLongPeriodException.class);
             }
         }
     }

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/vo/TripTitleTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/vo/TripTitleTest.java
@@ -1,0 +1,86 @@
+package com.cosain.trilo.unit.trip.domain.vo;
+
+import com.cosain.trilo.trip.domain.exception.InvalidTripTitleException;
+import com.cosain.trilo.trip.domain.vo.TripTitle;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("TripTitle 테스트")
+public class TripTitleTest {
+
+    @Test
+    @DisplayName("null 제목 -> InvalidTripTitleException 발생")
+    void nullTripTitleTest() {
+        // given
+        String nullTitle = null;
+
+        // when
+        assertThatThrownBy(() -> TripTitle.of(nullTitle))
+                .isInstanceOf(InvalidTripTitleException.class);
+    }
+
+    @Test
+    @DisplayName("빈 문자열 제목 -> InvalidTripTitleException 발생")
+    void emptyTripTitleTest() {
+        // given
+        String emptyTitle = "";
+
+        // when
+        assertThatThrownBy(() -> TripTitle.of(emptyTitle))
+                .isInstanceOf(InvalidTripTitleException.class);
+    }
+
+    @Test
+    @DisplayName("공백만으로 구성된 제목 -> InvalidTripTitleException 발생")
+    void whiteSpaceTripTitleTest() {
+        // given
+        String whiteSpaceTitle = "   ";
+
+        // when
+        assertThatThrownBy(() -> TripTitle.of(whiteSpaceTitle))
+                .isInstanceOf(InvalidTripTitleException.class);
+    }
+
+    @Test
+    @DisplayName("제한 길이보다 긴 제목 -> InvalidTripTitleException 발생")
+    void tooLongTripTitleTest() {
+        // given
+        String tooLongTitle = "A".repeat(TripTitle.MAX_LENGTH + 1);
+
+        // when
+        assertThatThrownBy(() -> TripTitle.of(tooLongTitle))
+                .isInstanceOf(InvalidTripTitleException.class);
+    }
+
+    @Test
+    @DisplayName("정상적인 길이의 비어있지 않은 여행제목 -> 생성 성공")
+    void createTripTitleSuccessTest() {
+        // given
+        String normalTitle = "정상적인 제목";
+
+        // when
+        TripTitle title = TripTitle.of(normalTitle);
+
+        // then
+        assertThat(title.getValue()).isEqualTo(normalTitle);
+    }
+
+    @Test
+    @DisplayName("같은 제목일 때 동등하다")
+    void equalsTest() {
+        // given
+        String normalTitle = "정상적인 제목";
+        TripTitle title1 = TripTitle.of(normalTitle);
+        TripTitle title2 = TripTitle.of(normalTitle);
+
+        // when
+        boolean equality = title1.equals(title2);
+
+        // then
+        assertTrue(equality);
+    }
+}

--- a/src/test/java/com/cosain/trilo/unit/trip/infra/repository/DayScheduleQueryRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/infra/repository/DayScheduleQueryRepositoryTest.java
@@ -69,7 +69,7 @@ public class DayScheduleQueryRepositoryTest {
                 .scheduleTitle(ScheduleTitle.of("Test Schedule"))
                 .place(Place.of("장소 1", "광산구", Coordinate.of(62.62, 62.62)))
                 .scheduleIndex(ScheduleIndex.of(scheduleIndexValue))
-                .content("Test Content")
+                .scheduleContent(ScheduleContent.of("일정 본문"))
                 .build();
     }
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/infra/repository/DayScheduleQueryRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/infra/repository/DayScheduleQueryRepositoryTest.java
@@ -7,6 +7,7 @@ import com.cosain.trilo.trip.domain.entity.Trip;
 import com.cosain.trilo.trip.domain.vo.Coordinate;
 import com.cosain.trilo.trip.domain.vo.Place;
 import com.cosain.trilo.trip.domain.vo.ScheduleIndex;
+import com.cosain.trilo.trip.domain.vo.TripTitle;
 import com.cosain.trilo.trip.infra.repository.day.DayScheduleQueryRepository;
 import com.cosain.trilo.trip.infra.dto.DayScheduleDetail;
 import jakarta.persistence.EntityManager;
@@ -31,7 +32,7 @@ public class DayScheduleQueryRepositoryTest {
     @Test
     void Day_조회를_하면_해당_Day정보와_해당_Day에_속한_Schedule들의_요약정보와_함께_조회된다(){
         // given
-        Trip trip = Trip.create("여행제목", 1L);
+        Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
         em.persist(trip);
 
         Day day1 = Day.of(LocalDate.of(2023, 5, 10), trip);

--- a/src/test/java/com/cosain/trilo/unit/trip/infra/repository/DayScheduleQueryRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/infra/repository/DayScheduleQueryRepositoryTest.java
@@ -4,10 +4,7 @@ import com.cosain.trilo.support.RepositoryTest;
 import com.cosain.trilo.trip.domain.entity.Day;
 import com.cosain.trilo.trip.domain.entity.Schedule;
 import com.cosain.trilo.trip.domain.entity.Trip;
-import com.cosain.trilo.trip.domain.vo.Coordinate;
-import com.cosain.trilo.trip.domain.vo.Place;
-import com.cosain.trilo.trip.domain.vo.ScheduleIndex;
-import com.cosain.trilo.trip.domain.vo.TripTitle;
+import com.cosain.trilo.trip.domain.vo.*;
 import com.cosain.trilo.trip.infra.repository.day.DayScheduleQueryRepository;
 import com.cosain.trilo.trip.infra.dto.DayScheduleDetail;
 import jakarta.persistence.EntityManager;
@@ -69,7 +66,7 @@ public class DayScheduleQueryRepositoryTest {
         return Schedule.builder()
                 .trip(trip)
                 .day(day)
-                .title("Test Schedule")
+                .scheduleTitle(ScheduleTitle.of("Test Schedule"))
                 .place(Place.of("장소 1", "광산구", Coordinate.of(62.62, 62.62)))
                 .scheduleIndex(ScheduleIndex.of(scheduleIndexValue))
                 .content("Test Content")

--- a/src/test/java/com/cosain/trilo/unit/trip/infra/repository/ScheduleQueryRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/infra/repository/ScheduleQueryRepositoryTest.java
@@ -40,7 +40,7 @@ public class ScheduleQueryRepositoryTest {
                 .scheduleTitle(ScheduleTitle.of("Test Schedule"))
                 .place(Place.of("장소 1", "광산구", Coordinate.of(62.62, 62.62)))
                 .scheduleIndex(ScheduleIndex.ZERO_INDEX)
-                .content("Test Content")
+                .scheduleContent(ScheduleContent.of("일정 본문"))
                 .build();
         em.persist(schedule);
         em.flush();
@@ -56,8 +56,7 @@ public class ScheduleQueryRepositoryTest {
         assertThat(dto.getCoordinate().getLatitude()).isEqualTo(schedule.getPlace().getCoordinate().getLatitude());
         assertThat(dto.getCoordinate().getLatitude()).isEqualTo(schedule.getPlace().getCoordinate().getLongitude());
         assertThat(dto.getOrder()).isEqualTo(schedule.getScheduleIndex().getValue());
-        assertThat(dto.getContent()).isEqualTo(schedule.getContent());
-
+        assertThat(dto.getContent()).isEqualTo(schedule.getScheduleContent().getValue());
     }
 
     @Nested
@@ -111,7 +110,7 @@ public class ScheduleQueryRepositoryTest {
                     .scheduleTitle(ScheduleTitle.of("Test Schedule"))
                     .place(Place.of("장소 1", "광산구", Coordinate.of(62.62, 62.62)))
                     .scheduleIndex(ScheduleIndex.of(scheduleIndexValue))
-                    .content("Test Content")
+                    .scheduleContent(ScheduleContent.of("일정 본문"))
                     .build();
         }
     }

--- a/src/test/java/com/cosain/trilo/unit/trip/infra/repository/ScheduleQueryRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/infra/repository/ScheduleQueryRepositoryTest.java
@@ -4,12 +4,9 @@ package com.cosain.trilo.unit.trip.infra.repository;
 import com.cosain.trilo.support.RepositoryTest;
 import com.cosain.trilo.trip.domain.entity.Schedule;
 import com.cosain.trilo.trip.domain.entity.Trip;
-import com.cosain.trilo.trip.domain.vo.Coordinate;
-import com.cosain.trilo.trip.domain.vo.Place;
-import com.cosain.trilo.trip.domain.vo.ScheduleIndex;
+import com.cosain.trilo.trip.domain.vo.*;
 import com.cosain.trilo.trip.infra.dto.ScheduleDetail;
 import com.cosain.trilo.trip.infra.dto.ScheduleSummary;
-import com.cosain.trilo.trip.domain.vo.TripTitle;
 import com.cosain.trilo.trip.infra.repository.schedule.ScheduleQueryRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -40,7 +37,7 @@ public class ScheduleQueryRepositoryTest {
         em.persist(trip);
         Schedule schedule = Schedule.builder()
                 .trip(trip)
-                .title("Test Schedule")
+                .scheduleTitle(ScheduleTitle.of("Test Schedule"))
                 .place(Place.of("장소 1", "광산구", Coordinate.of(62.62, 62.62)))
                 .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                 .content("Test Content")
@@ -54,7 +51,7 @@ public class ScheduleQueryRepositoryTest {
         // then
         assertThat(dto.getScheduleId()).isEqualTo(schedule.getId());
         assertThat(dto.getScheduleId()).isEqualTo(schedule.getId());
-        assertThat(dto.getTitle()).isEqualTo(schedule.getTitle());
+        assertThat(dto.getTitle()).isEqualTo(schedule.getScheduleTitle().getValue());
         assertThat(dto.getPlaceName()).isEqualTo(schedule.getPlace().getPlaceName());
         assertThat(dto.getCoordinate().getLatitude()).isEqualTo(schedule.getPlace().getCoordinate().getLatitude());
         assertThat(dto.getCoordinate().getLatitude()).isEqualTo(schedule.getPlace().getCoordinate().getLongitude());
@@ -111,7 +108,7 @@ public class ScheduleQueryRepositoryTest {
         private Schedule createSchedule(Trip trip, long scheduleIndexValue){
             return Schedule.builder()
                     .trip(trip)
-                    .title("Test Schedule")
+                    .scheduleTitle(ScheduleTitle.of("Test Schedule"))
                     .place(Place.of("장소 1", "광산구", Coordinate.of(62.62, 62.62)))
                     .scheduleIndex(ScheduleIndex.of(scheduleIndexValue))
                     .content("Test Content")

--- a/src/test/java/com/cosain/trilo/unit/trip/infra/repository/ScheduleQueryRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/infra/repository/ScheduleQueryRepositoryTest.java
@@ -1,3 +1,4 @@
+
 package com.cosain.trilo.unit.trip.infra.repository;
 
 import com.cosain.trilo.support.RepositoryTest;
@@ -8,6 +9,7 @@ import com.cosain.trilo.trip.domain.vo.Place;
 import com.cosain.trilo.trip.domain.vo.ScheduleIndex;
 import com.cosain.trilo.trip.infra.dto.ScheduleDetail;
 import com.cosain.trilo.trip.infra.dto.ScheduleSummary;
+import com.cosain.trilo.trip.domain.vo.TripTitle;
 import com.cosain.trilo.trip.infra.repository.schedule.ScheduleQueryRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -34,7 +36,7 @@ public class ScheduleQueryRepositoryTest {
     @Test
     void findScheduleTest(){
         // given
-        Trip trip = Trip.create("제목", 1L);
+        Trip trip = Trip.create(TripTitle.of("제목"), 1L);
         em.persist(trip);
         Schedule schedule = Schedule.builder()
                 .trip(trip)
@@ -70,7 +72,7 @@ public class ScheduleQueryRepositoryTest {
         @DisplayName("tripId 가 일치하고 dayId 가 null 인 일정들이 페이지의 크기만큼 조회된다.")
         void findTest(){
             // given
-            Trip trip = Trip.create("제목", 1L);
+            Trip trip = Trip.create(TripTitle.of("제목"), 1L);
             em.persist(trip);
             Schedule schedule = createSchedule(trip, 1L);
             em.persist(schedule);
@@ -87,7 +89,7 @@ public class ScheduleQueryRepositoryTest {
         @DisplayName("scheduleIndex 기준 오름차순으로 조회된다.")
         void sortTest(){
             // given
-            Trip trip = Trip.create("제목", 1L);
+            Trip trip = Trip.create(TripTitle.of("제목"), 1L);
             em.persist(trip);
             Schedule schedule1 = createSchedule(trip, 1L);
             Schedule schedule2 = createSchedule(trip, 2L);

--- a/src/test/java/com/cosain/trilo/unit/trip/infra/repository/TripQueryRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/infra/repository/TripQueryRepositoryTest.java
@@ -1,3 +1,4 @@
+
 package com.cosain.trilo.unit.trip.infra.repository;
 
 import com.cosain.trilo.support.RepositoryTest;
@@ -6,6 +7,7 @@ import com.cosain.trilo.trip.domain.vo.TripPeriod;
 import com.cosain.trilo.trip.domain.vo.TripStatus;
 import com.cosain.trilo.trip.infra.dto.TripDetail;
 import com.cosain.trilo.trip.infra.dto.TripSummary;
+import com.cosain.trilo.trip.domain.vo.TripTitle;
 import com.cosain.trilo.trip.infra.repository.trip.TripQueryRepository;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
@@ -34,7 +36,7 @@ public class TripQueryRepositoryTest {
         // given
         Trip trip = Trip.builder()
                 .tripperId(1L)
-                .title("제목")
+                .tripTitle(TripTitle.of("제목"))
                 .status(TripStatus.DECIDED)
                 .tripPeriod(TripPeriod.of(LocalDate.of(2023, 5, 5), LocalDate.of(2023, 5, 10)))
                 .build();
@@ -44,7 +46,7 @@ public class TripQueryRepositoryTest {
         TripDetail tripDetail = tripQueryRepository.findTripDetailByTripId(1L).get();
 
         // then
-        assertThat(tripDetail.getTitle()).isEqualTo(trip.getTitle());
+        assertThat(tripDetail.getTitle()).isEqualTo(trip.getTripTitle().getValue());
         assertThat(tripDetail.getTripperId()).isEqualTo(trip.getTripperId());
         assertThat(tripDetail.getTripId()).isEqualTo(trip.getId());
         assertThat(tripDetail.getStartDate()).isEqualTo(trip.getTripPeriod().getStartDate());
@@ -62,14 +64,14 @@ public class TripQueryRepositoryTest {
             // given
             Trip trip1 = Trip.builder()
                     .tripperId(1L)
-                    .title("제목 1")
+                    .tripTitle(TripTitle.of("제목 1"))
                     .status(TripStatus.DECIDED)
                     .tripPeriod(TripPeriod.of(LocalDate.of(2023, 5, 5), LocalDate.of(2023, 5, 10)))
                     .build();
 
             Trip trip2 = Trip.builder()
                     .tripperId(1L)
-                    .title("제목 2")
+                    .tripTitle(TripTitle.of("제목 2"))
                     .status(TripStatus.DECIDED)
                     .tripPeriod(TripPeriod.of(LocalDate.of(2023, 5, 5), LocalDate.of(2023, 5, 10)))
                     .build();
@@ -91,14 +93,14 @@ public class TripQueryRepositoryTest {
             // given
             Trip trip1 = Trip.builder()
                     .tripperId(1L)
-                    .title("제목 1")
+                    .tripTitle(TripTitle.of("제목 1"))
                     .status(TripStatus.DECIDED)
                     .tripPeriod(TripPeriod.of(LocalDate.of(2023, 5, 5), LocalDate.of(2023, 5, 10)))
                     .build();
 
             Trip trip2 = Trip.builder()
                     .tripperId(1L)
-                    .title("제목 2")
+                    .tripTitle(TripTitle.of("제목 2"))
                     .status(TripStatus.DECIDED)
                     .tripPeriod(TripPeriod.of(LocalDate.of(2023, 5, 5), LocalDate.of(2023, 5, 10)))
                     .build();
@@ -112,9 +114,8 @@ public class TripQueryRepositoryTest {
 
 
             // then
-            assertThat(tripSummariesByTripperId.getContent().get(0).getTitle()).isEqualTo(trip2.getTitle());
-            assertThat(tripSummariesByTripperId.getContent().get(1).getTitle()).isEqualTo(trip1.getTitle());
-
+            assertThat(tripSummariesByTripperId.getContent().get(0).getTitle()).isEqualTo(trip2.getTripTitle().getValue());
+            assertThat(tripSummariesByTripperId.getContent().get(1).getTitle()).isEqualTo(trip1.getTripTitle().getValue());
         }
 
         @Test
@@ -122,7 +123,7 @@ public class TripQueryRepositoryTest {
             // given
             Trip trip = Trip.builder()
                     .tripperId(1L)
-                    .title("제목 1")
+                    .tripTitle(TripTitle.of("제목 1"))
                     .status(TripStatus.DECIDED)
                     .tripPeriod(TripPeriod.of(LocalDate.of(2023, 5, 5), LocalDate.of(2023, 5, 10)))
                     .build();
@@ -136,6 +137,5 @@ public class TripQueryRepositoryTest {
         }
 
     }
-
 
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/ScheduleDeleteControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/ScheduleDeleteControllerTest.java
@@ -23,7 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@DisplayName("[TripCommand] 일정 삭제 API 테스트")
+@DisplayName("일정 삭제 API 테스트")
 @WebMvcTest(ScheduleDeleteController.class)
 class ScheduleDeleteControllerTest extends RestControllerTest {
 

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/ScheduleMoveControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/ScheduleMoveControllerTest.java
@@ -27,7 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@DisplayName("[TripCommand] 일정 이동 API 테스트")
+@DisplayName("일정 이동 API 테스트")
 @WebMvcTest(ScheduleMoveController.class)
 public class ScheduleMoveControllerTest extends RestControllerTest {
 
@@ -90,6 +90,75 @@ public class ScheduleMoveControllerTest extends RestControllerTest {
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorCode").exists())
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
+
+    @Test
+    @DisplayName("비어있는 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void moveSchedule_with_emptyContent() throws Exception {
+        mockingForLoginUserAnnotation();
+
+        String emptyContent = "";
+
+        mockMvc.perform(patch("/api/schedules/1")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(emptyContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
+    @Test
+    @DisplayName("형식이 올바르지 않은 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void moveSchedule_with_invalidContent() throws Exception {
+        mockingForLoginUserAnnotation();
+        String invalidContent = """
+                {
+                    "targetDayId": 따옴표로 감싸지 않은 값,
+                    "targetOrder": 123
+                }
+                """;
+
+        mockMvc.perform(patch("/api/schedules/1")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(invalidContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
+    @Test
+    @DisplayName("타입이 올바르지 않은 요청 데이터 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void moveSchedule_with_invalidType() throws Exception {
+        mockingForLoginUserAnnotation();
+        String invalidTypeContent = """
+                {
+                    "targetDayId": 1,
+                    "targetOrder": "숫자가 아닌 값"
+                }
+                """;
+
+        mockMvc.perform(patch("/api/schedules/1")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(invalidTypeContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
                 .andExpect(jsonPath("$.errorMessage").exists())
                 .andExpect(jsonPath("$.errorDetail").exists());
     }

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/ScheduleMoveControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/ScheduleMoveControllerTest.java
@@ -5,6 +5,7 @@ import com.cosain.trilo.support.RestControllerTest;
 import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleMoveCommand;
 import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleMoveResult;
 import com.cosain.trilo.trip.application.schedule.command.usecase.ScheduleMoveUseCase;
+import com.cosain.trilo.trip.application.schedule.command.usecase.dto.factory.ScheduleMoveCommandFactory;
 import com.cosain.trilo.trip.presentation.schedule.command.ScheduleMoveController;
 import com.cosain.trilo.trip.presentation.schedule.command.dto.request.ScheduleMoveRequest;
 import org.junit.jupiter.api.DisplayName;
@@ -34,6 +35,9 @@ public class ScheduleMoveControllerTest extends RestControllerTest {
     @MockBean
     private ScheduleMoveUseCase scheduleMoveUseCase;
 
+    @MockBean
+    private ScheduleMoveCommandFactory scheduleMoveCommandFactory;
+
     private final static String ACCESS_TOKEN = "Bearer accessToken";
 
     @Test
@@ -53,6 +57,10 @@ public class ScheduleMoveControllerTest extends RestControllerTest {
                 .build();
 
         ScheduleMoveRequest request = new ScheduleMoveRequest(targetDayId, targetOrder);
+        ScheduleMoveCommand command = new ScheduleMoveCommand(targetDayId, targetOrder);
+
+        given(scheduleMoveCommandFactory.createCommand(eq(targetDayId), eq(targetOrder)))
+                .willReturn(command);
         given(scheduleMoveUseCase.moveSchedule(eq(scheduleId), any(), any(ScheduleMoveCommand.class)))
                 .willReturn(moveResult);
 
@@ -69,6 +77,7 @@ public class ScheduleMoveControllerTest extends RestControllerTest {
                 .andExpect(jsonPath("$.afterDayId").value(moveResult.getAfterDayId()))
                 .andExpect(jsonPath("$.positionChanged").value(moveResult.isPositionChanged()));
 
+        verify(scheduleMoveCommandFactory).createCommand(eq(targetDayId), eq(targetOrder));
         verify(scheduleMoveUseCase).moveSchedule(eq(scheduleId), any(), any(ScheduleMoveCommand.class));
     }
 

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/ScheduleUpdateControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/ScheduleUpdateControllerTest.java
@@ -1,8 +1,11 @@
 package com.cosain.trilo.unit.trip.presentation.schedule.command;
 
 import com.cosain.trilo.support.RestControllerTest;
-import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleUpdateCommand;
 import com.cosain.trilo.trip.application.schedule.command.usecase.ScheduleUpdateUseCase;
+import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleUpdateCommand;
+import com.cosain.trilo.trip.application.schedule.command.usecase.dto.factory.ScheduleUpdateCommandFactory;
+import com.cosain.trilo.trip.domain.vo.ScheduleContent;
+import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
 import com.cosain.trilo.trip.presentation.schedule.command.ScheduleUpdateController;
 import com.cosain.trilo.trip.presentation.schedule.command.dto.request.ScheduleUpdateRequest;
 import org.junit.jupiter.api.DisplayName;
@@ -15,8 +18,7 @@ import org.springframework.security.test.context.support.WithAnonymousUser;
 
 import java.nio.charset.StandardCharsets;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -31,6 +33,9 @@ class ScheduleUpdateControllerTest extends RestControllerTest {
     @MockBean
     private ScheduleUpdateUseCase scheduleUpdateUseCase;
 
+    @MockBean
+    private ScheduleUpdateCommandFactory scheduleUpdateCommandFactory;
+
     private final String ACCESS_TOKEN = "Bearer accessToken";
 
     @Test
@@ -39,21 +44,28 @@ class ScheduleUpdateControllerTest extends RestControllerTest {
 
         // given
         mockingForLoginUserAnnotation();
-        ScheduleUpdateRequest scheduleUpdateRequest = new ScheduleUpdateRequest("수정할 제목", "수정할 내용");
 
-        given(scheduleUpdateUseCase.updateSchedule(anyLong(),any(),any(ScheduleUpdateCommand.class))).willReturn(1L);
+        Long scheduleId = 1L;
+        String rawTitle = "수정할 제목";
+        String rawContent = "수정할 내용";
+        ScheduleUpdateRequest request = new ScheduleUpdateRequest(rawTitle, rawContent);
+        ScheduleUpdateCommand command = new ScheduleUpdateCommand(ScheduleTitle.of(rawContent), ScheduleContent.of(rawContent));
+
+        given(scheduleUpdateCommandFactory.createCommand(eq(rawTitle),eq(rawContent))).willReturn(command);
+        given(scheduleUpdateUseCase.updateSchedule(eq(scheduleId),any(),any(ScheduleUpdateCommand.class))).willReturn(1L);
 
         // when & then
-        mockMvc.perform(put("/api/schedules/1")
+        mockMvc.perform(put("/api/schedules/" + scheduleId)
                         .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
-                        .content(createJson(scheduleUpdateRequest))
+                        .content(createJson(request))
                         .contentType(MediaType.APPLICATION_JSON)
                         .characterEncoding(StandardCharsets.UTF_8))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.scheduleId").value(1L))
                 .andDo(print());
 
-        verify(scheduleUpdateUseCase).updateSchedule(anyLong(),any(),any(ScheduleUpdateCommand.class));
+        verify(scheduleUpdateCommandFactory).createCommand(eq(rawTitle), eq(rawContent));
+        verify(scheduleUpdateUseCase).updateSchedule(eq(scheduleId),any(),any(ScheduleUpdateCommand.class));
     }
 
     @Test

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/ScheduleUpdateControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/ScheduleUpdateControllerTest.java
@@ -68,4 +68,48 @@ class ScheduleUpdateControllerTest extends RestControllerTest {
                 .andExpect(jsonPath("$.errorDetail").exists());
     }
 
+
+    @Test
+    @DisplayName("비어있는 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void updateSchedule_with_emptyContent() throws Exception {
+        mockingForLoginUserAnnotation();
+
+        String emptyContent = "";
+
+        mockMvc.perform(put("/api/schedules/1")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(emptyContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
+    @Test
+    @DisplayName("형식이 올바르지 않은 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void updateSchedule_with_invalidContent() throws Exception {
+        mockingForLoginUserAnnotation();
+        String invalidContent = """
+                {
+                    "title": 따옴표로 감싸지 않은 제목,
+                    "content": "본문"
+                }
+                """;
+
+        mockMvc.perform(put("/api/schedules/1")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(invalidContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/TripCreateControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/TripCreateControllerTest.java
@@ -61,5 +61,49 @@ class TripCreateControllerTest extends RestControllerTest {
                 .andExpect(jsonPath("$.errorMessage").exists())
                 .andExpect(jsonPath("$.errorDetail").exists());
     }
-}
 
+
+    @Test
+    @DisplayName("비어있는 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void createTrip_with_emptyContent() throws Exception {
+        mockingForLoginUserAnnotation();
+
+        String emptyContent = "";
+
+        mockMvc.perform(post("/api/trips")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(emptyContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
+    @Test
+    @DisplayName("형식이 올바르지 않은 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void createTrip_with_invalidContent() throws Exception {
+        mockingForLoginUserAnnotation();
+        String invalidContent = """
+                {
+                    "title": 따옴표 안 감싼 제목
+                }
+                """;
+
+        mockMvc.perform(post("/api/trips")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(invalidContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
+}

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/TripCreateControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/TripCreateControllerTest.java
@@ -2,6 +2,9 @@ package com.cosain.trilo.unit.trip.presentation.trip.command;
 
 import com.cosain.trilo.support.RestControllerTest;
 import com.cosain.trilo.trip.application.trip.command.usecase.TripCreateUseCase;
+import com.cosain.trilo.trip.application.trip.command.usecase.dto.TripCreateCommand;
+import com.cosain.trilo.trip.application.trip.command.usecase.dto.factory.TripCreateCommandFactory;
+import com.cosain.trilo.trip.domain.vo.TripTitle;
 import com.cosain.trilo.trip.presentation.trip.command.TripCreateController;
 import com.cosain.trilo.trip.presentation.trip.command.dto.request.TripCreateRequest;
 import org.junit.jupiter.api.DisplayName;
@@ -15,6 +18,7 @@ import org.springframework.security.test.context.support.WithAnonymousUser;
 import java.nio.charset.StandardCharsets;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -29,14 +33,19 @@ class TripCreateControllerTest extends RestControllerTest {
     @MockBean
     private TripCreateUseCase tripCreateUseCase;
 
+    @MockBean
+    private TripCreateCommandFactory tripCreateCommandFactory;
+
     private final static String ACCESS_TOKEN = "Bearer accessToken";
 
     @Test
     @DisplayName("인증된 사용자의 여행 생성 요청 -> 성공")
     public void successTest() throws Exception {
         mockingForLoginUserAnnotation();
-        TripCreateRequest request = new TripCreateRequest("제목");
-        given(tripCreateUseCase.createTrip(any(), any())).willReturn(1L);
+        String rawTitle = "제목";
+        TripCreateRequest request = new TripCreateRequest(rawTitle);
+        given(tripCreateCommandFactory.createCommand(eq(rawTitle))).willReturn(new TripCreateCommand(TripTitle.of(rawTitle)));
+        given(tripCreateUseCase.createTrip(any(), any(TripCreateCommand.class))).willReturn(1L);
 
         mockMvc.perform(post("/api/trips")
                         .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
@@ -106,116 +115,4 @@ class TripCreateControllerTest extends RestControllerTest {
                 .andExpect(jsonPath("$.errorDetail").exists());
     }
 
-    @Test
-    @DisplayName("제목이 null -> 필드 검증 실패 -> 400 예외")
-    public void createTrip_with_nullTitle() throws Exception {
-        mockingForLoginUserAnnotation();
-        TripCreateRequest request = new TripCreateRequest(null);
-
-        mockMvc.perform(post("/api/trips")
-                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
-                        .content(createJson(request))
-                        .characterEncoding(StandardCharsets.UTF_8)
-                        .contentType(MediaType.APPLICATION_JSON)
-                )
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errorCode").value("request-0003"))
-                .andExpect(jsonPath("$.errorMessage").exists())
-                .andExpect(jsonPath("$.errorDetail").exists())
-                .andExpect(jsonPath("$.fieldErrors").exists())
-                .andExpect(jsonPath("$.fieldErrors").isNotEmpty())
-                .andExpect(jsonPath("$.fieldErrors[*].errorCode").exists())
-                .andExpect(jsonPath("$.fieldErrors[*].errorMessage").exists())
-                .andExpect(jsonPath("$.fieldErrors[*].errorDetail").exists())
-                .andExpect(jsonPath("$.fieldErrors[*].field").exists())
-                .andExpect(jsonPath("$.fieldErrors[?(@.field=='title' && @.errorCode=='trip-0002')]").exists())
-                .andExpect(jsonPath("$.globalErrors").exists())
-                .andExpect(jsonPath("$.globalErrors").isEmpty());
-    }
-
-    @Test
-    @DisplayName("제목이 빈 문자열 -> 필드 검증 실패 -> 400 예외")
-    public void createTrip_with_emptyTitle() throws Exception {
-        mockingForLoginUserAnnotation();
-        TripCreateRequest request = new TripCreateRequest("");
-
-        mockMvc.perform(post("/api/trips")
-                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
-                        .content(createJson(request))
-                        .characterEncoding(StandardCharsets.UTF_8)
-                        .contentType(MediaType.APPLICATION_JSON)
-                )
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errorCode").value("request-0003"))
-                .andExpect(jsonPath("$.errorMessage").exists())
-                .andExpect(jsonPath("$.errorDetail").exists())
-                .andExpect(jsonPath("$.fieldErrors").exists())
-                .andExpect(jsonPath("$.fieldErrors").exists())
-                .andExpect(jsonPath("$.fieldErrors").isNotEmpty())
-                .andExpect(jsonPath("$.fieldErrors[*].errorCode").exists())
-                .andExpect(jsonPath("$.fieldErrors[*].errorMessage").exists())
-                .andExpect(jsonPath("$.fieldErrors[*].errorDetail").exists())
-                .andExpect(jsonPath("$.fieldErrors[*].field").exists())
-                .andExpect(jsonPath("$.fieldErrors[?(@.field=='title' && @.errorCode=='trip-0002')]").exists())
-                .andExpect(jsonPath("$.globalErrors").exists())
-                .andExpect(jsonPath("$.globalErrors").isEmpty());
-    }
-
-    @Test
-    @DisplayName("제목이 공백만으로 구성된 문자열 -> 필드 검증 실패 -> 400 예외")
-    public void createTrip_with_whiteSpaceTitle() throws Exception {
-        mockingForLoginUserAnnotation();
-        TripCreateRequest request = new TripCreateRequest("     ");
-
-        mockMvc.perform(post("/api/trips")
-                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
-                        .content(createJson(request))
-                        .characterEncoding(StandardCharsets.UTF_8)
-                        .contentType(MediaType.APPLICATION_JSON)
-                )
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errorCode").value("request-0003"))
-                .andExpect(jsonPath("$.errorMessage").exists())
-                .andExpect(jsonPath("$.errorDetail").exists())
-                .andExpect(jsonPath("$.fieldErrors").exists())
-                .andExpect(jsonPath("$.fieldErrors").isNotEmpty())
-                .andExpect(jsonPath("$.fieldErrors[*].errorCode").exists())
-                .andExpect(jsonPath("$.fieldErrors[*].errorMessage").exists())
-                .andExpect(jsonPath("$.fieldErrors[*].errorDetail").exists())
-                .andExpect(jsonPath("$.fieldErrors[*].field").exists())
-                .andExpect(jsonPath("$.fieldErrors[?(@.field=='title' && @.errorCode=='trip-0002')]").exists())
-                .andExpect(jsonPath("$.globalErrors").exists())
-                .andExpect(jsonPath("$.globalErrors").isEmpty());
-    }
-
-    @Test
-    @DisplayName("제목이 20자를 넘어갈 떄 -> 필드 검증 실패 -> 400 예외")
-    public void createTrip_with_tooLongTitle() throws Exception {
-        mockingForLoginUserAnnotation();
-        TripCreateRequest request = new TripCreateRequest("가".repeat(21));
-
-        mockMvc.perform(post("/api/trips")
-                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
-                        .content(createJson(request))
-                        .characterEncoding(StandardCharsets.UTF_8)
-                        .contentType(MediaType.APPLICATION_JSON)
-                )
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errorCode").value("request-0003"))
-                .andExpect(jsonPath("$.errorMessage").exists())
-                .andExpect(jsonPath("$.errorDetail").exists())
-                .andExpect(jsonPath("$.fieldErrors").exists())
-                .andExpect(jsonPath("$.fieldErrors").isNotEmpty())
-                .andExpect(jsonPath("$.fieldErrors[*].errorCode").exists())
-                .andExpect(jsonPath("$.fieldErrors[*].errorMessage").exists())
-                .andExpect(jsonPath("$.fieldErrors[*].errorDetail").exists())
-                .andExpect(jsonPath("$.fieldErrors[*].field").exists())
-                .andExpect(jsonPath("$.fieldErrors[?(@.field=='title' && @.errorCode=='trip-0002')]").exists())
-                .andExpect(jsonPath("$.globalErrors").exists())
-                .andExpect(jsonPath("$.globalErrors").isEmpty());
-    }
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/TripCreateControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/TripCreateControllerTest.java
@@ -33,7 +33,7 @@ class TripCreateControllerTest extends RestControllerTest {
 
     @Test
     @DisplayName("인증된 사용자의 여행 생성 요청 -> 성공")
-    public void successTest() throws Exception{
+    public void successTest() throws Exception {
         mockingForLoginUserAnnotation();
         TripCreateRequest request = new TripCreateRequest("제목");
         given(tripCreateUseCase.createTrip(any(), any())).willReturn(1L);
@@ -106,4 +106,117 @@ class TripCreateControllerTest extends RestControllerTest {
                 .andExpect(jsonPath("$.errorDetail").exists());
     }
 
+    @Test
+    @DisplayName("제목이 null -> 필드 검증 실패 -> 400 예외")
+    public void createTrip_with_nullTitle() throws Exception {
+        mockingForLoginUserAnnotation();
+        TripCreateRequest request = new TripCreateRequest(null);
+
+        mockMvc.perform(post("/api/trips")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(createJson(request))
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0003"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists())
+                .andExpect(jsonPath("$.fieldErrors").exists())
+                .andExpect(jsonPath("$.fieldErrors").isNotEmpty())
+                .andExpect(jsonPath("$.fieldErrors[*].errorCode").exists())
+                .andExpect(jsonPath("$.fieldErrors[*].errorMessage").exists())
+                .andExpect(jsonPath("$.fieldErrors[*].errorDetail").exists())
+                .andExpect(jsonPath("$.fieldErrors[*].field").exists())
+                .andExpect(jsonPath("$.fieldErrors[?(@.field=='title' && @.errorCode=='trip-0002')]").exists())
+                .andExpect(jsonPath("$.globalErrors").exists())
+                .andExpect(jsonPath("$.globalErrors").isEmpty());
+    }
+
+    @Test
+    @DisplayName("제목이 빈 문자열 -> 필드 검증 실패 -> 400 예외")
+    public void createTrip_with_emptyTitle() throws Exception {
+        mockingForLoginUserAnnotation();
+        TripCreateRequest request = new TripCreateRequest("");
+
+        mockMvc.perform(post("/api/trips")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(createJson(request))
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0003"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists())
+                .andExpect(jsonPath("$.fieldErrors").exists())
+                .andExpect(jsonPath("$.fieldErrors").exists())
+                .andExpect(jsonPath("$.fieldErrors").isNotEmpty())
+                .andExpect(jsonPath("$.fieldErrors[*].errorCode").exists())
+                .andExpect(jsonPath("$.fieldErrors[*].errorMessage").exists())
+                .andExpect(jsonPath("$.fieldErrors[*].errorDetail").exists())
+                .andExpect(jsonPath("$.fieldErrors[*].field").exists())
+                .andExpect(jsonPath("$.fieldErrors[?(@.field=='title' && @.errorCode=='trip-0002')]").exists())
+                .andExpect(jsonPath("$.fieldErrors[?(@.field=='title' && @.errorCode=='trip-0003')]").exists())
+                .andExpect(jsonPath("$.globalErrors").exists())
+                .andExpect(jsonPath("$.globalErrors").isEmpty());
+    }
+
+    @Test
+    @DisplayName("제목이 공백만으로 구성된 문자열 -> 필드 검증 실패 -> 400 예외")
+    public void createTrip_with_whiteSpaceTitle() throws Exception {
+        mockingForLoginUserAnnotation();
+        TripCreateRequest request = new TripCreateRequest("     ");
+
+        mockMvc.perform(post("/api/trips")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(createJson(request))
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0003"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists())
+                .andExpect(jsonPath("$.fieldErrors").exists())
+                .andExpect(jsonPath("$.fieldErrors").isNotEmpty())
+                .andExpect(jsonPath("$.fieldErrors[*].errorCode").exists())
+                .andExpect(jsonPath("$.fieldErrors[*].errorMessage").exists())
+                .andExpect(jsonPath("$.fieldErrors[*].errorDetail").exists())
+                .andExpect(jsonPath("$.fieldErrors[*].field").exists())
+                .andExpect(jsonPath("$.fieldErrors[?(@.field=='title' && @.errorCode=='trip-0002')]").exists())
+                .andExpect(jsonPath("$.globalErrors").exists())
+                .andExpect(jsonPath("$.globalErrors").isEmpty());
+    }
+
+    @Test
+    @DisplayName("제목이 20자를 넘어갈 떄 -> 필드 검증 실패 -> 400 예외")
+    public void createTrip_with_tooLongTitle() throws Exception {
+        mockingForLoginUserAnnotation();
+        TripCreateRequest request = new TripCreateRequest("가".repeat(21));
+
+        mockMvc.perform(post("/api/trips")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(createJson(request))
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0003"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists())
+                .andExpect(jsonPath("$.fieldErrors").exists())
+                .andExpect(jsonPath("$.fieldErrors").isNotEmpty())
+                .andExpect(jsonPath("$.fieldErrors[*].errorCode").exists())
+                .andExpect(jsonPath("$.fieldErrors[*].errorMessage").exists())
+                .andExpect(jsonPath("$.fieldErrors[*].errorDetail").exists())
+                .andExpect(jsonPath("$.fieldErrors[*].field").exists())
+                .andExpect(jsonPath("$.fieldErrors[?(@.field=='title' && @.errorCode=='trip-0003')]").exists())
+                .andExpect(jsonPath("$.globalErrors").exists())
+                .andExpect(jsonPath("$.globalErrors").isEmpty());
+    }
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/TripCreateControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/TripCreateControllerTest.java
@@ -159,7 +159,6 @@ class TripCreateControllerTest extends RestControllerTest {
                 .andExpect(jsonPath("$.fieldErrors[*].errorDetail").exists())
                 .andExpect(jsonPath("$.fieldErrors[*].field").exists())
                 .andExpect(jsonPath("$.fieldErrors[?(@.field=='title' && @.errorCode=='trip-0002')]").exists())
-                .andExpect(jsonPath("$.fieldErrors[?(@.field=='title' && @.errorCode=='trip-0003')]").exists())
                 .andExpect(jsonPath("$.globalErrors").exists())
                 .andExpect(jsonPath("$.globalErrors").isEmpty());
     }
@@ -215,7 +214,7 @@ class TripCreateControllerTest extends RestControllerTest {
                 .andExpect(jsonPath("$.fieldErrors[*].errorMessage").exists())
                 .andExpect(jsonPath("$.fieldErrors[*].errorDetail").exists())
                 .andExpect(jsonPath("$.fieldErrors[*].field").exists())
-                .andExpect(jsonPath("$.fieldErrors[?(@.field=='title' && @.errorCode=='trip-0003')]").exists())
+                .andExpect(jsonPath("$.fieldErrors[?(@.field=='title' && @.errorCode=='trip-0002')]").exists())
                 .andExpect(jsonPath("$.globalErrors").exists())
                 .andExpect(jsonPath("$.globalErrors").isEmpty());
     }

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/TripDeleteControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/TripDeleteControllerTest.java
@@ -20,7 +20,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@DisplayName("[TripCommand] 여행 삭제 API 테스트")
+@DisplayName("여행 삭제 API 테스트")
 @WebMvcTest(TripDeleteController.class)
 class TripDeleteControllerTest extends RestControllerTest {
 

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/TripDeleteControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/TripDeleteControllerTest.java
@@ -61,4 +61,20 @@ class TripDeleteControllerTest extends RestControllerTest {
                 .andExpect(jsonPath("$.errorDetail").exists());
     }
 
+    @Test
+    @DisplayName("tripId으로 숫자가 아닌 문자열 주입 -> 올바르지 않은 경로 변수 타입 400 에러")
+    public void deleteTrip_with_stringTripId() throws Exception {
+        mockingForLoginUserAnnotation();
+
+        mockMvc.perform(delete("/api/trips/가가가")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0004"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/TripUpdateControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/TripUpdateControllerTest.java
@@ -64,4 +64,74 @@ class TripUpdateControllerTest extends RestControllerTest {
                 .andExpect(jsonPath("$.errorDetail").exists());
     }
 
+
+    @Test
+    @DisplayName("비어있는 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void updateTrip_with_emptyContent() throws Exception {
+        mockingForLoginUserAnnotation();
+
+        String emptyContent = "";
+
+        mockMvc.perform(put("/api/trips/1")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(emptyContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
+    @Test
+    @DisplayName("형식이 올바르지 않은 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void updateTrip_with_invalidContent() throws Exception {
+        mockingForLoginUserAnnotation();
+        String invalidContent = """
+                {
+                    "title": 괄호로 감싸지 않은 제목,
+                    "startDate": "2023-03-01",
+                    "endDate": "2023-03-02"
+                }
+                """;
+
+        mockMvc.perform(put("/api/trips/1")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(invalidContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
+    @Test
+    @DisplayName("타입이 올바르지 않은 요청 데이터 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void updateTrip_with_invalidType() throws Exception {
+        mockingForLoginUserAnnotation();
+        String invalidTypeContent = """
+                {
+                    "title": "제목",
+                    "startDate": "2023-03-01",
+                    "endDate": "날짜형식이 아닌 문자열"
+                }
+                """;
+
+        mockMvc.perform(put("/api/trips/1")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(invalidTypeContent)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/docs/TripUpdateControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/docs/TripUpdateControllerDocsTest.java
@@ -2,8 +2,13 @@ package com.cosain.trilo.unit.trip.presentation.trip.command.docs;
 
 import com.cosain.trilo.support.RestDocsTestSupport;
 import com.cosain.trilo.trip.application.trip.command.usecase.TripUpdateUseCase;
+import com.cosain.trilo.trip.application.trip.command.usecase.dto.TripUpdateCommand;
+import com.cosain.trilo.trip.application.trip.command.usecase.dto.factory.TripUpdateCommandFactory;
+import com.cosain.trilo.trip.domain.vo.TripPeriod;
+import com.cosain.trilo.trip.domain.vo.TripTitle;
 import com.cosain.trilo.trip.presentation.trip.command.TripUpdateController;
 import com.cosain.trilo.trip.presentation.trip.command.dto.request.TripUpdateRequest;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -13,6 +18,11 @@ import org.springframework.http.MediaType;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.verify;
 import static org.springframework.data.redis.connection.DataType.STRING;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
@@ -23,38 +33,59 @@ import static org.springframework.restdocs.request.RequestDocumentation.pathPara
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(TripUpdateController.class)
+@DisplayName("여행 수정 API DOCS 테스트")
 public class TripUpdateControllerDocsTest extends RestDocsTestSupport {
 
     @MockBean
     private TripUpdateUseCase tripUpdateUseCase;
 
+    @MockBean
+    private TripUpdateCommandFactory tripUpdateCommandFactory;
+
     private final String BASE_URL = "/api/trips";
     private final String ACCESS_TOKEN = "Bearer accessToken";
+
     @Test
-    void 여행_수정_요청() throws Exception{
+    void 여행_수정_요청() throws Exception {
+
+        // given
         mockingForLoginUserAnnotation();
-        TripUpdateRequest tripUpdateRequest = new TripUpdateRequest("제목", LocalDate.of(2023, 04, 04), LocalDate.of(2023, 04, 06));
-        mockMvc.perform(put(BASE_URL + "/{tripId}", 1)
-                .header(HttpHeaders.AUTHORIZATION,ACCESS_TOKEN)
-                .content(createJson(tripUpdateRequest))
-                .contentType(MediaType.APPLICATION_JSON)
-                .characterEncoding(StandardCharsets.UTF_8))
+
+        Long tripId = 1L;
+        String rawTitle = "변경할 제목";
+        LocalDate startDate = LocalDate.of(2023, 4, 4);
+        LocalDate endDate = LocalDate.of(2023, 4, 6);
+        TripUpdateRequest request = new TripUpdateRequest(rawTitle, startDate, endDate);
+
+        given(tripUpdateCommandFactory.createCommand(eq(rawTitle), eq(startDate), eq(endDate)))
+                .willReturn(new TripUpdateCommand(TripTitle.of(rawTitle), TripPeriod.of(startDate, endDate)));
+        willDoNothing().given(tripUpdateUseCase).updateTrip(eq(tripId), any(), any(TripUpdateCommand.class));
+
+        // when & then
+        mockMvc.perform(put(BASE_URL + "/{tripId}", tripId)
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(createJson(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding(StandardCharsets.UTF_8))
                 .andExpect(status().isOk())
                 .andDo(restDocs.document(
-                   requestHeaders(
-                           headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer 타입 AccessToken")
-                   ),
-                   pathParameters(
-                           parameterWithName("tripId").description("수정할 여행 ID")
-                   ),
-                   requestFields(
-                           fieldWithPath("title").type(STRING).description("여행 제목"),
-                           fieldWithPath("startDate").type(STRING).description("여행 시작 일자 (yyyy-MM-dd) "),
-                           fieldWithPath("endDate").type(STRING).description("여행 종료 일자 (yyyy-MM-dd)")
-                   ),
-                   responseFields(
-                           fieldWithPath("updatedTripId").type(STRING).description("수정된 여행 ID")
-                   )
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer 타입 AccessToken")
+                        ),
+                        pathParameters(
+                                parameterWithName("tripId").description("수정할 여행 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("title").type(STRING).description("여행 제목"),
+                                fieldWithPath("startDate").type(STRING).description("여행 시작 일자 (yyyy-MM-dd) "),
+                                fieldWithPath("endDate").type(STRING).description("여행 종료 일자 (yyyy-MM-dd)")
+                        ),
+                        responseFields(
+                                fieldWithPath("updatedTripId").type(STRING).description("수정된 여행 ID")
+                        )
                 ));
+
+        verify(tripUpdateUseCase).updateTrip(eq(tripId), any(), any(TripUpdateCommand.class));
+        verify(tripUpdateCommandFactory).createCommand(eq(rawTitle), eq(startDate), eq(endDate));
     }
 }


### PR DESCRIPTION
# JIRA 티켓
- [TRL-272]

---

# 작업 내역
- [x] 여행 생성 API 입력값 검증
- [x] 여행 수정 API 입력값 검증
- [x] 일정 생성 API 입력값 검증
- [x] 일정 수정 API 입력값 검증
- [x] 일정 이동 API 입력값 검증
- [x] 잘못된 Http 메시지 바디 형식/데이터 타입이 전달됐을 때의 예외 API
- [x] 잘못된 Path Variable, Query Parameter 전달시의 예외 API
- [x] 추가적인 도메인 규칙 작성(여행 제목, 여행 기간 제약, 일정 제목, ...)

---

# 설명
- 처음에는 Spring의 BeanValidation을 통해 입력값 검증을 시도해봤는데 도메인규칙과 중복되는 코드를 표현계층에 중복해서 작성해야하는게  바람직하지 않아보였습니다.
- request를 command 로 변환하는 과정에서 commandFactory가 개입하고, 이 계층에서 사용자 입력을 도메인 값 객체로 변환하는 과정을 거쳐, command를 생성하도록 했습니다. 이 과정에서 도메인 규칙에 어긋나는 요소들은 예외 수집을 하여 바깥으로 전파하도록 합니다.


[TRL-272]: https://cosain.atlassian.net/browse/TRL-272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ