### PR TITLE
[TRL-280] refactor: 일정 요약 정보 응답 DTO 구조화

### DIFF
--- a/src/main/java/com/cosain/trilo/trip/infra/dto/Coordinate.java
+++ b/src/main/java/com/cosain/trilo/trip/infra/dto/Coordinate.java
@@ -1,0 +1,18 @@
+package com.cosain.trilo.trip.infra.dto;
+
+import lombok.Getter;
+
+@Getter
+public class Coordinate {
+    private double latitude;
+    private double longitude;
+
+    public static Coordinate from(double latitude, double longitude){
+        return new Coordinate(latitude, longitude);
+    }
+
+    private Coordinate(double latitude, double longitude){
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/infra/dto/DayScheduleDetail.java
+++ b/src/main/java/com/cosain/trilo/trip/infra/dto/DayScheduleDetail.java
@@ -11,13 +11,13 @@ public class DayScheduleDetail {
     private Long dayId;
     private Long tripId;
     private LocalDate date;
-    private List<ScheduleSummary> scheduleSummaries;
+    private List<ScheduleSummary> schedules;
 
     @QueryProjection
     public DayScheduleDetail(Long dayId, Long tripId, LocalDate date, List<ScheduleSummary> scheduleSummaries) {
         this.dayId = dayId;
         this.tripId = tripId;
         this.date = date;
-        this.scheduleSummaries = scheduleSummaries;
+        this.schedules = scheduleSummaries;
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/infra/dto/ScheduleSummary.java
+++ b/src/main/java/com/cosain/trilo/trip/infra/dto/ScheduleSummary.java
@@ -8,15 +8,13 @@ public class ScheduleSummary {
     private Long scheduleId;
     private String title;
     private String placeName;
-    private double latitude;
-    private double longitude;
+    private Coordinate coordinate;
 
     @QueryProjection
     public ScheduleSummary(Long scheduleId, String title, String placeName, double latitude, double longitude) {
         this.scheduleId = scheduleId;
         this.title = title;
         this.placeName = placeName;
-        this.latitude = latitude;
-        this.longitude = longitude;
+        this.coordinate = Coordinate.from(latitude, longitude);
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/infra/dto/ScheduleSummary.java
+++ b/src/main/java/com/cosain/trilo/trip/infra/dto/ScheduleSummary.java
@@ -8,13 +8,15 @@ public class ScheduleSummary {
     private Long scheduleId;
     private String title;
     private String placeName;
+    private String placeId;
     private Coordinate coordinate;
 
     @QueryProjection
-    public ScheduleSummary(Long scheduleId, String title, String placeName, double latitude, double longitude) {
+    public ScheduleSummary(Long scheduleId, String title, String placeName,String placeId, double latitude, double longitude) {
         this.scheduleId = scheduleId;
         this.title = title;
         this.placeName = placeName;
+        this.placeId = placeId;
         this.coordinate = Coordinate.from(latitude, longitude);
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/infra/repository/day/jpa/DayQueryJpaRepositoryImpl.java
+++ b/src/main/java/com/cosain/trilo/trip/infra/repository/day/jpa/DayQueryJpaRepositoryImpl.java
@@ -34,6 +34,7 @@ public class DayQueryJpaRepositoryImpl implements DayQueryJpaRepositoryCustom{
                                 schedule.id,
                                 schedule.title,
                                 schedule.place.placeName,
+                                schedule.place.placeId,
                                 schedule.place.coordinate.latitude,
                                 schedule.place.coordinate.longitude
                         ))

--- a/src/main/java/com/cosain/trilo/trip/infra/repository/schedule/jpa/ScheduleQueryJpaRepositoryImpl.java
+++ b/src/main/java/com/cosain/trilo/trip/infra/repository/schedule/jpa/ScheduleQueryJpaRepositoryImpl.java
@@ -31,7 +31,7 @@ public class ScheduleQueryJpaRepositoryImpl implements ScheduleQueryJpaRepositor
 
     @Override
     public Slice<ScheduleSummary> findTemporaryScheduleListByTripId(Long tripId, Pageable pageable) {
-        JPAQuery<ScheduleSummary> jpaQuery = query.select(new QScheduleSummary(schedule.id, schedule.title, schedule.place.placeName, schedule.place.coordinate.latitude, schedule.place.coordinate.longitude))
+        JPAQuery<ScheduleSummary> jpaQuery = query.select(new QScheduleSummary(schedule.id, schedule.title, schedule.place.placeName, schedule.place.placeId, schedule.place.coordinate.latitude, schedule.place.coordinate.longitude))
                 .from(schedule)
                 .where(schedule.trip.id.eq(tripId).and(schedule.day.id.isNull()))
                 .orderBy(schedule.scheduleIndex.value.asc())

--- a/src/test/java/com/cosain/trilo/unit/trip/application/day/query/DaySearchServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/day/query/DaySearchServiceTest.java
@@ -37,7 +37,7 @@ public class DaySearchServiceTest {
 
         // given
         Long dayId = 1L;
-        ScheduleSummary scheduleSummary = new ScheduleSummary(1L, "제목", "장소", 33.33, 33.33);
+        ScheduleSummary scheduleSummary = new ScheduleSummary(1L, "제목", "장소","장소 식별자", 33.33, 33.33);
         DayScheduleDetail dayScheduleDetail = new DayScheduleDetail(dayId, 1L, LocalDate.of(2023, 5, 5), List.of(scheduleSummary));
         given(dayQueryRepository.findDayWithSchedulesByDayId(1L)).willReturn(Optional.of(dayScheduleDetail));
 

--- a/src/test/java/com/cosain/trilo/unit/trip/infra/repository/DayScheduleQueryRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/infra/repository/DayScheduleQueryRepositoryTest.java
@@ -59,9 +59,9 @@ public class DayScheduleQueryRepositoryTest {
         assertThat(dayScheduleDetail.getDayId()).isEqualTo(day1.getId());
         assertThat(dayScheduleDetail.getDate()).isEqualTo(day1.getTripDate());
         assertThat(dayScheduleDetail.getTripId()).isEqualTo(trip.getId());
-        assertThat(dayScheduleDetail.getScheduleSummaries().size()).isEqualTo(findSchedulesSize);
-        assertThat(dayScheduleDetail.getScheduleSummaries().get(0).getScheduleId()).isEqualTo(schedule1.getId());
-        assertThat(dayScheduleDetail.getScheduleSummaries().get(2).getScheduleId()).isEqualTo(schedule3.getId());
+        assertThat(dayScheduleDetail.getSchedules().size()).isEqualTo(findSchedulesSize);
+        assertThat(dayScheduleDetail.getSchedules().get(0).getScheduleId()).isEqualTo(schedule1.getId());
+        assertThat(dayScheduleDetail.getSchedules().get(2).getScheduleId()).isEqualTo(schedule3.getId());
     }
 
     private Schedule createSchedule(Trip trip, Day day, Long scheduleIndexValue){

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/day/query/SingleDayQueryControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/day/query/SingleDayQueryControllerTest.java
@@ -50,7 +50,17 @@ class SingleDayQueryControllerTest extends RestControllerTest {
                 .andExpect(jsonPath("$.dayId").value(dayScheduleDetail.getDayId()))
                 .andExpect(jsonPath("$.date").value(dayScheduleDetail.getDate().toString()))
                 .andExpect(jsonPath("$.tripId").value(dayScheduleDetail.getTripId()))
-                .andExpect(jsonPath("$.scheduleSummaries").isArray());
+                .andExpect(jsonPath("$.scheduleSummaries").isArray())
+                .andExpect(jsonPath("$.scheduleSummaries[0].coordinate.latitude").value(scheduleSummary1.getCoordinate().getLatitude()))
+                .andExpect(jsonPath("$.scheduleSummaries[0].coordinate.longitude").value(scheduleSummary1.getCoordinate().getLongitude()))
+                .andExpect(jsonPath("$.scheduleSummaries[0].scheduleId").value(scheduleSummary1.getScheduleId()))
+                .andExpect(jsonPath("$.scheduleSummaries[0].title").value(scheduleSummary1.getTitle()))
+                .andExpect(jsonPath("$.scheduleSummaries[0].placeName").value(scheduleSummary1.getPlaceName()))
+                .andExpect(jsonPath("$.scheduleSummaries[1].coordinate.latitude").value(scheduleSummary2.getCoordinate().getLatitude()))
+                .andExpect(jsonPath("$.scheduleSummaries[1].coordinate.longitude").value(scheduleSummary2.getCoordinate().getLongitude()))
+                .andExpect(jsonPath("$.scheduleSummaries[1].scheduleId").value(scheduleSummary2.getScheduleId()))
+                .andExpect(jsonPath("$.scheduleSummaries[1].title").value(scheduleSummary2.getTitle()))
+                .andExpect(jsonPath("$.scheduleSummaries[1].placeName").value(scheduleSummary2.getPlaceName()));
     }
 
     @Test

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/day/query/SingleDayQueryControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/day/query/SingleDayQueryControllerTest.java
@@ -50,17 +50,17 @@ class SingleDayQueryControllerTest extends RestControllerTest {
                 .andExpect(jsonPath("$.dayId").value(dayScheduleDetail.getDayId()))
                 .andExpect(jsonPath("$.date").value(dayScheduleDetail.getDate().toString()))
                 .andExpect(jsonPath("$.tripId").value(dayScheduleDetail.getTripId()))
-                .andExpect(jsonPath("$.scheduleSummaries").isArray())
-                .andExpect(jsonPath("$.scheduleSummaries[0].coordinate.latitude").value(scheduleSummary1.getCoordinate().getLatitude()))
-                .andExpect(jsonPath("$.scheduleSummaries[0].coordinate.longitude").value(scheduleSummary1.getCoordinate().getLongitude()))
-                .andExpect(jsonPath("$.scheduleSummaries[0].scheduleId").value(scheduleSummary1.getScheduleId()))
-                .andExpect(jsonPath("$.scheduleSummaries[0].title").value(scheduleSummary1.getTitle()))
-                .andExpect(jsonPath("$.scheduleSummaries[0].placeName").value(scheduleSummary1.getPlaceName()))
-                .andExpect(jsonPath("$.scheduleSummaries[1].coordinate.latitude").value(scheduleSummary2.getCoordinate().getLatitude()))
-                .andExpect(jsonPath("$.scheduleSummaries[1].coordinate.longitude").value(scheduleSummary2.getCoordinate().getLongitude()))
-                .andExpect(jsonPath("$.scheduleSummaries[1].scheduleId").value(scheduleSummary2.getScheduleId()))
-                .andExpect(jsonPath("$.scheduleSummaries[1].title").value(scheduleSummary2.getTitle()))
-                .andExpect(jsonPath("$.scheduleSummaries[1].placeName").value(scheduleSummary2.getPlaceName()));
+                .andExpect(jsonPath("$.schedules").isArray())
+                .andExpect(jsonPath("$.schedules[0].coordinate.latitude").value(scheduleSummary1.getCoordinate().getLatitude()))
+                .andExpect(jsonPath("$.schedules[0].coordinate.longitude").value(scheduleSummary1.getCoordinate().getLongitude()))
+                .andExpect(jsonPath("$.schedules[0].scheduleId").value(scheduleSummary1.getScheduleId()))
+                .andExpect(jsonPath("$.schedules[0].title").value(scheduleSummary1.getTitle()))
+                .andExpect(jsonPath("$.schedules[0].placeName").value(scheduleSummary1.getPlaceName()))
+                .andExpect(jsonPath("$.schedules[1].coordinate.latitude").value(scheduleSummary2.getCoordinate().getLatitude()))
+                .andExpect(jsonPath("$.schedules[1].coordinate.longitude").value(scheduleSummary2.getCoordinate().getLongitude()))
+                .andExpect(jsonPath("$.schedules[1].scheduleId").value(scheduleSummary2.getScheduleId()))
+                .andExpect(jsonPath("$.schedules[1].title").value(scheduleSummary2.getTitle()))
+                .andExpect(jsonPath("$.schedules[1].placeName").value(scheduleSummary2.getPlaceName()));
     }
 
     @Test

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/day/query/SingleDayQueryControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/day/query/SingleDayQueryControllerTest.java
@@ -36,8 +36,8 @@ class SingleDayQueryControllerTest extends RestControllerTest {
     public void findSingleSchedule_with_authorizedUser() throws Exception {
 
         mockingForLoginUserAnnotation();
-        ScheduleSummary scheduleSummary1 = new ScheduleSummary(1L, "제목", "장소 이름", 33.33, 33.33);
-        ScheduleSummary scheduleSummary2 = new ScheduleSummary(2L, "제목2", "장소 이름2", 33.33, 33.33);
+        ScheduleSummary scheduleSummary1 = new ScheduleSummary(1L, "제목", "장소 이름","장소 식별자1", 33.33, 33.33);
+        ScheduleSummary scheduleSummary2 = new ScheduleSummary(2L, "제목2", "장소 이름2","장소 식별자2", 33.33, 33.33);
 
         DayScheduleDetail dayScheduleDetail = new DayScheduleDetail(1L, 1L, LocalDate.of(2023, 2, 3), List.of(scheduleSummary1, scheduleSummary2));
         given(daySearchUseCase.searchDeySchedule(eq(1L))).willReturn(dayScheduleDetail);
@@ -56,11 +56,13 @@ class SingleDayQueryControllerTest extends RestControllerTest {
                 .andExpect(jsonPath("$.schedules[0].scheduleId").value(scheduleSummary1.getScheduleId()))
                 .andExpect(jsonPath("$.schedules[0].title").value(scheduleSummary1.getTitle()))
                 .andExpect(jsonPath("$.schedules[0].placeName").value(scheduleSummary1.getPlaceName()))
+                .andExpect(jsonPath("$.schedules[0].placeId").value(scheduleSummary1.getPlaceId()))
                 .andExpect(jsonPath("$.schedules[1].coordinate.latitude").value(scheduleSummary2.getCoordinate().getLatitude()))
                 .andExpect(jsonPath("$.schedules[1].coordinate.longitude").value(scheduleSummary2.getCoordinate().getLongitude()))
                 .andExpect(jsonPath("$.schedules[1].scheduleId").value(scheduleSummary2.getScheduleId()))
                 .andExpect(jsonPath("$.schedules[1].title").value(scheduleSummary2.getTitle()))
-                .andExpect(jsonPath("$.schedules[1].placeName").value(scheduleSummary2.getPlaceName()));
+                .andExpect(jsonPath("$.schedules[1].placeName").value(scheduleSummary2.getPlaceName()))
+                .andExpect(jsonPath("$.schedules[1].placeId").value(scheduleSummary2.getPlaceId()));
     }
 
     @Test

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/query/TripTemporaryStorageQueryControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/query/TripTemporaryStorageQueryControllerTest.java
@@ -41,12 +41,9 @@ class TripTemporaryStorageQueryControllerTest extends RestControllerTest {
         // given
         Long tripId = 1L;
         mockingForLoginUserAnnotation();
-        SliceImpl<ScheduleSummary> scheduleSummaries = new SliceImpl<>(List.of(
-                new ScheduleSummary(1L, null, "제목", 33.33, 33.33),
-                new ScheduleSummary(2L, null, "제목", 33.33, 33.33),
-                new ScheduleSummary(3L, null, "제목", 33.33, 33.33),
-                new ScheduleSummary(4L, null, "제목", 33.33, 33.33)
-        ));
+        ScheduleSummary scheduleSummary1 = new ScheduleSummary(1L, null, "제목", 33.33, 33.33);
+        ScheduleSummary scheduleSummary2 = new ScheduleSummary(2L, null, "제목", 33.33, 33.33);
+        SliceImpl<ScheduleSummary> scheduleSummaries = new SliceImpl<>(List.of(scheduleSummary1, scheduleSummary2));
         given(temporarySearchUseCase.searchTemporary(eq(tripId), any(Pageable.class))).willReturn(scheduleSummaries);
 
         mockMvc.perform(get("/api/trips/1/temporary-storage")
@@ -55,6 +52,16 @@ class TripTemporaryStorageQueryControllerTest extends RestControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.tempSchedules").isArray())
                 .andExpect(jsonPath("$.tempSchedules.size()").value(scheduleSummaries.getSize()))
+                .andExpect(jsonPath("$.tempSchedules[0].coordinate.latitude").value(scheduleSummary1.getCoordinate().getLatitude()))
+                .andExpect(jsonPath("$.tempSchedules[0].coordinate.longitude").value(scheduleSummary1.getCoordinate().getLongitude()))
+                .andExpect(jsonPath("$.tempSchedules[0].scheduleId").value(scheduleSummary1.getScheduleId()))
+                .andExpect(jsonPath("$.tempSchedules[0].title").value(scheduleSummary1.getTitle()))
+                .andExpect(jsonPath("$.tempSchedules[0].placeName").value(scheduleSummary1.getPlaceName()))
+                .andExpect(jsonPath("$.tempSchedules[1].coordinate.latitude").value(scheduleSummary2.getCoordinate().getLatitude()))
+                .andExpect(jsonPath("$.tempSchedules[1].coordinate.longitude").value(scheduleSummary2.getCoordinate().getLongitude()))
+                .andExpect(jsonPath("$.tempSchedules[1].scheduleId").value(scheduleSummary2.getScheduleId()))
+                .andExpect(jsonPath("$.tempSchedules[1].title").value(scheduleSummary2.getTitle()))
+                .andExpect(jsonPath("$.tempSchedules[1].placeName").value(scheduleSummary2.getPlaceName()))
                 .andExpect(jsonPath("$.hasNext").isBoolean())
                 .andExpect(status().isOk());
     }

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/query/TripTemporaryStorageQueryControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/query/TripTemporaryStorageQueryControllerTest.java
@@ -41,8 +41,8 @@ class TripTemporaryStorageQueryControllerTest extends RestControllerTest {
         // given
         Long tripId = 1L;
         mockingForLoginUserAnnotation();
-        ScheduleSummary scheduleSummary1 = new ScheduleSummary(1L, null, "제목", 33.33, 33.33);
-        ScheduleSummary scheduleSummary2 = new ScheduleSummary(2L, null, "제목", 33.33, 33.33);
+        ScheduleSummary scheduleSummary1 = new ScheduleSummary(1L, null, "제목","장소 식별자", 33.33, 33.33);
+        ScheduleSummary scheduleSummary2 = new ScheduleSummary(2L, null, "제목","장소 식별자",33.33, 33.33);
         SliceImpl<ScheduleSummary> scheduleSummaries = new SliceImpl<>(List.of(scheduleSummary1, scheduleSummary2));
         given(temporarySearchUseCase.searchTemporary(eq(tripId), any(Pageable.class))).willReturn(scheduleSummaries);
 
@@ -57,11 +57,13 @@ class TripTemporaryStorageQueryControllerTest extends RestControllerTest {
                 .andExpect(jsonPath("$.tempSchedules[0].scheduleId").value(scheduleSummary1.getScheduleId()))
                 .andExpect(jsonPath("$.tempSchedules[0].title").value(scheduleSummary1.getTitle()))
                 .andExpect(jsonPath("$.tempSchedules[0].placeName").value(scheduleSummary1.getPlaceName()))
+                .andExpect(jsonPath("$.tempSchedules[0].placeId").value(scheduleSummary1.getPlaceId()))
                 .andExpect(jsonPath("$.tempSchedules[1].coordinate.latitude").value(scheduleSummary2.getCoordinate().getLatitude()))
                 .andExpect(jsonPath("$.tempSchedules[1].coordinate.longitude").value(scheduleSummary2.getCoordinate().getLongitude()))
                 .andExpect(jsonPath("$.tempSchedules[1].scheduleId").value(scheduleSummary2.getScheduleId()))
                 .andExpect(jsonPath("$.tempSchedules[1].title").value(scheduleSummary2.getTitle()))
                 .andExpect(jsonPath("$.tempSchedules[1].placeName").value(scheduleSummary2.getPlaceName()))
+                .andExpect(jsonPath("$.tempSchedules[1].placeId").value(scheduleSummary2.getPlaceId()))
                 .andExpect(jsonPath("$.hasNext").isBoolean())
                 .andExpect(status().isOk());
     }


### PR DESCRIPTION
# JIRA 티켓
[TRL-280]

# 작업 내역
- [x] ScheduleSummary DTO 구조화

# 작업 상세

`latitude`, `longitude` 는 관련있는 데이터이므로 API 컨슈머 입장에서 소비하기 쉽도록 `Coordinate` 라는 이름으로 구조화해서 보내도록 했습니다. Domain 계층에 있는 Coordinate VO는 사용할 수 없으니 INFRA 계층 dto 패키지에 `Coordinate` 라는 동일한 이름의 Coordinate DTO 를 만들어서 사용하도록 했습니다. 

총 3개의 API 에서 해당 DTO 가 사용이 되는데, Presentation 계층에서 API 구조화를 위한 DTO 매핑을 하게 되면 재사용성이 떨어지니 INFRA 계층에서 구조화를 진행했습니다. 

<img width="274" alt="image" src="https://github.com/teamCoSaIn/trilo-be/assets/53935439/c44a83df-74e9-499f-8f57-f78602b767c3">


[TRL-280]: https://cosain.atlassian.net/browse/TRL-280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ