### PR TITLE
[TRL-289] fix: OAuth2 로그인 관련 인증 오류 발생 문제 해결

### DIFF
--- a/src/main/java/com/cosain/trilo/config/security/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/cosain/trilo/config/security/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -3,20 +3,17 @@ package com.cosain.trilo.config.security;
 import com.cosain.trilo.config.security.util.CookieUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.stereotype.Component;
 
 @Component
-@Slf4j
 public class HttpCookieOAuth2AuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
     public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
     private static final int cookieExpireSeconds = 180;
 
     @Override
     public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
-        log.info("loadAuthorizationRequest");
         return CookieUtil.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
                 .map(cookie -> CookieUtil.deserialize(cookie, OAuth2AuthorizationRequest.class))
                 .orElse(null);
@@ -24,7 +21,6 @@ public class HttpCookieOAuth2AuthorizationRequestRepository implements Authoriza
 
     @Override
     public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
-        log.info("saveAuthorizationRequest");
         if (authorizationRequest == null) {
             CookieUtil.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
             return;
@@ -34,7 +30,6 @@ public class HttpCookieOAuth2AuthorizationRequestRepository implements Authoriza
 
     @Override
     public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request, HttpServletResponse response) {
-        log.info("removeAuthorizationRequest");
         return this.loadAuthorizationRequest(request);
     }
 

--- a/src/main/java/com/cosain/trilo/config/security/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/cosain/trilo/config/security/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,45 @@
+package com.cosain.trilo.config.security;
+
+import com.cosain.trilo.config.security.util.CookieUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class HttpCookieOAuth2AuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+    public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+    private static final int cookieExpireSeconds = 180;
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        log.info("loadAuthorizationRequest");
+        return CookieUtil.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+                .map(cookie -> CookieUtil.deserialize(cookie, OAuth2AuthorizationRequest.class))
+                .orElse(null);
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+        log.info("saveAuthorizationRequest");
+        if (authorizationRequest == null) {
+            CookieUtil.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+            return;
+        }
+        CookieUtil.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CookieUtil.serialize(authorizationRequest), cookieExpireSeconds);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request, HttpServletResponse response) {
+        log.info("removeAuthorizationRequest");
+        return this.loadAuthorizationRequest(request);
+    }
+
+    public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
+        CookieUtil.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+    }
+
+}

--- a/src/main/java/com/cosain/trilo/config/security/SecurityConfig.java
+++ b/src/main/java/com/cosain/trilo/config/security/SecurityConfig.java
@@ -2,7 +2,6 @@ package com.cosain.trilo.config.security;
 
 import com.cosain.trilo.auth.domain.repository.TokenRepository;
 import com.cosain.trilo.auth.infra.TokenAnalyzer;
-import com.cosain.trilo.config.security.dto.AuthUriResponse;
 import com.cosain.trilo.config.security.filter.ExceptionHandlerFilter;
 import com.cosain.trilo.config.security.filter.TokenAuthenticationFilter;
 import com.cosain.trilo.config.security.handler.CustomAccessDeniedHandler;
@@ -11,8 +10,6 @@ import com.cosain.trilo.config.security.handler.OAuthSuccessHandler;
 import com.cosain.trilo.config.security.service.CustomOAuthService;
 import com.cosain.trilo.user.domain.UserRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -21,15 +18,12 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.web.RedirectStrategy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.servlet.HandlerExceptionResolver;
-
-import java.io.IOException;
 
 import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
 
@@ -43,6 +37,7 @@ public class SecurityConfig {
     private final OAuthSuccessHandler oAuthSuccessHandler;
     private final CustomOAuthService customOAuthService;
     private final TokenRepository tokenRepository;
+    private final HttpCookieOAuth2AuthorizationRequestRepository authorizationRequestRepository;
 
     private final ObjectMapper objectMapper;
     private final TokenAnalyzer tokenAnalyzer;
@@ -79,7 +74,7 @@ public class SecurityConfig {
                 .oauth2Login(oauth2 -> oauth2
                         .authorizationEndpoint(authorize -> authorize
                                 .baseUri("/api/auth/login")
-                                .authorizationRedirectStrategy(new CustomRedirectStrategy())
+                                .authorizationRequestRepository(this.authorizationRequestRepository)
                         )
                         .redirectionEndpoint(redirect -> redirect
                                 .baseUri("/api/auth/login/oauth2/code")
@@ -98,12 +93,12 @@ public class SecurityConfig {
         return http.build();
     }
 
-    private class CustomRedirectStrategy implements RedirectStrategy {
-        @Override
-        public void sendRedirect(HttpServletRequest request, HttpServletResponse response, String url) throws IOException {
-            objectMapper.writeValue(response.getWriter(), AuthUriResponse.from(url));
-        }
-    }
+//    private class CustomRedirectStrategy implements RedirectStrategy {
+//        @Override
+//        public void sendRedirect(HttpServletRequest request, HttpServletResponse response, String url) throws IOException {
+//            objectMapper.writeValue(response.getWriter(), AuthUriResponse.from(url));
+//        }
+//    }
 
     @Bean
     public CorsConfigurationSource configurationSource() {

--- a/src/main/java/com/cosain/trilo/config/security/handler/OAuthSuccessHandler.java
+++ b/src/main/java/com/cosain/trilo/config/security/handler/OAuthSuccessHandler.java
@@ -5,6 +5,7 @@ import com.cosain.trilo.auth.domain.repository.TokenRepository;
 import com.cosain.trilo.auth.infra.TokenAnalyzer;
 import com.cosain.trilo.auth.infra.TokenProvider;
 import com.cosain.trilo.auth.presentation.dto.AuthResponse;
+import com.cosain.trilo.config.security.HttpCookieOAuth2AuthorizationRequestRepository;
 import com.cosain.trilo.config.security.util.CookieUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
@@ -28,6 +29,7 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     private final TokenAnalyzer tokenAnalyzer;
     private final TokenRepository tokenRepository;
     private final ObjectMapper objectMapper;
+    private final HttpCookieOAuth2AuthorizationRequestRepository cookieOAuth2AuthorizationRequestRepository;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
@@ -38,6 +40,7 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
         Long tokenExpiry = tokenAnalyzer.getTokenRemainExpiryFrom(refreshToken);
         tokenRepository.saveRefreshToken(RefreshToken.of(refreshToken, tokenExpiry));
 
+        cookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
         CookieUtil.addAuthCookie(response, refreshToken, tokenExpiry);
         response.setStatus(HttpStatus.OK.value());
         objectMapper.writeValue(response.getWriter(), AuthResponse.from(accessToken));

--- a/src/main/java/com/cosain/trilo/config/security/util/CookieUtil.java
+++ b/src/main/java/com/cosain/trilo/config/security/util/CookieUtil.java
@@ -3,14 +3,12 @@ package com.cosain.trilo.config.security.util;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.SerializationUtils;
 
 import java.util.Base64;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-@Slf4j
 public class CookieUtil {
 
     private static final String AUTH_COOKIE_NAME = "refreshToken";

--- a/src/main/java/com/cosain/trilo/config/security/util/CookieUtil.java
+++ b/src/main/java/com/cosain/trilo/config/security/util/CookieUtil.java
@@ -1,10 +1,16 @@
 package com.cosain.trilo.config.security.util;
 
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.SerializationUtils;
 
+import java.util.Base64;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+@Slf4j
 public class CookieUtil {
 
     private static final String AUTH_COOKIE_NAME = "refreshToken";
@@ -16,5 +22,45 @@ public class CookieUtil {
         cookie.setMaxAge(maxAge);
         response.addCookie(cookie);
 
+    }
+
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(name)) {
+                    return Optional.of(cookie);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie: cookies) {
+                if (cookie.getName().equals(name)) {
+                    cookie.setValue("");
+                    cookie.setPath("/");
+                    cookie.setMaxAge(0);
+                    response.addCookie(cookie);
+                }
+            }
+        }
+    }
+    public static String serialize(Object object) {
+        return Base64.getUrlEncoder()
+                .encodeToString(SerializationUtils.serialize(object));
+    }
+    public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+        return cls.cast(SerializationUtils.deserialize(
+                Base64.getUrlDecoder().decode(cookie.getValue())));
     }
 }

--- a/src/test/java/com/cosain/trilo/unit/security/OAuth2LoginTest.java
+++ b/src/test/java/com/cosain/trilo/unit/security/OAuth2LoginTest.java
@@ -5,10 +5,10 @@ import com.cosain.trilo.support.RestDocsTestSupport;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.responseCookies;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.payload.JsonFieldType.STRING;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(SecurityConfig.class)
@@ -19,27 +19,35 @@ public class OAuth2LoginTest extends RestDocsTestSupport{
     @Test
     void 카카오_인증_URL_요청() throws Exception {
         mockMvc.perform(get(AUTH_URL_REQUEST_URL+"kakao"))
-                .andExpect(status().isOk())
+                .andExpect(status().is3xxRedirection())
+                .andDo(print())
                 .andDo(restDocs.document(
-                        responseFields(fieldWithPath("uri").type(STRING).description("카카오 인증 URI"))
+                        responseCookies(
+                                cookieWithName("oauth2_auth_request").description("응답요청에 포함된 쿠키")
+                        )
                 ));
+
     }
 
     @Test
     void 구글_인증_URL_요청() throws Exception{
         mockMvc.perform(get(AUTH_URL_REQUEST_URL+"google"))
-                .andExpect(status().isOk())
+                .andExpect(status().is3xxRedirection())
                 .andDo(restDocs.document(
-                        responseFields(fieldWithPath("uri").type(STRING).description("구글 인증 URI"))
+                        responseCookies(
+                                cookieWithName("oauth2_auth_request").description("응답요청에 포함된 쿠키")
+                        )
                 ));
     }
 
     @Test
     void 네이버_인증_URL_요청() throws Exception{
         mockMvc.perform(get(AUTH_URL_REQUEST_URL+"naver"))
-                .andExpect(status().isOk())
+                .andExpect(status().is3xxRedirection())
                 .andDo(restDocs.document(
-                        responseFields(fieldWithPath("uri").type(STRING).description("네이버 인증 URI"))
+                        responseCookies(
+                                cookieWithName("oauth2_auth_request").description("응답요청에 포함된 쿠키")
+                        )
                 ));
     }
 


### PR DESCRIPTION
# JIRA 티켓
[TRL-289] 

# 작업내역

기존에 OAuth2 로그인 과정 중 FE 에서 올바른 state, code를 BE에 전달했음에도 인증 오류가 발생하는 문제 해결하기 위한 작업을 진행했습니다.

Session 이 아닌 Cookie를 가지고 요청에 대한 검증을 수행할 수 있도록 변경했습니다.

[TRL-289]: https://cosain.atlassian.net/browse/TRL-289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ