### PR TITLE
[TRL-291] fix: OAuth2 성공 시 토큰과 함께 리다이렉트 하도록 변경

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -8,19 +8,31 @@
 :docinfo: shared-head
 
 == Auth API
-=== 인증 URI
 
-==== 구글 URI
-operation::o-auth2-login-test/구글_인증_url_요청[snippets = 'http-request,http-response']
+=== OAuth2 로그인
 
-==== 네이버 URI
-operation::o-auth2-login-test/네이버_인증_url_요청[snippets = 'http-request,http-response']
+- 메서드 : GET
+- URL : `/api/auth/login/{provider}?redirect_uri={redirectUri}`
 
-==== 카카오 URI
-operation::o-auth2-login-test/카카오_인증_url_요청[snippets = 'http-request,http-response']
+==== 요청
+===== 경로 변수
+include::{snippets}/o-auth2-login-test/소셜_로그인/path-parameters.adoc[]
 
-=== 로그아웃
-operation::auth-rest-controller-docs-test/로그아웃_요청[snippets = 'http-request,request-headers,http-response']
+===== 쿼리 변수
+include::{snippets}/o-auth2-login-test/소셜_로그인/query-parameters.adoc[]
+
+==== 응답
+===== 쿠키
+include::{snippets}/o-auth2-login-test/소셜_로그인/response-cookies.adoc[]
+
+==== 예제
+===== 요청
+include::{snippets}/o-auth2-login-test/소셜_로그인/http-request.adoc[]
+===== 응답
+include::{snippets}/o-auth2-login-test/소셜_로그인/http-response.adoc[]
+
+
+---
 
 === 재발급 토큰 상태 조회
 operation::auth-rest-controller-docs-test/재발급_토큰_상태_조회_요청[snippets = 'http-request,http-response,response-fields']
@@ -140,17 +152,26 @@ include::{snippets}/single-trip-query-controller-docs-test/여행_단건_조회/
 
 ---
 
-==== Schedule 조회
-===== 요청
-====== 헤더
+=== Schedule 조회
+
+==== 기본 정보
+
+- 메서드 : GET
+- URL : `/api/schedules/{scheduleId}`
+- 인증 방식 : 엑세스 토큰
+
+==== 요청
+===== 헤더
 include::{snippets}/single-schedule-query-controller-docs-test/일정_단건_조회/request-headers.adoc[]
-====== 경로 변수
+===== 경로 변수
 include::{snippets}/single-schedule-query-controller-docs-test/일정_단건_조회/path-parameters.adoc[]
-===== 응답
-====== 본문
+
+==== 응답
+===== 본문
 include::{snippets}/single-schedule-query-controller-docs-test/일정_단건_조회/response-fields.adoc[]
-===== 예제
-====== 요청
+
+==== 예제
+===== 요청
 include::{snippets}/single-schedule-query-controller-docs-test/일정_단건_조회/http-request.adoc[]
-====== 응답
+===== 응답
 include::{snippets}/single-schedule-query-controller-docs-test/일정_단건_조회/http-response.adoc[]

--- a/src/main/java/com/cosain/trilo/config/security/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/cosain/trilo/config/security/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,12 +1,12 @@
 package com.cosain.trilo.config.security;
 
 import com.cosain.trilo.config.security.util.CookieUtil;
-import com.nimbusds.oauth2.sdk.util.StringUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 @Component
 public class HttpCookieOAuth2AuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
@@ -31,7 +31,7 @@ public class HttpCookieOAuth2AuthorizationRequestRepository implements Authoriza
 
         CookieUtil.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CookieUtil.serialize(authorizationRequest), cookieExpireSeconds);
         String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
-        if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
+        if (StringUtils.hasText(redirectUriAfterLogin)) {
             CookieUtil.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, cookieExpireSeconds);
         }
     }

--- a/src/main/java/com/cosain/trilo/config/security/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/cosain/trilo/config/security/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,6 +1,7 @@
 package com.cosain.trilo.config.security;
 
 import com.cosain.trilo.config.security.util.CookieUtil;
+import com.nimbusds.oauth2.sdk.util.StringUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class HttpCookieOAuth2AuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
     public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+    public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
     private static final int cookieExpireSeconds = 180;
 
     @Override
@@ -23,9 +25,15 @@ public class HttpCookieOAuth2AuthorizationRequestRepository implements Authoriza
     public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
         if (authorizationRequest == null) {
             CookieUtil.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+            CookieUtil.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
             return;
         }
+
         CookieUtil.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CookieUtil.serialize(authorizationRequest), cookieExpireSeconds);
+        String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+        if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
+            CookieUtil.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, cookieExpireSeconds);
+        }
     }
 
     @Override
@@ -35,6 +43,7 @@ public class HttpCookieOAuth2AuthorizationRequestRepository implements Authoriza
 
     public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
         CookieUtil.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        CookieUtil.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
     }
 
 }

--- a/src/main/java/com/cosain/trilo/config/security/util/CookieUtil.java
+++ b/src/main/java/com/cosain/trilo/config/security/util/CookieUtil.java
@@ -7,21 +7,8 @@ import org.springframework.util.SerializationUtils;
 
 import java.util.Base64;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
 public class CookieUtil {
-
-    private static final String AUTH_COOKIE_NAME = "refreshToken";
-
-    public static void addAuthCookie(HttpServletResponse response, String refreshToken, Long tokenExpiry){
-        int maxAge = (int) TimeUnit.MICROSECONDS.toSeconds(tokenExpiry);
-        Cookie cookie = new Cookie(AUTH_COOKIE_NAME, refreshToken);
-        cookie.setHttpOnly(true);
-        cookie.setMaxAge(maxAge);
-        response.addCookie(cookie);
-
-    }
-
     public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
         Cookie[] cookies = request.getCookies();
         if (cookies != null && cookies.length > 0) {

--- a/src/test/java/com/cosain/trilo/unit/security/OAuth2LoginTest.java
+++ b/src/test/java/com/cosain/trilo/unit/security/OAuth2LoginTest.java
@@ -8,47 +8,35 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
 import static org.springframework.restdocs.cookies.CookieDocumentation.responseCookies;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(SecurityConfig.class)
 public class OAuth2LoginTest extends RestDocsTestSupport{
 
-    private static final String AUTH_URL_REQUEST_URL = "/api/auth/login/";
+    private final String QUERY_PARAM = "?redirect_uri=http://localhost:3000/oauth2/redirect";
 
     @Test
-    void 카카오_인증_URL_요청() throws Exception {
-        mockMvc.perform(get(AUTH_URL_REQUEST_URL+"kakao"))
+    void 소셜_로그인() throws Exception {
+
+        mockMvc.perform(get("/api/auth/login/{provider}"+QUERY_PARAM, "kakao"))
                 .andExpect(status().is3xxRedirection())
                 .andDo(print())
                 .andDo(restDocs.document(
+                        pathParameters(
+                                parameterWithName("provider").description("소셜 로그인 써드 파티 API 제공자 (kakao, google, naver)")
+                        ),
+                        queryParameters(
+                                parameterWithName("redirect_uri").description("로그인 성공 시 이동할 리다이렉트 URL")
+                        ),
                         responseCookies(
-                                cookieWithName("oauth2_auth_request").description("응답요청에 포함된 쿠키")
+                                cookieWithName("oauth2_auth_request").description("oauth 요청 정보를 담은 쿠키"),
+                                cookieWithName("redirect_uri").description("리다이렉트 URL를 담은 쿠키")
+
                         )
                 ));
 
-    }
-
-    @Test
-    void 구글_인증_URL_요청() throws Exception{
-        mockMvc.perform(get(AUTH_URL_REQUEST_URL+"google"))
-                .andExpect(status().is3xxRedirection())
-                .andDo(restDocs.document(
-                        responseCookies(
-                                cookieWithName("oauth2_auth_request").description("응답요청에 포함된 쿠키")
-                        )
-                ));
-    }
-
-    @Test
-    void 네이버_인증_URL_요청() throws Exception{
-        mockMvc.perform(get(AUTH_URL_REQUEST_URL+"naver"))
-                .andExpect(status().is3xxRedirection())
-                .andDo(restDocs.document(
-                        responseCookies(
-                                cookieWithName("oauth2_auth_request").description("응답요청에 포함된 쿠키")
-                        )
-                ));
     }
 
 }


### PR DESCRIPTION
# JIRA 티켓
[TRL-291]

# 작업 내역

최종 OAuth2 성공 시 FE에서 쿼리 파라미터로 전달한 URL 로 발급한 AccessToken과 RefreshToken 과 함께 리다이렉트 하도록 변경했습니다.

# 참고자료

[callicoder - SpringSecurity + OAuth2 + JWT](https://www.callicoder.com/spring-boot-security-oauth2-social-login-part-2/)
[카카오 OAuth2 로그인 개발문서 - REST API](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api)


[TRL-291]: https://cosain.atlassian.net/browse/TRL-291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ