### PR TITLE
[TRL-293] feat: 일정 생성 가능 개수 제약 추가

### DIFF
--- a/src/main/java/com/cosain/trilo/trip/application/exception/TooManyDayScheduleException.java
+++ b/src/main/java/com/cosain/trilo/trip/application/exception/TooManyDayScheduleException.java
@@ -1,0 +1,35 @@
+package com.cosain.trilo.trip.application.exception;
+
+import com.cosain.trilo.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class TooManyDayScheduleException extends CustomException {
+
+    private static final String ERROR_CODE = "schedule-0010";
+    private static final HttpStatus HTTP_STATUS = HttpStatus.FORBIDDEN;
+
+    public TooManyDayScheduleException() {
+    }
+
+    public TooManyDayScheduleException(String debugMessage) {
+        super(debugMessage);
+    }
+
+    public TooManyDayScheduleException(Throwable cause) {
+        super(cause);
+    }
+
+    public TooManyDayScheduleException(String debugMessage, Throwable cause) {
+        super(debugMessage, cause);
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HTTP_STATUS;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/application/exception/TooManyTripScheduleException.java
+++ b/src/main/java/com/cosain/trilo/trip/application/exception/TooManyTripScheduleException.java
@@ -1,0 +1,35 @@
+package com.cosain.trilo.trip.application.exception;
+
+import com.cosain.trilo.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class TooManyTripScheduleException extends CustomException {
+
+    private static final String ERROR_CODE = "schedule-0009";
+    private static final HttpStatus HTTP_STATUS = HttpStatus.FORBIDDEN;
+
+    public TooManyTripScheduleException() {
+    }
+
+    public TooManyTripScheduleException(String debugMessage) {
+        super(debugMessage);
+    }
+
+    public TooManyTripScheduleException(Throwable cause) {
+        super(cause);
+    }
+
+    public TooManyTripScheduleException(String debugMessage, Throwable cause) {
+        super(debugMessage, cause);
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HTTP_STATUS;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/application/schedule/command/service/ScheduleCreateService.java
+++ b/src/main/java/com/cosain/trilo/trip/application/schedule/command/service/ScheduleCreateService.java
@@ -1,5 +1,6 @@
 package com.cosain.trilo.trip.application.schedule.command.service;
 
+import com.cosain.trilo.trip.application.exception.TooManyTripScheduleException;
 import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleCreateCommand;
 import com.cosain.trilo.trip.application.exception.DayNotFoundException;
 import com.cosain.trilo.trip.application.exception.NoScheduleCreateAuthorityException;
@@ -33,12 +34,16 @@ public class ScheduleCreateService implements ScheduleCreateUseCase {
         Day day = findDay(dayId);
         Trip trip = findTrip(tripId);
         validateCreateAuthority(trip, tripperId);
+        validateTripScheduleCount(tripId);
 
         Schedule schedule;
         try {
             schedule = trip.createSchedule(day, createCommand.getScheduleTitle(), createCommand.getPlace());
         } catch (ScheduleIndexRangeException e) {
+            // 기존 ScheduleIndex 뒤에 일정 생성을 시도했으나, 가능한 ScheduleIndex 범위를 벗어났으므로 전체 재정렬
             scheduleRepository.relocateDaySchedules(tripId, dayId);
+
+            // 영속성 컨텍스트가 초기화 됐으므로 trip, day를 다시 가져오고 다시 작업
             trip = findTrip(trip.getId());
             day = findDay(dayId);
             schedule =  trip.createSchedule(day, createCommand.getScheduleTitle(), createCommand.getPlace());
@@ -60,6 +65,14 @@ public class ScheduleCreateService implements ScheduleCreateUseCase {
     private void validateCreateAuthority(Trip trip, Long tripperId) {
         if(!trip.getTripperId().equals(tripperId)){
             throw new NoScheduleCreateAuthorityException("여행의 소유주가 아닌 사람이, 일정을 생성하려고 함");
+        }
+    }
+
+    private void validateTripScheduleCount(Long tripId) {
+        int tripScheduleCount = scheduleRepository.findTripScheduleCount(tripId);
+
+        if (tripScheduleCount == Trip.MAX_TRIP_SCHEDULE_COUNT) {
+            throw new TooManyTripScheduleException("여행 생성 시도 -> 여행 최대 일정 갯수 초과");
         }
     }
 

--- a/src/main/java/com/cosain/trilo/trip/application/schedule/command/service/ScheduleCreateService.java
+++ b/src/main/java/com/cosain/trilo/trip/application/schedule/command/service/ScheduleCreateService.java
@@ -1,10 +1,7 @@
 package com.cosain.trilo.trip.application.schedule.command.service;
 
-import com.cosain.trilo.trip.application.exception.TooManyTripScheduleException;
+import com.cosain.trilo.trip.application.exception.*;
 import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleCreateCommand;
-import com.cosain.trilo.trip.application.exception.DayNotFoundException;
-import com.cosain.trilo.trip.application.exception.NoScheduleCreateAuthorityException;
-import com.cosain.trilo.trip.application.exception.TripNotFoundException;
 import com.cosain.trilo.trip.application.schedule.command.usecase.ScheduleCreateUseCase;
 import com.cosain.trilo.trip.domain.entity.Day;
 import com.cosain.trilo.trip.domain.entity.Schedule;
@@ -35,6 +32,7 @@ public class ScheduleCreateService implements ScheduleCreateUseCase {
         Trip trip = findTrip(tripId);
         validateCreateAuthority(trip, tripperId);
         validateTripScheduleCount(tripId);
+        validateDayScheduleCount(dayId);
 
         Schedule schedule;
         try {
@@ -73,6 +71,17 @@ public class ScheduleCreateService implements ScheduleCreateUseCase {
 
         if (tripScheduleCount == Trip.MAX_TRIP_SCHEDULE_COUNT) {
             throw new TooManyTripScheduleException("여행 생성 시도 -> 여행 최대 일정 갯수 초과");
+        }
+    }
+
+    private void validateDayScheduleCount(Long dayId) {
+        if (dayId == null) {
+            return;
+        }
+        int dayScheduleCount = scheduleRepository.findDayScheduleCount(dayId);
+
+        if (dayScheduleCount == Day.MAX_DAY_SCHEDULE_COUNT) {
+            throw new TooManyDayScheduleException("여행 생성 시도 -> Day의 최대 일정 갯수 초과");
         }
     }
 

--- a/src/main/java/com/cosain/trilo/trip/domain/entity/Day.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/entity/Day.java
@@ -22,6 +22,8 @@ import java.util.Objects;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Day {
 
+    public static final int MAX_DAY_SCHEDULE_COUNT = 10;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "day_id")

--- a/src/main/java/com/cosain/trilo/trip/domain/entity/Trip.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/entity/Trip.java
@@ -26,6 +26,8 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Trip {
 
+    public static final int MAX_TRIP_SCHEDULE_COUNT = 110;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "trip_id")

--- a/src/main/java/com/cosain/trilo/trip/domain/repository/ScheduleRepository.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/repository/ScheduleRepository.java
@@ -67,4 +67,11 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             WHERE s.trip.id = :tripId
             """)
     int findTripScheduleCount(@Param("tripId") Long tripId);
+
+    @Query("""
+            SELECT COUNT(s)
+            FROM Schedule as s
+            WHERE s.day.id = :dayId
+            """)
+    int findDayScheduleCount(@Param("dayId") Long dayId);
 }

--- a/src/main/java/com/cosain/trilo/trip/domain/repository/ScheduleRepository.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/repository/ScheduleRepository.java
@@ -60,4 +60,11 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
                     "WHERE " +
                     "   s1.day_id IN :dayIds", nativeQuery = true)
     int moveSchedulesToTemporaryStorage(@Param("tripId") Long tripId, @Param("dayIds") List<Long> dayIds);
+
+    @Query("""
+            SELECT COUNT(s)
+            FROM Schedule as s
+            WHERE s.trip.id = :tripId
+            """)
+    int findTripScheduleCount(@Param("tripId") Long tripId);
 }

--- a/src/main/resources/exceptions/exception.yml
+++ b/src/main/resources/exceptions/exception.yml
@@ -147,6 +147,10 @@ schedule-0009:
   message: Too Many Trip Schedule Count
   detail: 여행에 더 이상 일정을 생성할 수 없습니다. 한 여행은 최대 110개의 일정을 가질 수 있습니다.
 
+schedule-0010:
+  message: Too Many Day Schedule Count
+  detail: Day에 더 이상 일정을 생성할 수 없습니다. 한 Day는 최대 10개의 일정을 가질 수 있습니다.
+
 # 장소 관련
 place-0001:
   message: InvalidCoordinate

--- a/src/main/resources/exceptions/exception.yml
+++ b/src/main/resources/exceptions/exception.yml
@@ -143,6 +143,9 @@ schedule-0008:
   message: Invalid Schedule Title
   detail: 일정 제목이 올바르지 않습니다. 일정 제목은 null 또는 공백으로만 구성된 문자열일 수 없고, 길이는 1자 이상 20자 이하여야 합니다.
 
+schedule-0009:
+  message: Too Many Trip Schedule Count
+  detail: 여행에 더 이상 일정을 생성할 수 없습니다. 한 여행은 최대 110개의 일정을 가질 수 있습니다.
 
 # 장소 관련
 place-0001:

--- a/src/main/resources/exceptions/exception_en.yml
+++ b/src/main/resources/exceptions/exception_en.yml
@@ -143,6 +143,11 @@ schedule-0008:
   message: Invalid Schedule Title
   detail: The ScheduleTitle is not valid. The ScheduleTitle cannot be a null or empty string, and its length must be between 1 and 20 characters
 
+schedule-0009:
+  message: Too Many Trip Schedule Count
+  detail: Cannot create any more schedules for your trip. Each trip can have a maximum of 110 schedules.
+
+
 # 장소 관련
 place-0001:
   message: InvalidCoordinate

--- a/src/main/resources/exceptions/exception_en.yml
+++ b/src/main/resources/exceptions/exception_en.yml
@@ -144,8 +144,12 @@ schedule-0008:
   detail: The ScheduleTitle is not valid. The ScheduleTitle cannot be a null or empty string, and its length must be between 1 and 20 characters
 
 schedule-0009:
+  message: Too Many Trip Schedule Count
+  detail: Cannot create any more schedules for your trip. Each trip can have a maximum of 110 schedules.
+
+schedule-0010:
   message: Too Many Day Schedule Count
-  detail: Cannot create any more schedules for your TripDay. Each TripDay can have a maximum of 110 schedules.
+  detail: Cannot create any more schedules for your TripDay. Each TripDay can have a maximum of 10 schedules.
 
 
 # 장소 관련

--- a/src/main/resources/exceptions/exception_en.yml
+++ b/src/main/resources/exceptions/exception_en.yml
@@ -144,8 +144,8 @@ schedule-0008:
   detail: The ScheduleTitle is not valid. The ScheduleTitle cannot be a null or empty string, and its length must be between 1 and 20 characters
 
 schedule-0009:
-  message: Too Many Trip Schedule Count
-  detail: Cannot create any more schedules for your trip. Each trip can have a maximum of 110 schedules.
+  message: Too Many Day Schedule Count
+  detail: Cannot create any more schedules for your TripDay. Each TripDay can have a maximum of 110 schedules.
 
 
 # 장소 관련

--- a/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleCreateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleCreateServiceTest.java
@@ -1,6 +1,7 @@
 package com.cosain.trilo.unit.trip.application.schedule.command.service;
 
 import com.cosain.trilo.fixture.TripFixture;
+import com.cosain.trilo.trip.application.exception.TooManyDayScheduleException;
 import com.cosain.trilo.trip.application.exception.TooManyTripScheduleException;
 import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleCreateCommand;
 import com.cosain.trilo.trip.application.exception.NoScheduleCreateAuthorityException;
@@ -91,6 +92,7 @@ public class ScheduleCreateServiceTest {
             given(tripRepository.findById(eq(tripId))).willReturn(Optional.of(trip));
             given(scheduleRepository.save(any(Schedule.class))).willReturn(createdSchedule);
             given(scheduleRepository.findTripScheduleCount(eq(tripId))).willReturn(0);
+            given(scheduleRepository.findDayScheduleCount(eq(dayId))).willReturn(0);
 
             // when
             scheduleCreateService.createSchedule(tripperId, scheduleCreateCommand);
@@ -101,6 +103,7 @@ public class ScheduleCreateServiceTest {
             verify(scheduleRepository, times(0)).relocateDaySchedules(eq(tripId), eq(dayId));
             verify(scheduleRepository, times(1)).save(any(Schedule.class));
             verify(scheduleRepository, times(1)).findTripScheduleCount(eq(tripId));
+            verify(scheduleRepository, times(1)).findDayScheduleCount(eq(dayId));
         }
 
         @Test
@@ -190,7 +193,8 @@ public class ScheduleCreateServiceTest {
 
             given(scheduleRepository.relocateDaySchedules(eq(tripId), eq(dayId))).willReturn(1);
             given(scheduleRepository.save(any(Schedule.class))).willReturn(createdSchedule);
-            given(scheduleRepository.findTripScheduleCount(tripId)).willReturn(0);
+            given(scheduleRepository.findTripScheduleCount(eq(tripId))).willReturn(1);
+            given(scheduleRepository.findDayScheduleCount(eq(dayId))).willReturn(1);
 
             // when
             scheduleCreateService.createSchedule(tripperId, scheduleCreateCommand);
@@ -201,6 +205,7 @@ public class ScheduleCreateServiceTest {
             verify(scheduleRepository, times(1)).relocateDaySchedules(eq(tripId), eq(dayId));
             verify(scheduleRepository, times(1)).save(any(Schedule.class));
             verify(scheduleRepository, times(1)).findTripScheduleCount(eq(tripId));
+            verify(scheduleRepository, times(1)).findDayScheduleCount(eq(dayId));
         }
     }
 
@@ -214,6 +219,7 @@ public class ScheduleCreateServiceTest {
             // given
             Long tripperId = 1L;
             Long tripId = 2L;
+            Long dayId = null;
 
             Trip trip = Trip.builder()
                     .id(tripId)
@@ -224,7 +230,7 @@ public class ScheduleCreateServiceTest {
                     .build();
 
             ScheduleCreateCommand scheduleCreateCommand = ScheduleCreateCommand.builder()
-                    .dayId(null)
+                    .dayId(dayId)
                     .tripId(tripId)
                     .scheduleTitle(ScheduleTitle.of("일정 제목"))
                     .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
@@ -252,6 +258,7 @@ public class ScheduleCreateServiceTest {
             verify(scheduleRepository, times(0)).relocateDaySchedules(eq(tripId), isNull());
             verify(scheduleRepository, times(1)).save(any(Schedule.class));
             verify(scheduleRepository, times(1)).findTripScheduleCount(eq(tripId));
+            verify(scheduleRepository, times(0)).findDayScheduleCount(isNull());
         }
 
         @Test
@@ -304,7 +311,7 @@ public class ScheduleCreateServiceTest {
                     .thenReturn(Optional.of(rediscoveredTrip));
             given(scheduleRepository.relocateDaySchedules(eq(tripId), isNull())).willReturn(1);
             given(scheduleRepository.save(any(Schedule.class))).willReturn(newSchedule);
-            given(scheduleRepository.findTripScheduleCount(eq(tripId))).willReturn(0);
+            given(scheduleRepository.findTripScheduleCount(eq(tripId))).willReturn(1);
 
             // when
             scheduleCreateService.createSchedule(tripperId, scheduleCreateCommand);
@@ -315,6 +322,7 @@ public class ScheduleCreateServiceTest {
             verify(scheduleRepository, times(1)).relocateDaySchedules(eq(tripId), isNull());
             verify(scheduleRepository, times(1)).save(any(Schedule.class));
             verify(scheduleRepository, times(1)).findTripScheduleCount(eq(tripId));
+            verify(scheduleRepository, times(0)).findDayScheduleCount(isNull());
         }
 
     }
@@ -384,6 +392,55 @@ public class ScheduleCreateServiceTest {
         verify(scheduleRepository, times(0)).relocateDaySchedules(eq(tripId), isNull());
         verify(scheduleRepository, times(0)).save(any(Schedule.class));
         verify(scheduleRepository, times(1)).findTripScheduleCount(eq(tripId));
+    }
+
+    @Test
+    @DisplayName("Day에 일정이 너무 많이 있으면, TooManyDayScheduleException이 발생한다.")
+    public void tooManyDayScheduleTest() {
+        // given
+        Long tripperId = 1L;
+        Long tripId = 2L;
+        Long dayId = 3L;
+
+        Trip trip = Trip.builder()
+                .id(tripId)
+                .tripperId(tripperId)
+                .tripTitle(TripTitle.of("여행 제목"))
+                .status(TripStatus.DECIDED)
+                .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
+                .build();
+
+        Day day = Day.builder()
+                .id(dayId)
+                .tripDate(LocalDate.of(2023,3,1))
+                .trip(trip)
+                .build();
+
+
+        ScheduleCreateCommand scheduleCreateCommand = ScheduleCreateCommand.builder()
+                .dayId(dayId)
+                .tripId(tripId)
+                .scheduleTitle(ScheduleTitle.of("일정 제목"))
+                .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
+                .build();
+
+
+        given(tripRepository.findById(eq(tripId))).willReturn(Optional.of(trip));
+        given(dayRepository.findByIdWithTrip(eq(dayId))).willReturn(Optional.of(day));
+        given(scheduleRepository.findTripScheduleCount(eq(tripId))).willReturn(10);
+        given(scheduleRepository.findDayScheduleCount(eq(dayId))).willReturn(10);
+
+        // when
+        assertThatThrownBy(() -> scheduleCreateService.createSchedule(tripperId, scheduleCreateCommand))
+                .isInstanceOf(TooManyDayScheduleException.class);
+
+        // then
+        verify(dayRepository, times(0)).findByIdWithTrip(isNull());
+        verify(tripRepository, times(1)).findById(eq(tripId));
+        verify(scheduleRepository, times(0)).relocateDaySchedules(eq(tripId), isNull());
+        verify(scheduleRepository, times(0)).save(any(Schedule.class));
+        verify(scheduleRepository, times(1)).findTripScheduleCount(eq(tripId));
+        verify(scheduleRepository, times(1)).findDayScheduleCount(eq(dayId));
     }
 
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/repository/ScheduleRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/repository/ScheduleRepositoryTest.java
@@ -528,4 +528,58 @@ public class ScheduleRepositoryTest {
                 .build();
     }
 
+    @Nested
+    @DisplayName("findDayScheduleCount : Day에 속한 일정의 갯수를 가져온다.")
+    class FindDayScheduleCountTest {
+
+        @DisplayName("Day에 아무 일정도 없음 -> 0 반환")
+        @Test
+        void noDayScheduleTest() {
+            Trip trip = Trip.builder()
+                    .tripperId(1L)
+                    .tripTitle(TripTitle.of("여행 제목"))
+                    .status(TripStatus.DECIDED)
+                    .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
+                    .build();
+            em.persist(trip);
+
+            Day day = Day.of(LocalDate.of(2023,3,1), trip);
+            em.persist(day);
+
+            int scheduleTripCount = scheduleRepository.findDayScheduleCount(day.getId());
+            assertThat(scheduleTripCount).isEqualTo(0);
+        }
+
+        @DisplayName("Day에 일정 3개 -> 3 반환")
+        @Test
+        void threeDayScheduleTest() {
+            Trip trip = Trip.builder()
+                    .tripperId(1L)
+                    .tripTitle(TripTitle.of("여행 제목"))
+                    .status(TripStatus.DECIDED)
+                    .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)))
+                    .build();
+            em.persist(trip);
+
+            Day day1 = Day.of(LocalDate.of(2023,3,1), trip);
+            Day day2 = Day.of(LocalDate.of(2023,3,2), trip);
+            em.persist(day1);
+            em.persist(day2);
+
+            Schedule schedule1 = trip.createSchedule(day1, ScheduleTitle.of("일정제목1"), Place.of("장소식별자1", "장소명1", Coordinate.of(34.127, 124.7771)));
+            Schedule schedule2 = trip.createSchedule(day1, ScheduleTitle.of("일정제목2"), Place.of("장소식별자2", "장소명2", Coordinate.of(34.127, 124.7771)));
+            Schedule schedule3 = trip.createSchedule(day1, ScheduleTitle.of("일정제목3"), Place.of("장소식별자3", "장소명3", Coordinate.of(34.127, 124.7771)));
+            Schedule schedule4 = trip.createSchedule(day2, ScheduleTitle.of("일정제목4"), Place.of("장소식별자4", "장소명4", Coordinate.of(34.127, 124.7771)));
+            Schedule schedule5 = trip.createSchedule(day2, ScheduleTitle.of("일정제목5"), Place.of("장소식별자5", "장소명5", Coordinate.of(34.127, 124.7771)));
+            em.persist(schedule1);
+            em.persist(schedule2);
+            em.persist(schedule3);
+            em.persist(schedule4);
+            em.persist(schedule5);
+
+            int scheduleTripCount = scheduleRepository.findDayScheduleCount(day1.getId());
+            assertThat(scheduleTripCount).isEqualTo(3);
+        }
+    }
+
 }


### PR DESCRIPTION

# JIRA 티켓
- [TRL-293]

---

# 작업 내역
- [x] 데이터베이스를 통해 여행이 가진 일정의 갯수 조회해오는 기능 추가
- [x] 여행 당 일정 생성 제약 추가(110개)
- [x] Day당 일정 생성 제약 추가(10개)

[TRL-293]: https://cosain.atlassian.net/browse/TRL-293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ