### PR TITLE
[TRL-296] feat: 일정 생성 API 사양 수정 - 좌표를 객체로 전달

### DIFF
--- a/src/main/java/com/cosain/trilo/trip/application/schedule/command/usecase/dto/factory/ScheduleCreateCommandFactory.java
+++ b/src/main/java/com/cosain/trilo/trip/application/schedule/command/usecase/dto/factory/ScheduleCreateCommandFactory.java
@@ -9,7 +9,6 @@ import com.cosain.trilo.trip.domain.vo.Place;
 import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Component
@@ -18,10 +17,7 @@ public class ScheduleCreateCommandFactory {
     public ScheduleCreateCommand createCommand(
             Long dayId, Long tripId, String title,
             String placeId, String placeName,
-            Double latitude, Double longitude) {
-
-        List<CustomException> exceptions = new ArrayList<>();
-
+            Double latitude, Double longitude, List<CustomException> exceptions) {
         validateTripIdNotNull(tripId, exceptions);
 
         ScheduleTitle scheduleTitle = makeScheduleTitle(title, exceptions);

--- a/src/main/java/com/cosain/trilo/trip/presentation/exception/NullRequestCoordinateException.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/exception/NullRequestCoordinateException.java
@@ -1,0 +1,35 @@
+package com.cosain.trilo.trip.presentation.exception;
+
+import com.cosain.trilo.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class NullRequestCoordinateException extends CustomException {
+
+    private static final String ERROR_CODE = "place-0002";
+    private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+    public NullRequestCoordinateException() {
+    }
+
+    public NullRequestCoordinateException(String debugMessage) {
+        super(debugMessage);
+    }
+
+    public NullRequestCoordinateException(Throwable cause) {
+        super(cause);
+    }
+
+    public NullRequestCoordinateException(String debugMessage, Throwable cause) {
+        super(debugMessage, cause);
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HTTP_STATUS;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/presentation/schedule/command/ScheduleCreateController.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/schedule/command/ScheduleCreateController.java
@@ -1,20 +1,25 @@
 package com.cosain.trilo.trip.presentation.schedule.command;
 
 import com.cosain.trilo.common.LoginUser;
+import com.cosain.trilo.common.exception.CustomException;
 import com.cosain.trilo.trip.application.schedule.command.usecase.ScheduleCreateUseCase;
 import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleCreateCommand;
 import com.cosain.trilo.trip.application.schedule.command.usecase.dto.factory.ScheduleCreateCommandFactory;
+import com.cosain.trilo.trip.presentation.exception.NullRequestCoordinateException;
+import com.cosain.trilo.trip.presentation.schedule.command.dto.request.RequestCoordinate;
 import com.cosain.trilo.trip.presentation.schedule.command.dto.request.ScheduleCreateRequest;
 import com.cosain.trilo.trip.presentation.schedule.command.dto.response.ScheduleCreateResponse;
 import com.cosain.trilo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -26,19 +31,30 @@ public class ScheduleCreateController {
 
     @PostMapping("/api/schedules")
     @ResponseStatus(HttpStatus.CREATED)
-    public ScheduleCreateResponse createSchedule(@LoginUser User user, @RequestBody ScheduleCreateRequest request){
+    public ScheduleCreateResponse createSchedule(@LoginUser User user, @RequestBody ScheduleCreateRequest request) {
         Long tripperId = user.getId();
         ScheduleCreateCommand command = createCommand(request);
 
         Long scheduleId = scheduleCreateUseCase.createSchedule(tripperId, command);
+        log.info("scheduleId = {}", scheduleId);
         return ScheduleCreateResponse.from(scheduleId);
     }
 
     private ScheduleCreateCommand createCommand(ScheduleCreateRequest request) {
+        List<CustomException> exceptions = new ArrayList<>();
+
+        RequestCoordinate requestCoordinate = request.getCoordinate();
+
+        if (requestCoordinate == null) {
+            // 사용자가 좌표를 누락시킨 경우, 예외 수집기에 좌표 누락 예외를 수집하고, 요청좌표를 위도 경도가 모두 null 인 요청좌표로 대체함
+            exceptions.add(new NullRequestCoordinateException("입력 좌표가 누락됨"));
+            requestCoordinate = new RequestCoordinate(null, null);
+        }
+
         return scheduleCreateCommandFactory.createCommand(
-                request.getDayId(), request.getTripId(), request.getTitle(),
-                request.getPlaceId(), request.getPlaceName(),
-                request.getLatitude(), request.getLongitude()
-        );
+                    request.getDayId(), request.getTripId(), request.getTitle(),
+                    request.getPlaceId(), request.getPlaceName(),
+                    requestCoordinate.getLatitude(), requestCoordinate.getLongitude(), exceptions);
     }
+
 }

--- a/src/main/java/com/cosain/trilo/trip/presentation/schedule/command/dto/request/RequestCoordinate.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/schedule/command/dto/request/RequestCoordinate.java
@@ -1,0 +1,18 @@
+package com.cosain.trilo.trip.presentation.schedule.command.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RequestCoordinate {
+
+    private Double latitude;
+    private Double longitude;
+
+    public RequestCoordinate(Double latitude, Double longitude) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/presentation/schedule/command/dto/request/ScheduleCreateRequest.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/schedule/command/dto/request/ScheduleCreateRequest.java
@@ -1,6 +1,5 @@
 package com.cosain.trilo.trip.presentation.schedule.command.dto.request;
 
-import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleCreateCommand;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,21 +15,19 @@ public class ScheduleCreateRequest {
 
     private String placeId;
     private String placeName;
-    private Double latitude;
-    private Double longitude;
+    private RequestCoordinate coordinate;
 
     /**
      * 테스트의 편의성을 위해 Builder accessLevel = PUBLIC 으로 설정
      */
     @Builder(access = AccessLevel.PUBLIC)
-    private ScheduleCreateRequest(Long dayId, Long tripId, String title, String placeId, String placeName, Double latitude, Double longitude) {
+    private ScheduleCreateRequest(Long dayId, Long tripId, String title, String placeId, String placeName, RequestCoordinate coordinate) {
         this.dayId = dayId;
         this.tripId = tripId;
         this.title = title;
         this.placeId = placeId;
         this.placeName = placeName;
-        this.latitude = latitude;
-        this.longitude = longitude;
+        this.coordinate = coordinate;
     }
 
 }

--- a/src/main/resources/exceptions/exception.yml
+++ b/src/main/resources/exceptions/exception.yml
@@ -154,4 +154,8 @@ schedule-0010:
 # 장소 관련
 place-0001:
   message: InvalidCoordinate
-  detail: 위도 또는 경도의 범위가 유효하지 않습니다.
+  detail: 위도 또는 경도가 누락됐거나, 범위가 유효하지 않습니다. 위도는 -90 이상 90 이하여야 하며, 경도는 -180 이상 180 미만이여야 합니다.
+
+place-0002:
+  message: Null Coordinate
+  detail: 좌표가 누락됐습니다. 좌표는 필수입니다.

--- a/src/main/resources/exceptions/exception_en.yml
+++ b/src/main/resources/exceptions/exception_en.yml
@@ -155,4 +155,8 @@ schedule-0010:
 # 장소 관련
 place-0001:
   message: InvalidCoordinate
-  detail: The latitude or longitude range is invalid.
+  detail: The latitude or longitude is missing or the range is not valid. Latitude must be between -90 and 90, and longitude must be between -180 and less than 180.
+
+place-0002:
+  message: Null Coordinate
+  detail: Coordinate is missing. Coordinates is mandatory.

--- a/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/dto/factory/ScheduleCreateCommandFactoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/dto/factory/ScheduleCreateCommandFactoryTest.java
@@ -1,5 +1,6 @@
 package com.cosain.trilo.unit.trip.application.schedule.command.dto.factory;
 
+import com.cosain.trilo.common.exception.CustomException;
 import com.cosain.trilo.common.exception.CustomValidationException;
 import com.cosain.trilo.trip.application.exception.NullTripIdException;
 import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleCreateCommand;
@@ -11,6 +12,9 @@ import com.cosain.trilo.trip.domain.vo.Place;
 import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
@@ -31,13 +35,14 @@ public class ScheduleCreateCommandFactoryTest {
         String placeName = "place-name";
         Double latitude = 39.123;
         Double longitude = 123.7712;
+        List<CustomException> exceptions = new ArrayList<>();
 
         // when
         CustomValidationException cve = catchThrowableOfType(
                 () -> scheduleCreateCommandFactory.createCommand(
                         dayId, tripId, rawScheduleTitle,
                         placeId, placeName,
-                        latitude, longitude),
+                        latitude, longitude, exceptions),
                 CustomValidationException.class);
 
         // then
@@ -57,13 +62,15 @@ public class ScheduleCreateCommandFactoryTest {
         String placeName = "place-name";
         Double latitude = 39.123;
         Double longitude = 123.7712;
+        List<CustomException> exceptions = new ArrayList<>();
+
 
         // when
         CustomValidationException cve = catchThrowableOfType(
                 () -> scheduleCreateCommandFactory.createCommand(
                         dayId, tripId, rawScheduleTitle,
                         placeId, placeName,
-                        latitude, longitude),
+                        latitude, longitude, exceptions),
                 CustomValidationException.class);
 
         // then
@@ -83,13 +90,14 @@ public class ScheduleCreateCommandFactoryTest {
         String placeName = "place-name";
         Double latitude = 39.123;
         Double longitude = 123.7712;
+        List<CustomException> exceptions = new ArrayList<>();
 
         // when
         CustomValidationException cve = catchThrowableOfType(
                 () -> scheduleCreateCommandFactory.createCommand(
                         dayId, tripId, rawScheduleTitle,
                         placeId, placeName,
-                        latitude, longitude),
+                        latitude, longitude, exceptions),
                 CustomValidationException.class);
 
         // then
@@ -109,13 +117,14 @@ public class ScheduleCreateCommandFactoryTest {
         String placeName = "place-name";
         Double latitude = 39.123;
         Double longitude = 123.7712;
+        List<CustomException> exceptions = new ArrayList<>();
 
         // when
         CustomValidationException cve = catchThrowableOfType(
                 () -> scheduleCreateCommandFactory.createCommand(
                         dayId, tripId, rawScheduleTitle,
                         placeId, placeName,
-                        latitude, longitude),
+                        latitude, longitude, exceptions),
                 CustomValidationException.class);
 
         // then
@@ -135,13 +144,14 @@ public class ScheduleCreateCommandFactoryTest {
         String placeName = "place-name";
         Double latitude = 39.123;
         Double longitude = 123.7712;
+        List<CustomException> exceptions = new ArrayList<>();
 
         // when
         CustomValidationException cve = catchThrowableOfType(
                 () -> scheduleCreateCommandFactory.createCommand(
                         dayId, tripId, rawScheduleTitle,
                         placeId, placeName,
-                        latitude, longitude),
+                        latitude, longitude, exceptions),
                 CustomValidationException.class);
 
         // then
@@ -161,13 +171,14 @@ public class ScheduleCreateCommandFactoryTest {
         String placeName = "place-name";
         Double latitude = null;
         Double longitude = 123.7712;
+        List<CustomException> exceptions = new ArrayList<>();
 
         // when
         CustomValidationException cve = catchThrowableOfType(
                 () -> scheduleCreateCommandFactory.createCommand(
                         dayId, tripId, rawScheduleTitle,
                         placeId, placeName,
-                        latitude, longitude),
+                        latitude, longitude, exceptions),
                 CustomValidationException.class);
 
         // then
@@ -187,13 +198,14 @@ public class ScheduleCreateCommandFactoryTest {
         String placeName = "place-name";
         Double latitude = 39.123;
         Double longitude = null;
+        List<CustomException> exceptions = new ArrayList<>();
 
         // when
         CustomValidationException cve = catchThrowableOfType(
                 () -> scheduleCreateCommandFactory.createCommand(
                         dayId, tripId, rawScheduleTitle,
                         placeId, placeName,
-                        latitude, longitude),
+                        latitude, longitude, exceptions),
                 CustomValidationException.class);
 
         // then
@@ -213,13 +225,14 @@ public class ScheduleCreateCommandFactoryTest {
         String placeName = "place-name";
         Double latitude = null;
         Double longitude = null;
+        List<CustomException> exceptions = new ArrayList<>();
 
         // when
         CustomValidationException cve = catchThrowableOfType(
                 () -> scheduleCreateCommandFactory.createCommand(
                         dayId, tripId, rawScheduleTitle,
                         placeId, placeName,
-                        latitude, longitude),
+                        latitude, longitude, exceptions),
                 CustomValidationException.class);
 
         // then
@@ -239,13 +252,14 @@ public class ScheduleCreateCommandFactoryTest {
         String placeName = "place-name";
         Double latitude = Coordinate.MIN_LATITUDE - 0.001;
         Double longitude = 127.123;
+        List<CustomException> exceptions = new ArrayList<>();
 
         // when
         CustomValidationException cve = catchThrowableOfType(
                 () -> scheduleCreateCommandFactory.createCommand(
                         dayId, tripId, rawScheduleTitle,
                         placeId, placeName,
-                        latitude, longitude),
+                        latitude, longitude, exceptions),
                 CustomValidationException.class);
 
         // then
@@ -265,13 +279,14 @@ public class ScheduleCreateCommandFactoryTest {
         String placeName = "place-name";
         Double latitude = Coordinate.MAX_LATITUDE + 0.001;
         Double longitude = 127.123;
+        List<CustomException> exceptions = new ArrayList<>();
 
         // when
         CustomValidationException cve = catchThrowableOfType(
                 () -> scheduleCreateCommandFactory.createCommand(
                         dayId, tripId, rawScheduleTitle,
                         placeId, placeName,
-                        latitude, longitude),
+                        latitude, longitude, exceptions),
                 CustomValidationException.class);
 
         // then
@@ -291,13 +306,14 @@ public class ScheduleCreateCommandFactoryTest {
         String placeName = "place-name";
         Double latitude = 37.1234;
         Double longitude = Coordinate.MIN_LONGITUDE - 0.001;
+        List<CustomException> exceptions = new ArrayList<>();
 
         // when
         CustomValidationException cve = catchThrowableOfType(
                 () -> scheduleCreateCommandFactory.createCommand(
                         dayId, tripId, rawScheduleTitle,
                         placeId, placeName,
-                        latitude, longitude),
+                        latitude, longitude, exceptions),
                 CustomValidationException.class);
 
         // then
@@ -317,13 +333,14 @@ public class ScheduleCreateCommandFactoryTest {
         String placeName = "place-name";
         Double latitude = 37.1234;
         Double longitude = Coordinate.MAX_LONGITUDE + 0.001;
+        List<CustomException> exceptions = new ArrayList<>();
 
         // when
         CustomValidationException cve = catchThrowableOfType(
                 () -> scheduleCreateCommandFactory.createCommand(
                         dayId, tripId, rawScheduleTitle,
                         placeId, placeName,
-                        latitude, longitude),
+                        latitude, longitude, exceptions),
                 CustomValidationException.class);
 
         // then
@@ -343,13 +360,14 @@ public class ScheduleCreateCommandFactoryTest {
         String placeName = "place-name";
         Double latitude = null;
         Double longitude = 37.124;
+        List<CustomException> exceptions = new ArrayList<>();
 
         // when
         CustomValidationException cve = catchThrowableOfType(
                 () -> scheduleCreateCommandFactory.createCommand(
                         dayId, tripId, rawScheduleTitle,
                         placeId, placeName,
-                        latitude, longitude),
+                        latitude, longitude, exceptions),
                 CustomValidationException.class);
 
         // then
@@ -371,13 +389,13 @@ public class ScheduleCreateCommandFactoryTest {
         String placeName = "place-name";
         Double latitude = 37.11924;
         Double longitude = 123.1274;
+        List<CustomException> exceptions = new ArrayList<>();
 
         // when
         ScheduleCreateCommand command = scheduleCreateCommandFactory.createCommand(
                 dayId, tripId, rawScheduleTitle,
                 placeId, placeName,
-                latitude, longitude);
-
+                latitude, longitude, exceptions);
 
         // then
         assertThat(command).isNotNull();


### PR DESCRIPTION
# JIRA 티켓
- [TRL-296]

---

# 작업 내역
- [x] 요청 좌표 DTO 정의
- [x] 요청 좌표 객체 누락 시 예외를 정의하고, 이 예외를 예외 수집하도록 하기
- [x] 요청 좌표를 객체로 전달받도록 API 사양 수정

[TRL-296]: https://cosain.atlassian.net/browse/TRL-296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ