### PR TITLE
[TRL-214] docs: 일정 생성 API 문서화 테스트 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -138,6 +138,7 @@ include::{snippets}/trip-update-controller-docs-test/trip-update-doc-test/http-r
 여행이 삭제되면, 여행에 속해있는 Day 및 일정들도 모두 일괄적으로 삭제됩니다.
 
 ==== 요청
+===== 헤더
 include::{snippets}/trip-delete-controller-docs-test/trip-delete-doc-test/request-headers.adoc[]
 
 ===== 경로 변수(PathVariable)
@@ -186,6 +187,51 @@ include::{snippets}/single-trip-query-controller-docs-test/여행_단건_조회/
 include::{snippets}/single-trip-query-controller-docs-test/여행_단건_조회/http-request.adoc[]
 ===== 응답
 include::{snippets}/single-trip-query-controller-docs-test/여행_단건_조회/http-response.adoc[]
+
+---
+
+=== Schedule 생성
+
+==== 기본 정보
+
+- 메서드 : POST
+- URL : `/api/schedules`
+- 인증 방식 : 액세스 토큰
+
+일정을 생성합니다.
+어느 Trip의 어느 Day에 일정을 생성할 지 지정할 수 있으며, day가 null 이면 해당 Trip(여행)의 임시보관함에 일정이 생성됩니다.
+이 때, 전달된 식별자의 Day가 해당 Trip에 속하지 않을 경우, 예외가 발생합니다.
+
+
+==== 요청
+===== 헤더
+include::{snippets}/schedule-create-controller-docs-test/schedule-create-doc-test/request-headers.adoc[]
+
+===== 본문
+include::{snippets}/schedule-create-controller-docs-test/schedule-create-doc-test/request-fields.adoc[]
+
+===== 좌표(Coordinate) 타입
+include::{snippets}/schedule-create-controller-docs-test/schedule-create-doc-test/request-fields-beneath-coordinate.adoc[]
+
+==== 응답
+===== 본문
+include::{snippets}/schedule-create-controller-docs-test/schedule-create-doc-test/response-fields.adoc[]
+
+
+
+==== 예제
+===== 요청
+include::{snippets}/schedule-create-controller-docs-test/schedule-create-doc-test/http-request.adoc[]
+
+
+사용자는 어느 Trip의 어느 Day에 일정을 생성할 것인지 지정합니다. 이 때, Trip Id가 null 이면 임시보관함에 삽입되고, dayId가 null 이 아니면
+해당 day에 일정이 생성됩니다. (단, 해당 식별자의 Day가 Trip에 속해야합니다!)
+
+
+===== 응답
+include::{snippets}/schedule-create-controller-docs-test/schedule-create-doc-test/http-response.adoc[]
+
+일정이 정상적으로 생성되면, 생성된 일정(Schedule)의 식별자가 반환되고, 상태코드로 201 Created가 전달됩니다.
 
 ---
 

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/docs/ScheduleCreateControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/docs/ScheduleCreateControllerDocsTest.java
@@ -1,0 +1,157 @@
+package com.cosain.trilo.unit.trip.presentation.schedule.command.docs;
+
+import com.cosain.trilo.support.RestDocsTestSupport;
+import com.cosain.trilo.trip.application.schedule.command.usecase.ScheduleCreateUseCase;
+import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleCreateCommand;
+import com.cosain.trilo.trip.application.schedule.command.usecase.dto.factory.ScheduleCreateCommandFactory;
+import com.cosain.trilo.trip.domain.vo.Coordinate;
+import com.cosain.trilo.trip.domain.vo.Place;
+import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
+import com.cosain.trilo.trip.presentation.schedule.command.ScheduleCreateController;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.snippet.Attributes.key;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ScheduleCreateController.class)
+@DisplayName("일정 생성 API DOCS 테스트")
+public class ScheduleCreateControllerDocsTest extends RestDocsTestSupport {
+
+    @MockBean
+    private ScheduleCreateUseCase scheduleCreateUseCase;
+
+    @MockBean
+    private ScheduleCreateCommandFactory scheduleCreateCommandFactory;
+
+    private final String ACCESS_TOKEN = "Bearer accessToken";
+
+    @Test
+    @DisplayName("인증된 사용자의 일정 생성 요청 -> 성공")
+    void scheduleCreateDocTest() throws Exception {
+        mockingForLoginUserAnnotation();
+
+        Long dayId = 1L;
+        Long tripId = 1L;
+        String rawScheduleTitle = "일정 제목";
+        String placeId = "place-id";
+        String placeName = "place-Name";
+        Double latitude = 37.564213;
+        Double longitude = 127.001698;
+
+        String requestJson = String.format("""
+                {
+                    "dayId": %d,
+                    "tripId": %d,
+                    "title": "%s",
+                    "placeId": "%s",
+                    "placeName": "%s",
+                    "coordinate": {
+                        "latitude": %f,
+                        "longitude": %f
+                    }
+                }
+                """, dayId, tripId, rawScheduleTitle, placeId, placeName, latitude, longitude);
+
+        ScheduleCreateCommand command = ScheduleCreateCommand.builder()
+                .dayId(dayId)
+                .tripId(tripId)
+                .scheduleTitle(ScheduleTitle.of(rawScheduleTitle))
+                .place(Place.of(placeId, placeName, Coordinate.of(latitude, longitude)))
+                .build();
+
+        Long createdScheduleId = 3L;
+
+        given(scheduleCreateCommandFactory.createCommand(
+                eq(dayId), eq(tripId), eq(rawScheduleTitle),
+                eq(placeId), eq(placeName),
+                eq(latitude), eq(longitude), anyList())).willReturn(command);
+        given(scheduleCreateUseCase.createSchedule(any(), any(ScheduleCreateCommand.class))).willReturn(createdScheduleId);
+
+
+        mockMvc.perform(post("/api/schedules")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(requestJson)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.scheduleId").value(createdScheduleId))
+                .andDo(restDocs.document(
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION)
+                                        .description("Bearer 타입 AccessToken")
+                        ),
+                        requestFields(
+                                fieldWithPath("dayId")
+                                        .type(NUMBER)
+                                        .optional()
+                                        .description("day의 식별자. null 일 경우 임시보관함으로 간주"),
+                                fieldWithPath("title")
+                                        .type(STRING)
+                                        .description("일정의 제목")
+                                        .attributes(key("constraints").value("null 또는 공백일 수 없으며, 길이는 1-20자까지만 허용됩니다.")),
+                                fieldWithPath("tripId")
+                                        .type(NUMBER)
+                                        .description("소속된 여행(Trip)의 식별자")
+                                        .attributes(key("constraints").value("null 이 허용되지 않습니다.")),
+                                fieldWithPath("placeId")
+                                        .type(STRING)
+                                        .optional()
+                                        .description("장소의 google map api 기준 식별자"),
+                                fieldWithPath("placeName")
+                                        .type(STRING)
+                                        .optional()
+                                        .description("장소명"),
+                                fieldWithPath("coordinate")
+                                        .type("Coordinate")
+                                        .description("장소의 좌표. 하위 표를 참고하세요.")
+                                        .attributes(key("constraints").value("null 이 허용되지 않습니다.")),
+                                fieldWithPath("coordinate.latitude").ignored(),
+                                fieldWithPath("coordinate.longitude").ignored()
+                        ),
+                        responseFields(
+                                fieldWithPath("scheduleId")
+                                        .type(NUMBER)
+                                        .description("생성된 일정 식별자(id)")
+                        )
+                ))
+                .andDo(restDocs.document(
+                        requestFields(beneathPath("coordinate"),
+                                fieldWithPath("latitude")
+                                        .type(NUMBER)
+                                        .description("위도")
+                                        .attributes(key("constraints").value("null이여선 안 되고 -90 이상 90 이하까지만 허용")),
+                                fieldWithPath("longitude")
+                                        .type(NUMBER)
+                                        .description("경도")
+                                        .attributes(key("constraints").value("null이여선 안 되고 -180 이상 180 이하까지만 허용"))
+                        )
+                ));
+
+        verify(scheduleCreateUseCase).createSchedule(any(), any(ScheduleCreateCommand.class));
+        verify(scheduleCreateCommandFactory).createCommand(
+                eq(dayId), eq(tripId), eq(rawScheduleTitle),
+                eq(placeId), eq(placeName),
+                eq(latitude), eq(longitude), anyList()
+        );
+    }
+}


### PR DESCRIPTION
# JIRA 티켓
- [TRL-214]

---

# 작업 내역
- [x] Coordinate의 필드를 별도 테이블로 분리해서 문서화
- [x] 일정 생성 API 문서화 테스트 작성
- [x] 일정 생성 API adoc 파일 작성

---

# 결과물

![image](https://github.com/teamCoSaIn/trilo-be/assets/88282356/34ee1186-b888-4aac-91c2-3548400ded80)

- 상위 객체와 하위 필드의 테이블을 별도로 분리


[TRL-214]: https://cosain.atlassian.net/browse/TRL-214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ