### PR TITLE
[TRL-298] feat: 일정 이동 API - 일정 개수 제약 조건 반영

### DIFF
--- a/src/main/resources/exceptions/exception.yml
+++ b/src/main/resources/exceptions/exception.yml
@@ -149,7 +149,7 @@ schedule-0009:
 
 schedule-0010:
   message: Too Many Day Schedule Count
-  detail: Day에 더 이상 일정을 생성할 수 없습니다. 한 Day는 최대 10개의 일정을 가질 수 있습니다.
+  detail: 지정 Day에 더 이상 일정을 둘 수 없습니다. 한 Day는 최대 10개의 일정을 가질 수 있습니다.
 
 # 장소 관련
 place-0001:

--- a/src/main/resources/exceptions/exception_en.yml
+++ b/src/main/resources/exceptions/exception_en.yml
@@ -149,7 +149,7 @@ schedule-0009:
 
 schedule-0010:
   message: Too Many Day Schedule Count
-  detail: Cannot create any more schedules for your TripDay. Each TripDay can have a maximum of 10 schedules.
+  detail: You cannot put any more schedule on the designated day. Each day can have a maximum of 10 schedules.
 
 
 # 장소 관련


### PR DESCRIPTION
# JIRA 티켓
- [TRL-298]

---

# 개요
- 각 Day는 최대 10개의 일정을 가질 수 있어야하는데, 이 제약조건은 일정 생성 기능에만 추가했고 일정 이동 기능에는 이 내용이 반영되어있지 않았음

---

# 작업 내역
- [x] 일정 이동 기능 상에서, 기존의 Day(임시보관함도 해당)와 다른 Day로 일정 이동 시 일정 갯수 제약 조건을 추가 
- [x] 테스트 코드 작성

[TRL-298]: https://cosain.atlassian.net/browse/TRL-298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ