### PR TITLE
[TRL-303] docs: API 문서 구조 리팩토링

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -42,23 +42,38 @@ include::{snippets}/auth-rest-controller-docs-test/로그인_요청/http-respons
 - 메서드 : GET
 - URL : `/api/auth/token/refresh-token-info`
 
-===== 요청
-====== 쿠키
+==== 요청
+===== 쿠키
 include::{snippets}/auth-rest-controller-docs-test/재발급_토큰_상태_조회_요청/request-cookies.adoc[]
-===== 응답
-====== 본문
+==== 응답
+===== 본문
 include::{snippets}/auth-rest-controller-docs-test/재발급_토큰_상태_조회_요청/response-fields.adoc[]
-===== 예제
-====== 요청
+==== 예제
+===== 요청
 include::{snippets}/auth-rest-controller-docs-test/재발급_토큰_상태_조회_요청/http-request.adoc[]
-====== 응답
+===== 응답
 include::{snippets}/auth-rest-controller-docs-test/재발급_토큰_상태_조회_요청/http-response.adoc[]
 
 ---
 
 === 접근 토큰 재발급
-operation::auth-rest-controller-docs-test/접근토큰_재발급_요청[snippets = 'http-request,http-response,response-fields']
 
+==== 기본 정보
+
+- 메서드 : POST
+- URL : `/api/auth/reissue`
+
+==== 요청
+===== 쿠키
+include::{snippets}/auth-rest-controller-docs-test/접근토큰_재발급_요청/request-cookies.adoc[]
+==== 응답
+===== 본문
+include::{snippets}/auth-rest-controller-docs-test/접근토큰_재발급_요청/response-fields.adoc[]
+==== 예제
+===== 요청
+include::{snippets}/auth-rest-controller-docs-test/접근토큰_재발급_요청/http-request.adoc[]
+===== 응답
+include::{snippets}/auth-rest-controller-docs-test/접근토큰_재발급_요청/http-response.adoc[]
 '''
 
 == Trip API

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -13,6 +13,7 @@
 
 === OAuth2 로그인
 
+==== 기본 정보
 - 메서드 : GET
 - URL : `/api/auth/login/{provider}?redirect_uri={redirectUri}&code={Authorization_Code}`
 
@@ -34,6 +35,26 @@ include::{snippets}/auth-rest-controller-docs-test/로그인_요청/http-request
 include::{snippets}/auth-rest-controller-docs-test/로그인_요청/http-response.adoc[]
 
 '''
+
+=== 로그아웃
+
+==== 기본 정보
+- 메서드 : POST
+- URL : `/api/auth/logout`
+
+==== 요청
+===== 쿠키
+include::{snippets}/auth-rest-controller-docs-test/로그아웃_요청/request-cookies.adoc[]
+===== 헤더
+include::{snippets}/auth-rest-controller-docs-test/로그아웃_요청/request-headers.adoc[]
+==== 예제
+===== 요청
+include::{snippets}/auth-rest-controller-docs-test/로그아웃_요청/http-request.adoc[]
+===== 응답
+include::{snippets}/auth-rest-controller-docs-test/로그아웃_요청/http-response.adoc[]
+
+
+---
 
 === 재발급 토큰 상태 조회
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -396,7 +396,7 @@ include::{snippets}/single-schedule-query-controller-docs-test/일정_단건_조
 
 '''
 
-=== Day 조회
+=== Day 단건 조회
 
 ==== 기본 정보
 
@@ -413,6 +413,10 @@ include::{snippets}/single-day-query-controller-docs-test/day_단건_조회/path
 ==== 응답
 ===== 본문
 include::{snippets}/single-day-query-controller-docs-test/day_단건_조회/response-fields.adoc[]
+===== Schedules
+include::{snippets}/single-day-query-controller-docs-test/day_단건_조회/response-fields-schedules.adoc[]
+===== Coordinate
+include::{snippets}/single-day-query-controller-docs-test/day_단건_조회/response-fields-coordinate.adoc[]
 
 ==== 예제
 ===== 요청
@@ -438,11 +442,11 @@ include::{snippets}/trip-day-list-query-controller-docs-test/day_목록_조회/p
 ==== 응답
 ===== 본문
 include::{snippets}/trip-day-list-query-controller-docs-test/day_목록_조회/response-fields.adoc[]
-====== Days
+===== Days
 include::{snippets}/trip-day-list-query-controller-docs-test/day_목록_조회/response-fields-days.adoc[]
-====== Schedules
+===== Schedules
 include::{snippets}/trip-day-list-query-controller-docs-test/day_목록_조회/response-fields-schedules.adoc[]
-====== Coordinate
+===== Coordinate
 include::{snippets}/trip-day-list-query-controller-docs-test/day_목록_조회/response-fields-coordinate.adoc[]
 ==== 예제
 ===== 요청

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -36,7 +36,25 @@ include::{snippets}/auth-rest-controller-docs-test/로그인_요청/http-respons
 '''
 
 === 재발급 토큰 상태 조회
-operation::auth-rest-controller-docs-test/재발급_토큰_상태_조회_요청[snippets = 'http-request,http-response,response-fields']
+
+==== 기본 정보
+
+- 메서드 : GET
+- URL : `/api/auth/token/refresh-token-info`
+
+===== 요청
+====== 쿠키
+include::{snippets}/auth-rest-controller-docs-test/재발급_토큰_상태_조회_요청/request-cookies.adoc[]
+===== 응답
+====== 본문
+include::{snippets}/auth-rest-controller-docs-test/재발급_토큰_상태_조회_요청/response-fields.adoc[]
+===== 예제
+====== 요청
+include::{snippets}/auth-rest-controller-docs-test/재발급_토큰_상태_조회_요청/http-request.adoc[]
+====== 응답
+include::{snippets}/auth-rest-controller-docs-test/재발급_토큰_상태_조회_요청/http-response.adoc[]
+
+---
 
 === 접근 토큰 재발급
 operation::auth-rest-controller-docs-test/접근토큰_재발급_요청[snippets = 'http-request,http-response,response-fields']

--- a/src/test/java/com/cosain/trilo/unit/auth/presentation/docs/AuthRestControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/auth/presentation/docs/AuthRestControllerDocsTest.java
@@ -83,6 +83,9 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
                 .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken"))
                 .andExpect(status().isOk())
                 .andDo(restDocs.document(
+                    requestCookies(
+                            cookieWithName("refreshToken").description("삭제할 재발급 토큰")
+                    ),
                     requestHeaders(
                             headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer 타입 AccessToken")
                     )

--- a/src/test/java/com/cosain/trilo/unit/auth/presentation/docs/AuthRestControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/auth/presentation/docs/AuthRestControllerDocsTest.java
@@ -46,6 +46,9 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
                         .cookie(new Cookie("refreshToken", "refreshToken")))
                 .andExpect(status().isOk())
                 .andDo(restDocs.document(
+                        requestCookies(
+                                cookieWithName("refreshToken").description("접근 토큰 발급에 사용될 재발급 토큰")
+                        ),
                         responseFields(
                                 fieldWithPath("authType").type(STRING).description("인증 타입 (Bearer)"),
                                 fieldWithPath("accessToken").type(STRING).description("재발급한 접근 토큰")

--- a/src/test/java/com/cosain/trilo/unit/auth/presentation/docs/AuthRestControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/auth/presentation/docs/AuthRestControllerDocsTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.cookies.CookieDocumentation;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 
 import org.springframework.security.test.context.support.WithMockUser;
@@ -18,6 +19,8 @@ import org.springframework.security.test.context.support.WithMockUser;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
 import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
@@ -59,6 +62,9 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
                         .cookie(new Cookie("refreshToken", "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzd2VldF9zbWVsbEBuYXRlLmNvbSIsImlhdCI6MTY3OTg4MjQ2NiwiZXhwIjoxNjc5ODkzMjY2fQ.v0E4tjveoiOSP2GONUvfTH8-pR_zB5A9w5l5ZNPc4Wk")))
                 .andExpect(status().isOk())
                 .andDo(restDocs.document(
+                        requestCookies(
+                            cookieWithName("refreshToken").description("상태 조회할 재발급 토큰")
+                        ),
                         responseFields(
                                 fieldWithPath("availability").type(BOOLEAN).description("토큰 사용 가능 여부")
                         )

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/day/query/docs/SingleDayQueryControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/day/query/docs/SingleDayQueryControllerDocsTest.java
@@ -21,10 +21,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
-import static org.springframework.restdocs.payload.JsonFieldType.STRING;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -63,18 +61,19 @@ public class SingleDayQueryControllerDocsTest extends RestDocsTestSupport {
                                 fieldWithPath("dayId").type(NUMBER).description("Day ID"),
                                 fieldWithPath("tripId").type(NUMBER).description("여행 ID"),
                                 fieldWithPath("date").type(STRING).description("여행 날짜"),
-                                fieldWithPath("schedules[0].scheduleId").type(NUMBER).description("일정 ID"),
-                                fieldWithPath("schedules[0].title").type(STRING).description("일정 제목"),
-                                fieldWithPath("schedules[0].placeName").type(STRING).description("장소 이름"),
-                                fieldWithPath("schedules[0].placeId").type(STRING).description("장소 식별자"),
-                                fieldWithPath("schedules[0].coordinate.latitude").type(NUMBER).description("위도"),
-                                fieldWithPath("schedules[0].coordinate.longitude").type(NUMBER).description("경도"),
-                                fieldWithPath("schedules[1].scheduleId").type(NUMBER).description("일정 ID"),
-                                fieldWithPath("schedules[1].title").type(STRING).description("일정 제목"),
-                                fieldWithPath("schedules[1].placeName").type(STRING).description("장소 이름"),
-                                fieldWithPath("schedules[1].placeId").type(STRING).description("장소 식별자"),
-                                fieldWithPath("schedules[1].coordinate.latitude").type(NUMBER).description("위도"),
-                                fieldWithPath("schedules[1].coordinate.longitude").type(NUMBER).description("경도")
+                                subsectionWithPath("schedules").type(ARRAY).description("일정 목록")
+                        ),
+                        responseFields(
+                                beneathPath("schedules").withSubsectionId("schedules"),
+                                fieldWithPath("scheduleId").type(NUMBER).description("일정 ID"),
+                                fieldWithPath("title").type(STRING).description("일정 제목"),
+                                fieldWithPath("placeName").type(STRING).description("장소 이름"),
+                                fieldWithPath("placeId").type(STRING).description("장소 ID"),
+                                subsectionWithPath("coordinate").type(OBJECT).description("장소의 좌표")
+                        ),
+                        responseFields(beneathPath("schedules[].coordinate").withSubsectionId("coordinate"),
+                                fieldWithPath("latitude").type(NUMBER).description("위도"),
+                                fieldWithPath("longitude").type(NUMBER).description("경도")
                         )
                 ));
     }

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/day/query/docs/TripDayListQueryControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/day/query/docs/TripDayListQueryControllerDocsTest.java
@@ -64,7 +64,7 @@ public class TripDayListQueryControllerDocsTest extends RestDocsTestSupport {
                                 fieldWithPath("dayId").type(NUMBER).description("Day ID"),
                                 fieldWithPath("tripId").type(NUMBER).description("여행 ID"),
                                 fieldWithPath("date").description(STRING).description("여행 날짜"),
-                                subsectionWithPath("schedules").type(ARRAY).description("Day 목록")
+                                subsectionWithPath("schedules").type(ARRAY).description("일정 목록")
                         ),
                         responseFields(
                                 beneathPath("days[].schedules").withSubsectionId("schedules"),


### PR DESCRIPTION
# JIRA 티켓
[TRL-303]

# 작업 내역
- [x] 자잘한 오타 수정 
- [x] Day 단건 조회 API 명세 구조화
- [x] RefreshToken 상태 조회 API 명세 팀 컨벤션에 맞게 수정
- [x] AccessToken 재발급 API 명세 팀 컨벤션에 맞게 수정
- [x] 로그아웃 API 명세 팀 컨벤션에 맞게 수정

[TRL-303]: https://cosain.atlassian.net/browse/TRL-303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ