### PR TITLE
[TRL-305] feat: 일정 - 시작/종료 속성 추가 및 API 반영

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -378,7 +378,7 @@ include::{snippets}/schedule-update-controller-docs-test/schedule-update-doc-tes
 ===== 요청
 include::{snippets}/schedule-update-controller-docs-test/schedule-update-doc-test/http-request.adoc[]
 
-사용자는 경로 변수를 통해 수정하고자 하는 여행의 식별자를 전달하고, 본문을 통해 어떤 제목/본문으로 변경할지 전달합니다.
+사용자는 경로 변수를 통해 수정하고자 하는 여행의 식별자를 전달하고, 본문을 통해 어떤 제목/본문으로 변경할지, 계획 시간을 어느 시간대로 변경할 지, 전달합니다.
 
 ===== 응답
 include::{snippets}/schedule-update-controller-docs-test/schedule-update-doc-test/http-response.adoc[]

--- a/src/main/java/com/cosain/trilo/trip/application/schedule/command/service/ScheduleUpdateService.java
+++ b/src/main/java/com/cosain/trilo/trip/application/schedule/command/service/ScheduleUpdateService.java
@@ -24,6 +24,7 @@ public class ScheduleUpdateService implements ScheduleUpdateUseCase {
 
         schedule.changeTitle(scheduleUpdateCommand.getScheduleTitle());
         schedule.changeContent(scheduleUpdateCommand.getScheduleContent());
+        schedule.changeTime(scheduleUpdateCommand.getScheduleTime());
 
         return schedule.getId();
     }

--- a/src/main/java/com/cosain/trilo/trip/application/schedule/command/usecase/dto/ScheduleUpdateCommand.java
+++ b/src/main/java/com/cosain/trilo/trip/application/schedule/command/usecase/dto/ScheduleUpdateCommand.java
@@ -1,6 +1,7 @@
 package com.cosain.trilo.trip.application.schedule.command.usecase.dto;
 
 import com.cosain.trilo.trip.domain.vo.ScheduleContent;
+import com.cosain.trilo.trip.domain.vo.ScheduleTime;
 import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
 import lombok.Getter;
 
@@ -8,9 +9,11 @@ import lombok.Getter;
 public class ScheduleUpdateCommand {
     private ScheduleTitle scheduleTitle;
     private ScheduleContent scheduleContent;
+    private ScheduleTime scheduleTime;
 
-    public ScheduleUpdateCommand(ScheduleTitle scheduleTitle, ScheduleContent scheduleContent){
+    public ScheduleUpdateCommand(ScheduleTitle scheduleTitle, ScheduleContent scheduleContent, ScheduleTime scheduleTime){
         this.scheduleTitle = scheduleTitle;
         this.scheduleContent = scheduleContent;
+        this.scheduleTime = scheduleTime;
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/application/schedule/command/usecase/dto/factory/ScheduleUpdateCommandFactory.java
+++ b/src/main/java/com/cosain/trilo/trip/application/schedule/command/usecase/dto/factory/ScheduleUpdateCommandFactory.java
@@ -4,24 +4,27 @@ import com.cosain.trilo.common.exception.CustomException;
 import com.cosain.trilo.common.exception.CustomValidationException;
 import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleUpdateCommand;
 import com.cosain.trilo.trip.domain.vo.ScheduleContent;
+import com.cosain.trilo.trip.domain.vo.ScheduleTime;
 import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Component
 public class ScheduleUpdateCommandFactory {
 
-    public ScheduleUpdateCommand createCommand(String rawTitle, String rawContent) {
+    public ScheduleUpdateCommand createCommand(String rawTitle, String rawContent, LocalTime startTime, LocalTime endTime) {
         List<CustomException> exceptions = new ArrayList<>();
         ScheduleTitle scheduleTitle = makeScheduleTitle(rawTitle, exceptions);
         ScheduleContent scheduleContent = makeScheduleContent(rawContent, exceptions);
+        ScheduleTime scheduleTime = makeScheduleTime(startTime, endTime, exceptions);
 
         if (!exceptions.isEmpty()) {
             throw new CustomValidationException(exceptions);
         }
-        return new ScheduleUpdateCommand(scheduleTitle, scheduleContent);
+        return new ScheduleUpdateCommand(scheduleTitle, scheduleContent, scheduleTime);
     }
 
     private ScheduleTitle makeScheduleTitle(String rawTitle, List<CustomException> exceptions) {
@@ -36,6 +39,15 @@ public class ScheduleUpdateCommandFactory {
     private ScheduleContent makeScheduleContent(String rawContent, List<CustomException> exceptions) {
         try {
             return ScheduleContent.of(rawContent);
+        } catch (CustomException e) {
+            exceptions.add(e);
+            return null;
+        }
+    }
+
+    private ScheduleTime makeScheduleTime(LocalTime startTime, LocalTime endTime, List<CustomException> exceptions) {
+        try {
+            return ScheduleTime.of(startTime, endTime);
         } catch (CustomException e) {
             exceptions.add(e);
             return null;

--- a/src/main/java/com/cosain/trilo/trip/domain/entity/Schedule.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/entity/Schedule.java
@@ -75,6 +75,10 @@ public class Schedule {
         this.scheduleContent = scheduleContent;
     }
 
+    public void changeTime(ScheduleTime scheduleTime) {
+        this.scheduleTime = scheduleTime;
+    }
+
     /**
      * 일정의 day와 ScheduleIndex를 변경합니다.
      * 기존의 day 또는 임시보관함이 있으면 해당 Day와 관계를 끊고 새로운 day 또는 임시보관함과 관계를 맺습니다.

--- a/src/main/java/com/cosain/trilo/trip/domain/entity/Schedule.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/entity/Schedule.java
@@ -1,9 +1,6 @@
 package com.cosain.trilo.trip.domain.entity;
 
-import com.cosain.trilo.trip.domain.vo.Place;
-import com.cosain.trilo.trip.domain.vo.ScheduleContent;
-import com.cosain.trilo.trip.domain.vo.ScheduleIndex;
-import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
+import com.cosain.trilo.trip.domain.vo.*;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
@@ -11,7 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Getter
-@ToString(of = {"id", "scheduleTitle", "scheduleContent", "place", "scheduleIndex"})
+@ToString(of = {"id", "scheduleTitle", "scheduleContent", "scheduleTime", "place", "scheduleIndex"})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "schedules")
 @Entity
@@ -37,6 +34,9 @@ public class Schedule {
     private ScheduleContent scheduleContent;
 
     @Embedded
+    private ScheduleTime scheduleTime;
+
+    @Embedded
     private Place place;
 
     @Embedded
@@ -56,27 +56,29 @@ public class Schedule {
      * 테스트의 편의성을 위해 Builder accessLevel = PUBLIC 으로 설정
      */
     @Builder(access = AccessLevel.PUBLIC)
-    private Schedule(Long id, Day day, Trip trip, ScheduleTitle scheduleTitle, ScheduleContent scheduleContent, Place place, ScheduleIndex scheduleIndex) {
+    private Schedule(Long id, Day day, Trip trip, ScheduleTitle scheduleTitle, ScheduleContent scheduleContent, ScheduleTime scheduleTime, Place place, ScheduleIndex scheduleIndex) {
         this.id = id;
         this.day = day;
         this.trip = trip;
         this.scheduleTitle = scheduleTitle;
         this.scheduleContent = scheduleContent;
+        this.scheduleTime = scheduleTime == null ? ScheduleTime.of(null, null) : scheduleTime;
         this.place = place;
         this.scheduleIndex = scheduleIndex;
     }
 
-    public void changeTitle(ScheduleTitle scheduleTitle){
+    public void changeTitle(ScheduleTitle scheduleTitle) {
         this.scheduleTitle = scheduleTitle;
     }
 
-    public void changeContent(ScheduleContent scheduleContent){
+    public void changeContent(ScheduleContent scheduleContent) {
         this.scheduleContent = scheduleContent;
     }
 
     /**
      * 일정의 day와 ScheduleIndex를 변경합니다.
      * 기존의 day 또는 임시보관함이 있으면 해당 Day와 관계를 끊고 새로운 day 또는 임시보관함과 관계를 맺습니다.
+     *
      * @param changeDay
      * @param changeScheduleIndex
      */

--- a/src/main/java/com/cosain/trilo/trip/domain/vo/ScheduleTime.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/vo/ScheduleTime.java
@@ -1,0 +1,30 @@
+package com.cosain.trilo.trip.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+import java.time.LocalTime;
+
+@Getter
+@ToString(of ={"startTime", "endTime"})
+@EqualsAndHashCode(of = {"startTime", "endTime"})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class ScheduleTime {
+
+    @Column(name = "start_time")
+    private LocalTime startTime;
+
+    @Column(name = "end_time")
+    private LocalTime endTime;
+
+    public static ScheduleTime of(LocalTime startTime, LocalTime endTime) {
+        return new ScheduleTime(startTime, endTime);
+    }
+
+    private ScheduleTime(LocalTime startTime, LocalTime endTime) {
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/presentation/schedule/command/ScheduleUpdateController.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/schedule/command/ScheduleUpdateController.java
@@ -1,8 +1,8 @@
 package com.cosain.trilo.trip.presentation.schedule.command;
 
 import com.cosain.trilo.common.LoginUser;
-import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleUpdateCommand;
 import com.cosain.trilo.trip.application.schedule.command.usecase.ScheduleUpdateUseCase;
+import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleUpdateCommand;
 import com.cosain.trilo.trip.application.schedule.command.usecase.dto.factory.ScheduleUpdateCommandFactory;
 import com.cosain.trilo.trip.presentation.schedule.command.dto.request.ScheduleUpdateRequest;
 import com.cosain.trilo.trip.presentation.schedule.command.dto.response.ScheduleUpdateResponse;
@@ -25,9 +25,10 @@ public class ScheduleUpdateController {
     public ScheduleUpdateResponse updateSchedule(@LoginUser User user, @PathVariable Long scheduleId, @RequestBody ScheduleUpdateRequest request) {
         Long tripperId = user.getId();
 
-        ScheduleUpdateCommand scheduleUpdateCommand = scheduleUpdateCommandFactory.createCommand(request.getTitle(), request.getContent());
+        ScheduleUpdateCommand scheduleUpdateCommand = scheduleUpdateCommandFactory.createCommand(request.getTitle(),request.getContent(), request.getStartTime(), request.getEndTime());
         Long updatedScheduleId = scheduleUpdateUseCase.updateSchedule(scheduleId,tripperId, scheduleUpdateCommand);
 
         return ScheduleUpdateResponse.from(updatedScheduleId);
     }
+
 }

--- a/src/main/java/com/cosain/trilo/trip/presentation/schedule/command/dto/request/ScheduleUpdateRequest.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/schedule/command/dto/request/ScheduleUpdateRequest.java
@@ -5,10 +5,15 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalTime;
+
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ScheduleUpdateRequest {
+
     private String title;
     private String content;
+    private LocalTime startTime;
+    private LocalTime endTime;
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/dto/factory/ScheduleUpdateCommandFactoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/dto/factory/ScheduleUpdateCommandFactoryTest.java
@@ -1,12 +1,13 @@
 package com.cosain.trilo.unit.trip.application.schedule.command.dto.factory;
 
 import com.cosain.trilo.common.exception.CustomValidationException;
-import com.cosain.trilo.trip.application.exception.NullTripIdException;
 import com.cosain.trilo.trip.application.schedule.command.usecase.dto.factory.ScheduleUpdateCommandFactory;
 import com.cosain.trilo.trip.domain.exception.InvalidScheduleTitleException;
 import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.time.LocalTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
@@ -23,10 +24,12 @@ public class ScheduleUpdateCommandFactoryTest {
         // given
         String rawScheduleTitle = null;
         String rawScheduleContent = "일정 본문";
+        LocalTime startTime = LocalTime.of(13,0);
+        LocalTime endTime = LocalTime.of(13,5);
 
         // when
         CustomValidationException cve = catchThrowableOfType(
-                () -> scheduleUpdateCommandFactory.createCommand(rawScheduleTitle, rawScheduleContent),
+                () -> scheduleUpdateCommandFactory.createCommand(rawScheduleTitle, rawScheduleContent, startTime, endTime),
                 CustomValidationException.class);
 
         // then
@@ -41,10 +44,12 @@ public class ScheduleUpdateCommandFactoryTest {
         // given
         String rawScheduleTitle = "";
         String rawScheduleContent = "일정 본문";
+        LocalTime startTime = LocalTime.of(13,0);
+        LocalTime endTime = LocalTime.of(13,5);
 
         // when
         CustomValidationException cve = catchThrowableOfType(
-                () -> scheduleUpdateCommandFactory.createCommand(rawScheduleTitle, rawScheduleContent),
+                () -> scheduleUpdateCommandFactory.createCommand(rawScheduleTitle, rawScheduleContent, startTime, endTime),
                 CustomValidationException.class);
 
         // then
@@ -59,10 +64,12 @@ public class ScheduleUpdateCommandFactoryTest {
         // given
         String rawScheduleTitle = "    ";
         String rawScheduleContent = "일정 본문";
+        LocalTime startTime = LocalTime.of(13,0);
+        LocalTime endTime = LocalTime.of(13,5);
 
         // when
         CustomValidationException cve = catchThrowableOfType(
-                () -> scheduleUpdateCommandFactory.createCommand(rawScheduleTitle, rawScheduleContent),
+                () -> scheduleUpdateCommandFactory.createCommand(rawScheduleTitle, rawScheduleContent, startTime, endTime),
                 CustomValidationException.class);
 
         // then
@@ -77,10 +84,12 @@ public class ScheduleUpdateCommandFactoryTest {
         // given
         String rawScheduleTitle = "가".repeat(ScheduleTitle.MAX_LENGTH + 1);
         String rawScheduleContent = "일정 본문";
+        LocalTime startTime = LocalTime.of(13,0);
+        LocalTime endTime = LocalTime.of(13,5);
 
         // when
         CustomValidationException cve = catchThrowableOfType(
-                () -> scheduleUpdateCommandFactory.createCommand(rawScheduleTitle, rawScheduleContent),
+                () -> scheduleUpdateCommandFactory.createCommand(rawScheduleTitle, rawScheduleContent, startTime, endTime),
                 CustomValidationException.class);
 
         // then

--- a/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleUpdateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleUpdateServiceTest.java
@@ -8,6 +8,7 @@ import com.cosain.trilo.trip.domain.entity.Schedule;
 import com.cosain.trilo.trip.domain.entity.Trip;
 import com.cosain.trilo.trip.domain.repository.ScheduleRepository;
 import com.cosain.trilo.trip.domain.vo.ScheduleContent;
+import com.cosain.trilo.trip.domain.vo.ScheduleTime;
 import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
 import com.cosain.trilo.trip.domain.vo.TripTitle;
 import org.assertj.core.api.Assertions;
@@ -18,6 +19,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalTime;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -37,7 +39,10 @@ public class ScheduleUpdateServiceTest {
     @DisplayName("호출이 제대로 이루어 지는지 테스트")
     public void update_schedule_test(){
         // given
-        ScheduleUpdateCommand command = new ScheduleUpdateCommand(ScheduleTitle.of("변경할 제목"), ScheduleContent.of("변경할 내용"));
+        ScheduleTitle newTitle = ScheduleTitle.of("변경할 제목");
+        ScheduleContent newContent = ScheduleContent.of("변경할 내용");
+        ScheduleTime newScheduleTime = ScheduleTime.of(LocalTime.of(13,0), LocalTime.of(13,5));
+        ScheduleUpdateCommand command = new ScheduleUpdateCommand(newTitle, newContent, newScheduleTime);
 
         Schedule schedule = Schedule.builder()
                 .trip(Trip.create(TripTitle.of("여행 제목"), 1L))
@@ -57,7 +62,10 @@ public class ScheduleUpdateServiceTest {
     @DisplayName("권한이 없는 사람이 Schedule 을 변경하려고 하면, NoScheduleUpdateAuthorityException 이 발생한다")
     public void when_no_authority_user_try_update_test(){
         // given
-        ScheduleUpdateCommand command = new ScheduleUpdateCommand(ScheduleTitle.of("변경할 제목"), ScheduleContent.of("변경할 내용"));
+        ScheduleTitle newTitle = ScheduleTitle.of("변경할 제목");
+        ScheduleContent newContent = ScheduleContent.of("변경할 내용");
+        ScheduleTime newScheduleTime = ScheduleTime.of(LocalTime.of(13,0), LocalTime.of(13,5));
+        ScheduleUpdateCommand command = new ScheduleUpdateCommand(newTitle, newContent, newScheduleTime);
 
         Schedule schedule = Schedule.builder()
                 .trip(Trip.create(TripTitle.of("여행 제목"), 2L))
@@ -75,7 +83,12 @@ public class ScheduleUpdateServiceTest {
     @DisplayName("일정이 존재하지 않는다면, ScheduleNotFoundException 이 발생한다")
     public void when_no_schedule_test(){
         // given
-        ScheduleUpdateCommand command = new ScheduleUpdateCommand(ScheduleTitle.of("변경할 제목"), ScheduleContent.of("변경할 내용"));
+        // given
+        ScheduleTitle newTitle = ScheduleTitle.of("변경할 제목");
+        ScheduleContent newContent = ScheduleContent.of("변경할 내용");
+        ScheduleTime newScheduleTime = ScheduleTime.of(LocalTime.of(13,0), LocalTime.of(13,5));
+        ScheduleUpdateCommand command = new ScheduleUpdateCommand(newTitle, newContent, newScheduleTime);
+
         given(scheduleRepository.findByIdWithTrip(anyLong())).willReturn(Optional.empty());
 
         // when & then

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/ScheduleUpdateControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/ScheduleUpdateControllerTest.java
@@ -5,6 +5,7 @@ import com.cosain.trilo.trip.application.schedule.command.usecase.ScheduleUpdate
 import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleUpdateCommand;
 import com.cosain.trilo.trip.application.schedule.command.usecase.dto.factory.ScheduleUpdateCommandFactory;
 import com.cosain.trilo.trip.domain.vo.ScheduleContent;
+import com.cosain.trilo.trip.domain.vo.ScheduleTime;
 import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
 import com.cosain.trilo.trip.presentation.schedule.command.ScheduleUpdateController;
 import com.cosain.trilo.trip.presentation.schedule.command.dto.request.ScheduleUpdateRequest;
@@ -17,6 +18,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithAnonymousUser;
 
 import java.nio.charset.StandardCharsets;
+import java.time.LocalTime;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
@@ -48,10 +50,13 @@ class ScheduleUpdateControllerTest extends RestControllerTest {
         Long scheduleId = 1L;
         String rawTitle = "수정할 제목";
         String rawContent = "수정할 내용";
-        ScheduleUpdateRequest request = new ScheduleUpdateRequest(rawTitle, rawContent);
-        ScheduleUpdateCommand command = new ScheduleUpdateCommand(ScheduleTitle.of(rawContent), ScheduleContent.of(rawContent));
+        LocalTime startTime = LocalTime.of(13,0);
+        LocalTime endTime = LocalTime.of(13,5);
 
-        given(scheduleUpdateCommandFactory.createCommand(eq(rawTitle),eq(rawContent))).willReturn(command);
+        ScheduleUpdateRequest request = new ScheduleUpdateRequest(rawTitle, rawContent, startTime, endTime);
+        ScheduleUpdateCommand command = new ScheduleUpdateCommand(ScheduleTitle.of(rawContent), ScheduleContent.of(rawContent), ScheduleTime.of(startTime, endTime));
+
+        given(scheduleUpdateCommandFactory.createCommand(eq(rawTitle),eq(rawContent), eq(startTime), eq(endTime))).willReturn(command);
         given(scheduleUpdateUseCase.updateSchedule(eq(scheduleId),any(),any(ScheduleUpdateCommand.class))).willReturn(1L);
 
         // when & then
@@ -64,7 +69,7 @@ class ScheduleUpdateControllerTest extends RestControllerTest {
                 .andExpect(jsonPath("$.scheduleId").value(1L))
                 .andDo(print());
 
-        verify(scheduleUpdateCommandFactory).createCommand(eq(rawTitle), eq(rawContent));
+        verify(scheduleUpdateCommandFactory).createCommand(eq(rawTitle), eq(rawContent), eq(startTime), eq(endTime));
         verify(scheduleUpdateUseCase).updateSchedule(eq(scheduleId),any(),any(ScheduleUpdateCommand.class));
     }
 
@@ -72,7 +77,19 @@ class ScheduleUpdateControllerTest extends RestControllerTest {
     @DisplayName("미인증 사용자 요청 -> 인증 실패 401")
     @WithAnonymousUser
     public void updateSchedule_with_unauthorizedUser() throws Exception {
-        mockMvc.perform(put("/api/schedules/1"))
+        Long scheduleId = 1L;
+        String rawTitle = "수정할 제목";
+        String rawContent = "수정할 내용";
+        LocalTime startTime = LocalTime.of(13,0);
+        LocalTime endTime = LocalTime.of(13,5);
+
+        ScheduleUpdateRequest request = new ScheduleUpdateRequest(rawTitle, rawContent, startTime, endTime);
+
+        mockMvc.perform(put("/api/schedules/"+scheduleId)
+                        .content(createJson(request))
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorCode").exists())
@@ -108,7 +125,9 @@ class ScheduleUpdateControllerTest extends RestControllerTest {
         String invalidContent = """
                 {
                     "title": 따옴표로 감싸지 않은 제목,
-                    "content": "본문"
+                    "content": "본문",
+                    "startTime": "13:05",
+                    "endTime": "13:07"
                 }
                 """;
 

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/docs/ScheduleUpdateControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/docs/ScheduleUpdateControllerDocsTest.java
@@ -5,6 +5,7 @@ import com.cosain.trilo.trip.application.schedule.command.usecase.ScheduleUpdate
 import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleUpdateCommand;
 import com.cosain.trilo.trip.application.schedule.command.usecase.dto.factory.ScheduleUpdateCommandFactory;
 import com.cosain.trilo.trip.domain.vo.ScheduleContent;
+import com.cosain.trilo.trip.domain.vo.ScheduleTime;
 import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
 import com.cosain.trilo.trip.presentation.schedule.command.ScheduleUpdateController;
 import com.cosain.trilo.trip.presentation.schedule.command.dto.request.ScheduleUpdateRequest;
@@ -16,6 +17,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
 import java.nio.charset.StandardCharsets;
+import java.time.LocalTime;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -58,10 +60,13 @@ public class ScheduleUpdateControllerDocsTest extends RestDocsTestSupport {
         Long scheduleId = 1L;
         String rawTitle = "수정 일정제목";
         String rawContent = "수정 일정내용";
-        ScheduleUpdateRequest request = new ScheduleUpdateRequest(rawTitle, rawContent);
-        ScheduleUpdateCommand command = new ScheduleUpdateCommand(ScheduleTitle.of(rawContent), ScheduleContent.of(rawContent));
+        LocalTime startTime = LocalTime.of(13,0);
+        LocalTime endTime = LocalTime.of(13,5);
 
-        given(scheduleUpdateCommandFactory.createCommand(eq(rawTitle), eq(rawContent))).willReturn(command);
+        ScheduleUpdateRequest request = new ScheduleUpdateRequest(rawTitle, rawContent, startTime, endTime);
+        ScheduleUpdateCommand command = new ScheduleUpdateCommand(ScheduleTitle.of(rawContent), ScheduleContent.of(rawContent), ScheduleTime.of(startTime, endTime));
+
+        given(scheduleUpdateCommandFactory.createCommand(eq(rawTitle), eq(rawContent), eq(startTime), eq(endTime))).willReturn(command);
         given(scheduleUpdateUseCase.updateSchedule(eq(scheduleId), any(), any(ScheduleUpdateCommand.class))).willReturn(1L);
 
         // when & then
@@ -90,7 +95,15 @@ public class ScheduleUpdateControllerDocsTest extends RestDocsTestSupport {
                                 fieldWithPath("content")
                                         .type(STRING)
                                         .optional()
-                                        .description("일정의 본문")
+                                        .description("일정의 본문"),
+                                fieldWithPath("startTime")
+                                        .type(STRING)
+                                        .optional()
+                                        .description("일정의 시작시간. null 허용"),
+                                fieldWithPath("endTime")
+                                        .type(STRING)
+                                        .optional()
+                                        .description("일정의 종료시간. null 허용")
                         ),
                         responseFields(
                                 fieldWithPath("scheduleId")
@@ -100,7 +113,7 @@ public class ScheduleUpdateControllerDocsTest extends RestDocsTestSupport {
                         )
                 ));
 
-        verify(scheduleUpdateCommandFactory).createCommand(eq(rawTitle), eq(rawContent));
+        verify(scheduleUpdateCommandFactory).createCommand(eq(rawTitle), eq(rawContent), eq(startTime), eq(endTime));
         verify(scheduleUpdateUseCase).updateSchedule(eq(scheduleId), any(), any(ScheduleUpdateCommand.class));
     }
 }


### PR DESCRIPTION
# JIRA 티켓
- [TRL-305]

---

# 작업 내역
- [x] 일정 시간 값 타입 정의
- [x] 일정 수정 시, 일정 시간 변경이 가능하도록 기능 추가
- [x] 일정 수정 API 문서에 해당 사항 반영

[TRL-305]: https://cosain.atlassian.net/browse/TRL-305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ