### PR TITLE
[TRL-302] feat: OAuth2 로그인 기능 구현 - NAVER

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -15,24 +15,21 @@
 
 ==== 기본 정보
 - 메서드 : GET
-- URL : `/api/auth/login/{provider}?redirect_uri={redirectUri}&code={Authorization_Code}`
+- URL : `/api/auth/login/kakao`
 
 ==== 요청
-===== 경로 변수
-include::{snippets}/auth-rest-controller-docs-test/로그인_요청/path-parameters.adoc[]
-===== 쿼리 변수
-include::{snippets}/auth-rest-controller-docs-test/로그인_요청/query-parameters.adoc[]
+===== 본문
+include::{snippets}/auth-rest-controller-docs-test/카카오_로그인_요청/request-fields.adoc[]
 ==== 응답
 ===== 헤더
-include::{snippets}/auth-rest-controller-docs-test/로그인_요청/response-headers.adoc[]
+include::{snippets}/auth-rest-controller-docs-test/카카오_로그인_요청/response-headers.adoc[]
 ===== 본문
-include::{snippets}/auth-rest-controller-docs-test/로그인_요청/response-fields.adoc[]
-
+include::{snippets}/auth-rest-controller-docs-test/카카오_로그인_요청/response-fields.adoc[]
 ==== 예제
 ===== 요청
-include::{snippets}/auth-rest-controller-docs-test/로그인_요청/http-request.adoc[]
+include::{snippets}/auth-rest-controller-docs-test/카카오_로그인_요청/http-request.adoc[]
 ===== 응답
-include::{snippets}/auth-rest-controller-docs-test/로그인_요청/http-response.adoc[]
+include::{snippets}/auth-rest-controller-docs-test/카카오_로그인_요청/http-response.adoc[]
 
 '''
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -35,6 +35,11 @@ include::{snippets}/auth-rest-controller-docs-test/카카오_로그인_요청/ht
 
 === 네이버 OAuth2 로그인
 
+==== 기본 정보
+
+- 메서드 : GET
+- URL : `/api/auth/login/naver`
+
 ==== 요청
 ===== 본문
 include::{snippets}/auth-rest-controller-docs-test/네이버_로그인_요청/request-fields.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -11,7 +11,7 @@
 
 == Auth API
 
-=== OAuth2 로그인
+=== 카카오 OAuth2 로그인
 
 ==== 기본 정보
 - 메서드 : GET
@@ -32,6 +32,21 @@ include::{snippets}/auth-rest-controller-docs-test/카카오_로그인_요청/ht
 include::{snippets}/auth-rest-controller-docs-test/카카오_로그인_요청/http-response.adoc[]
 
 '''
+
+=== 네이버 OAuth2 로그인
+
+==== 요청
+===== 본문
+include::{snippets}/auth-rest-controller-docs-test/네이버_로그인_요청/request-fields.adoc[]
+==== 응답
+include::{snippets}/auth-rest-controller-docs-test/네이버_로그인_요청/response-fields.adoc[]
+==== 예제
+===== 요청
+include::{snippets}/auth-rest-controller-docs-test/네이버_로그인_요청/http-request.adoc[]
+===== 응답
+include::{snippets}/auth-rest-controller-docs-test/네이버_로그인_요청/http-response.adoc[]
+
+---
 
 === 로그아웃
 

--- a/src/main/java/com/cosain/trilo/auth/application/AuthService.java
+++ b/src/main/java/com/cosain/trilo/auth/application/AuthService.java
@@ -5,7 +5,6 @@ import com.cosain.trilo.auth.application.dto.OAuthLoginParams;
 import com.cosain.trilo.auth.domain.LogoutAccessToken;
 import com.cosain.trilo.auth.domain.RefreshToken;
 import com.cosain.trilo.auth.domain.repository.TokenRepository;
-import com.cosain.trilo.auth.infra.OAuthClient;
 import com.cosain.trilo.auth.infra.OAuthProfileDto;
 import com.cosain.trilo.auth.infra.TokenAnalyzer;
 import com.cosain.trilo.auth.infra.TokenProvider;
@@ -29,7 +28,7 @@ public class AuthService {
     private final TokenRepository tokenRepository;
     private final TokenProvider tokenProvider;
     private final TokenAnalyzer tokenAnalyzer;
-    private final OAuthClient oAuthClient;
+    private final OAuthProfileRequestService OAuthProfileRequestService;
     private final UserRepository userRepository;
 
     @Transactional
@@ -100,8 +99,7 @@ public class AuthService {
     }
 
     private OAuthProfileDto getUserProfileResponse(OAuthLoginParams oAuthLoginParams) {
-        String accessToken = oAuthClient.getAccessToken(oAuthLoginParams);
-        return oAuthClient.getProfile(accessToken);
+        return OAuthProfileRequestService.request(oAuthLoginParams);
     }
 
     private User addOrUpdateUser(OAuthProfileDto oAuthProfileDto){

--- a/src/main/java/com/cosain/trilo/auth/application/AuthService.java
+++ b/src/main/java/com/cosain/trilo/auth/application/AuthService.java
@@ -1,6 +1,7 @@
 package com.cosain.trilo.auth.application;
 
 import com.cosain.trilo.auth.application.dto.LoginResult;
+import com.cosain.trilo.auth.application.dto.OAuthLoginParams;
 import com.cosain.trilo.auth.domain.LogoutAccessToken;
 import com.cosain.trilo.auth.domain.RefreshToken;
 import com.cosain.trilo.auth.domain.repository.TokenRepository;
@@ -84,9 +85,9 @@ public class AuthService {
     }
 
     @Transactional
-    public LoginResult login(String code, String provider, String redirectUri){
+    public LoginResult login(OAuthLoginParams oAuthLoginParams){
 
-        OAuthProfileDto oAuthProfileDto = getUserProfileResponse(code, redirectUri);
+        OAuthProfileDto oAuthProfileDto = getUserProfileResponse(oAuthLoginParams);
         User user = addOrUpdateUser(oAuthProfileDto);
 
         String accessToken = tokenProvider.createAccessToken(user.getEmail());
@@ -98,8 +99,8 @@ public class AuthService {
         return LoginResult.of(accessToken, refreshToken);
     }
 
-    private OAuthProfileDto getUserProfileResponse(String code, String redirectUri) {
-        String accessToken = oAuthClient.getAccessToken(code, redirectUri);
+    private OAuthProfileDto getUserProfileResponse(OAuthLoginParams oAuthLoginParams) {
+        String accessToken = oAuthClient.getAccessToken(oAuthLoginParams);
         return oAuthClient.getProfile(accessToken);
     }
 

--- a/src/main/java/com/cosain/trilo/auth/application/OAuthProfileRequestService.java
+++ b/src/main/java/com/cosain/trilo/auth/application/OAuthProfileRequestService.java
@@ -1,0 +1,29 @@
+package com.cosain.trilo.auth.application;
+
+import com.cosain.trilo.auth.application.dto.OAuthLoginParams;
+import com.cosain.trilo.auth.infra.OAuthClient;
+import com.cosain.trilo.auth.infra.OAuthProfileDto;
+import com.cosain.trilo.user.domain.AuthProvider;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+public class OAuthProfileRequestService {
+    private final Map<AuthProvider, OAuthClient> clients;
+
+    public OAuthProfileRequestService(List<OAuthClient> clients) {
+        this.clients = clients.stream().collect(
+                Collectors.toUnmodifiableMap(OAuthClient::authProvider, Function.identity())
+        );
+    }
+
+    public OAuthProfileDto request(OAuthLoginParams params){
+        OAuthClient client = clients.get(params.authProvider());
+        String accessToken = client.getAccessToken(params);
+        return client.getProfile(accessToken);
+    }
+}

--- a/src/main/java/com/cosain/trilo/auth/application/dto/KakaoLoginParams.java
+++ b/src/main/java/com/cosain/trilo/auth/application/dto/KakaoLoginParams.java
@@ -1,0 +1,27 @@
+package com.cosain.trilo.auth.application.dto;
+
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+public class KakaoLoginParams implements OAuthLoginParams{
+
+    private String code;
+    private String redirectUrl;
+
+    public KakaoLoginParams(String code, String redirectUrl) {
+        this.code = code;
+        this.redirectUrl = redirectUrl;
+    }
+
+    public static KakaoLoginParams of(String code, String redirectUrl){
+        return new KakaoLoginParams(code, redirectUrl);
+    }
+
+    @Override
+    public MultiValueMap<String, String> getParams() {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("code", code);
+        params.add("redirect_uri", redirectUrl);
+        return params;
+    }
+}

--- a/src/main/java/com/cosain/trilo/auth/application/dto/KakaoLoginParams.java
+++ b/src/main/java/com/cosain/trilo/auth/application/dto/KakaoLoginParams.java
@@ -8,12 +8,15 @@ public class KakaoLoginParams implements OAuthLoginParams{
 
     private String code;
 
-    public KakaoLoginParams(String code) {
+    private String redirectUri;
+
+    private KakaoLoginParams(String code, String redirectUri) {
         this.code = code;
+        this.redirectUri = redirectUri;
     }
 
-    public static KakaoLoginParams of(String code){
-        return new KakaoLoginParams(code);
+    public static KakaoLoginParams of(String code, String redirectUri){
+        return new KakaoLoginParams(code, redirectUri);
     }
 
     @Override
@@ -25,6 +28,7 @@ public class KakaoLoginParams implements OAuthLoginParams{
     public MultiValueMap<String, String> getParams() {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("code", code);
+        params.add("redirect_uri", redirectUri);
         return params;
     }
 }

--- a/src/main/java/com/cosain/trilo/auth/application/dto/KakaoLoginParams.java
+++ b/src/main/java/com/cosain/trilo/auth/application/dto/KakaoLoginParams.java
@@ -6,22 +6,19 @@ import org.springframework.util.MultiValueMap;
 public class KakaoLoginParams implements OAuthLoginParams{
 
     private String code;
-    private String redirectUrl;
 
-    public KakaoLoginParams(String code, String redirectUrl) {
+    public KakaoLoginParams(String code) {
         this.code = code;
-        this.redirectUrl = redirectUrl;
     }
 
-    public static KakaoLoginParams of(String code, String redirectUrl){
-        return new KakaoLoginParams(code, redirectUrl);
+    public static KakaoLoginParams of(String code){
+        return new KakaoLoginParams(code);
     }
 
     @Override
     public MultiValueMap<String, String> getParams() {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("code", code);
-        params.add("redirect_uri", redirectUrl);
         return params;
     }
 }

--- a/src/main/java/com/cosain/trilo/auth/application/dto/NaverLoginParams.java
+++ b/src/main/java/com/cosain/trilo/auth/application/dto/NaverLoginParams.java
@@ -4,27 +4,31 @@ import com.cosain.trilo.user.domain.AuthProvider;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-public class KakaoLoginParams implements OAuthLoginParams{
+public class NaverLoginParams implements OAuthLoginParams{
 
     private String code;
+    private String state;
 
-    public KakaoLoginParams(String code) {
+    public NaverLoginParams(String code, String state) {
         this.code = code;
+        this.state = state;
     }
 
-    public static KakaoLoginParams of(String code){
-        return new KakaoLoginParams(code);
+    public static NaverLoginParams of(String code, String state){
+        return new NaverLoginParams(code, state);
     }
 
     @Override
     public AuthProvider authProvider() {
-        return AuthProvider.KAKAO;
+        return AuthProvider.NAVER;
     }
 
     @Override
     public MultiValueMap<String, String> getParams() {
+
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("code", code);
+        params.add("state", state);
         return params;
     }
 }

--- a/src/main/java/com/cosain/trilo/auth/application/dto/OAuthLoginParams.java
+++ b/src/main/java/com/cosain/trilo/auth/application/dto/OAuthLoginParams.java
@@ -1,0 +1,7 @@
+package com.cosain.trilo.auth.application.dto;
+
+import org.springframework.util.MultiValueMap;
+
+public interface OAuthLoginParams {
+    MultiValueMap<String, String> getParams();
+}

--- a/src/main/java/com/cosain/trilo/auth/application/dto/OAuthLoginParams.java
+++ b/src/main/java/com/cosain/trilo/auth/application/dto/OAuthLoginParams.java
@@ -1,7 +1,9 @@
 package com.cosain.trilo.auth.application.dto;
 
+import com.cosain.trilo.user.domain.AuthProvider;
 import org.springframework.util.MultiValueMap;
 
 public interface OAuthLoginParams {
+    AuthProvider authProvider();
     MultiValueMap<String, String> getParams();
 }

--- a/src/main/java/com/cosain/trilo/auth/infra/NaverClient.java
+++ b/src/main/java/com/cosain/trilo/auth/infra/NaverClient.java
@@ -1,0 +1,7 @@
+package com.cosain.trilo.auth.infra;
+
+public interface NaverClient {
+    String getAccessToken(String code, String state);
+
+    OAuthProfileDto getProfile(String accessToken);
+}

--- a/src/main/java/com/cosain/trilo/auth/infra/NaverClient.java
+++ b/src/main/java/com/cosain/trilo/auth/infra/NaverClient.java
@@ -1,7 +1,0 @@
-package com.cosain.trilo.auth.infra;
-
-public interface NaverClient {
-    String getAccessToken(String code, String state);
-
-    OAuthProfileDto getProfile(String accessToken);
-}

--- a/src/main/java/com/cosain/trilo/auth/infra/OAuthClient.java
+++ b/src/main/java/com/cosain/trilo/auth/infra/OAuthClient.java
@@ -2,8 +2,11 @@ package com.cosain.trilo.auth.infra;
 
 
 import com.cosain.trilo.auth.application.dto.OAuthLoginParams;
+import com.cosain.trilo.user.domain.AuthProvider;
 
 public interface OAuthClient {
+
+    AuthProvider authProvider();
     String getAccessToken(OAuthLoginParams oAuthLoginParams);
     OAuthProfileDto getProfile(String accessToken);
 }

--- a/src/main/java/com/cosain/trilo/auth/infra/OAuthClient.java
+++ b/src/main/java/com/cosain/trilo/auth/infra/OAuthClient.java
@@ -1,7 +1,9 @@
 package com.cosain.trilo.auth.infra;
 
 
+import com.cosain.trilo.auth.application.dto.OAuthLoginParams;
+
 public interface OAuthClient {
-    String getAccessToken(String code, String redirectUri);
+    String getAccessToken(OAuthLoginParams oAuthLoginParams);
     OAuthProfileDto getProfile(String accessToken);
 }

--- a/src/main/java/com/cosain/trilo/auth/infra/OAuthProfileDto.java
+++ b/src/main/java/com/cosain/trilo/auth/infra/OAuthProfileDto.java
@@ -1,6 +1,7 @@
 package com.cosain.trilo.auth.infra;
 
 import com.cosain.trilo.auth.infra.oauth.kakao.dto.KakaoProfileResponse;
+import com.cosain.trilo.auth.infra.oauth.naver.dto.NaverInfoResponse;
 import com.cosain.trilo.user.domain.AuthProvider;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -28,6 +29,15 @@ public class OAuthProfileDto {
                 .email(kakaoProfileResponse.getKakaoAccount().getEmail())
                 .profileImageUrl(kakaoProfileResponse.getKakaoAccount().getProfile().getProfileImageUrl())
                 .provider(AuthProvider.KAKAO)
+                .build();
+    }
+
+    public static OAuthProfileDto of(NaverInfoResponse naverInfoResponse){
+        return OAuthProfileDto.builder()
+                .name(naverInfoResponse.getName())
+                .email(naverInfoResponse.getEmail())
+                .profileImageUrl(naverInfoResponse.getImageUrl())
+                .provider(AuthProvider.NAVER)
                 .build();
     }
 }

--- a/src/main/java/com/cosain/trilo/auth/infra/oauth/kakao/KakaoClient.java
+++ b/src/main/java/com/cosain/trilo/auth/infra/oauth/kakao/KakaoClient.java
@@ -1,5 +1,6 @@
 package com.cosain.trilo.auth.infra.oauth.kakao;
 
+import com.cosain.trilo.auth.application.dto.OAuthLoginParams;
 import com.cosain.trilo.auth.infra.OAuthClient;
 import com.cosain.trilo.auth.infra.OAuthProfileDto;
 import com.cosain.trilo.auth.infra.oauth.kakao.dto.KakaoTokenResponse;
@@ -35,21 +36,18 @@ public class KakaoClient implements OAuthClient {
     }
 
     @Override
-    public String getAccessToken(String code, String redirectUri) {
+    public String getAccessToken(OAuthLoginParams oAuthLoginParams) {
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        MultiValueMap<String, String> params = oAuthLoginParams.getParams();
         params.add("grant_type", "authorization_code");
         params.add("client_id", clientId);
-        params.add("redirect_uri", redirectUri);
-        params.add("code", code);
 
-        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+        HttpEntity<?> request = new HttpEntity<>(params, headers);
 
-        ResponseEntity<KakaoTokenResponse> kakaoTokenResponseResponseEntity = restTemplate.postForEntity(accessTokenUrl, request, KakaoTokenResponse.class);
-        KakaoTokenResponse kakaoTokenResponse = kakaoTokenResponseResponseEntity.getBody();
+        KakaoTokenResponse kakaoTokenResponse = restTemplate.postForObject(accessTokenUrl, request, KakaoTokenResponse.class);
         return kakaoTokenResponse.getAccessToken();
     }
 
@@ -62,11 +60,9 @@ public class KakaoClient implements OAuthClient {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("property_keys", "[\"kakao_account.profile\",\"kakao_account.nickname\",\"kakao_account.email\"]");
 
-        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+        HttpEntity<?> request = new HttpEntity<>(params, headers);
 
-        ResponseEntity<KakaoProfileResponse> profileResponseResponseEntity = restTemplate.postForEntity(profileUrl, request, KakaoProfileResponse.class);
-        KakaoProfileResponse kakaoProfileResponse = profileResponseResponseEntity.getBody();
-
+        KakaoProfileResponse kakaoProfileResponse = restTemplate.postForObject(profileUrl, request, KakaoProfileResponse.class);
         return OAuthProfileDto.of(kakaoProfileResponse);
     }
 }

--- a/src/main/java/com/cosain/trilo/auth/infra/oauth/kakao/KakaoClient.java
+++ b/src/main/java/com/cosain/trilo/auth/infra/oauth/kakao/KakaoClient.java
@@ -3,36 +3,34 @@ package com.cosain.trilo.auth.infra.oauth.kakao;
 import com.cosain.trilo.auth.application.dto.OAuthLoginParams;
 import com.cosain.trilo.auth.infra.OAuthClient;
 import com.cosain.trilo.auth.infra.OAuthProfileDto;
-import com.cosain.trilo.auth.infra.oauth.kakao.dto.KakaoTokenResponse;
 import com.cosain.trilo.auth.infra.oauth.kakao.dto.KakaoProfileResponse;
+import com.cosain.trilo.auth.infra.oauth.kakao.dto.KakaoTokenResponse;
+import com.cosain.trilo.user.domain.AuthProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 @Component
+@RequiredArgsConstructor
 public class KakaoClient implements OAuthClient {
 
-    private final String clientId;
-    private final String accessTokenUrl;
+    @Value("${oauth2.kakao.client-id}")
+    private String clientId;
+    @Value("${oauth2.kakao.token-uri}")
+    private String accessTokenUrl;
+    @Value("${oauth2.kakao.user-info-uri}")
+    private String profileUrl;
+
     private final RestTemplate restTemplate;
-    private final String profileUrl;
-    public KakaoClient(
-            @Value("${oauth2.kakao.client-id}") String clientId,
-            @Value("${oauth2.kakao.token-uri}") String accessTokenUrl,
-            @Value("${oauth2.kakao.user-info-uri}") String profileUrl,
-            RestTemplateBuilder restTemplateBuilder
-    ){
-        this.clientId = clientId;
-        this.accessTokenUrl = accessTokenUrl;
-        this.profileUrl = profileUrl;
-        this.restTemplate = restTemplateBuilder.build();
+    @Override
+    public AuthProvider authProvider() {
+        return AuthProvider.KAKAO;
     }
 
     @Override

--- a/src/main/java/com/cosain/trilo/auth/infra/oauth/naver/NaverClient.java
+++ b/src/main/java/com/cosain/trilo/auth/infra/oauth/naver/NaverClient.java
@@ -25,7 +25,7 @@ public class NaverClient implements OAuthClient {
     @Value("${oauth2.naver.client-id}")
     private String clientId;
     @Value("${oauth2.naver.client-secret}")
-    private String clinetSecret;
+    private String clientSecret;
     @Value("${oauth2.naver.token_uri}")
     private String accessTokenUrl;
     @Value("${oauth2.naver.user-info-uri}")
@@ -46,10 +46,12 @@ public class NaverClient implements OAuthClient {
         MultiValueMap<String, String> params = oAuthLoginParams.getParams();
         params.add("grant_type",grantType);
         params.add("client_id", clientId);
-        params.add("client_secret", clinetSecret);
+        params.add("client_secret", clientSecret);
 
         HttpEntity<?> request = makeAccessTokenRequest(headers, params);
 
+        System.out.println("dd");
+        log.info("dd");
         NaverTokenResponse naverTokenResponse = restTemplate.postForObject(accessTokenUrl, request, NaverTokenResponse.class);
 
         return naverTokenResponse.getAccessToken();

--- a/src/main/java/com/cosain/trilo/auth/infra/oauth/naver/NaverClient.java
+++ b/src/main/java/com/cosain/trilo/auth/infra/oauth/naver/NaverClient.java
@@ -50,8 +50,6 @@ public class NaverClient implements OAuthClient {
 
         HttpEntity<?> request = makeAccessTokenRequest(headers, params);
 
-        System.out.println("dd");
-        log.info("dd");
         NaverTokenResponse naverTokenResponse = restTemplate.postForObject(accessTokenUrl, request, NaverTokenResponse.class);
 
         return naverTokenResponse.getAccessToken();

--- a/src/main/java/com/cosain/trilo/auth/infra/oauth/naver/NaverClient.java
+++ b/src/main/java/com/cosain/trilo/auth/infra/oauth/naver/NaverClient.java
@@ -1,12 +1,14 @@
 package com.cosain.trilo.auth.infra.oauth.naver;
 
-import com.cosain.trilo.auth.infra.NaverClient;
+import com.cosain.trilo.auth.application.dto.OAuthLoginParams;
+import com.cosain.trilo.auth.infra.OAuthClient;
 import com.cosain.trilo.auth.infra.OAuthProfileDto;
 import com.cosain.trilo.auth.infra.oauth.naver.dto.NaverInfoResponse;
 import com.cosain.trilo.auth.infra.oauth.naver.dto.NaverTokenResponse;
+import com.cosain.trilo.user.domain.AuthProvider;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -17,37 +19,37 @@ import org.springframework.web.client.RestTemplate;
 
 @Slf4j
 @Component
-public class NaverClientImpl implements NaverClient {
-    private final String clientId;
-    private final String clinetSecret;
-    private final String accessTokenUrl;
-    private final String profileUrl;
-    private final RestTemplate restTemplate;
-    private final String grantType;
+@RequiredArgsConstructor
+public class NaverClient implements OAuthClient {
 
-    public NaverClientImpl(
-            @Value("${oauth2.naver.client-id}") String clientId,
-            @Value("${oauth2.naver.client-secret}") String clinetSecret,
-            @Value("${oauth2.naver.token_uri}") String accessTokenUrl,
-            @Value("${oauth2.naver.user-info-uri}") String profileUrl,
-            @Value("${oauth2.naver.grant_type}") String grantType,
-            RestTemplateBuilder restTemplateBuilder
-    ) {
-        this.clientId = clientId;
-        this.clinetSecret = clinetSecret;
-        this.accessTokenUrl = accessTokenUrl;
-        this.profileUrl = profileUrl;
-        this.grantType = grantType;
-        this.restTemplate = restTemplateBuilder.build();
+    @Value("${oauth2.naver.client-id}")
+    private String clientId;
+    @Value("${oauth2.naver.client-secret}")
+    private String clinetSecret;
+    @Value("${oauth2.naver.token_uri}")
+    private String accessTokenUrl;
+    @Value("${oauth2.naver.user-info-uri}")
+    private String profileUrl;
+    @Value("${oauth2.naver.grant_type}")
+    private String grantType;
+    private final RestTemplate restTemplate;
+
+    @Override
+    public AuthProvider authProvider() {
+        return AuthProvider.NAVER;
     }
 
     @Override
-    public String getAccessToken(String code, String state) {
+    public String getAccessToken(OAuthLoginParams oAuthLoginParams) {
 
         HttpHeaders headers = makeAccessTokenRequestHeader();
-        MultiValueMap<String, String> params = makeAccessTokenRequestParams(code, state);
+        MultiValueMap<String, String> params = oAuthLoginParams.getParams();
+        params.add("grant_type",grantType);
+        params.add("client_id", clientId);
+        params.add("client_secret", clinetSecret);
 
         HttpEntity<?> request = makeAccessTokenRequest(headers, params);
+
         NaverTokenResponse naverTokenResponse = restTemplate.postForObject(accessTokenUrl, request, NaverTokenResponse.class);
 
         return naverTokenResponse.getAccessToken();
@@ -55,18 +57,6 @@ public class NaverClientImpl implements NaverClient {
 
     private HttpEntity<MultiValueMap<String, String>> makeAccessTokenRequest(HttpHeaders headers, MultiValueMap<String, String> params) {
         return new HttpEntity<>(params, headers);
-    }
-
-    private MultiValueMap<String, String> makeAccessTokenRequestParams(String code, String state) {
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-
-        params.add("grant_type",grantType);
-        params.add("client_id", clientId);
-        params.add("client_secret", clinetSecret);
-        params.add("code", code);
-        params.add("state", state);
-
-        return params;
     }
 
     private HttpHeaders makeAccessTokenRequestHeader() {

--- a/src/main/java/com/cosain/trilo/auth/infra/oauth/naver/NaverClientImpl.java
+++ b/src/main/java/com/cosain/trilo/auth/infra/oauth/naver/NaverClientImpl.java
@@ -1,0 +1,95 @@
+package com.cosain.trilo.auth.infra.oauth.naver;
+
+import com.cosain.trilo.auth.infra.NaverClient;
+import com.cosain.trilo.auth.infra.OAuthProfileDto;
+import com.cosain.trilo.auth.infra.oauth.naver.dto.NaverInfoResponse;
+import com.cosain.trilo.auth.infra.oauth.naver.dto.NaverTokenResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Component
+public class NaverClientImpl implements NaverClient {
+    private final String clientId;
+    private final String clinetSecret;
+    private final String accessTokenUrl;
+    private final String profileUrl;
+    private final RestTemplate restTemplate;
+    private final String grantType;
+
+    public NaverClientImpl(
+            @Value("${oauth2.naver.client-id}") String clientId,
+            @Value("${oauth2.naver.client-secret}") String clinetSecret,
+            @Value("${oauth2.naver.token_uri}") String accessTokenUrl,
+            @Value("${oauth2.naver.user-info-uri}") String profileUrl,
+            @Value("${oauth2.naver.grant_type}") String grantType,
+            RestTemplateBuilder restTemplateBuilder
+    ) {
+        this.clientId = clientId;
+        this.clinetSecret = clinetSecret;
+        this.accessTokenUrl = accessTokenUrl;
+        this.profileUrl = profileUrl;
+        this.grantType = grantType;
+        this.restTemplate = restTemplateBuilder.build();
+    }
+
+    @Override
+    public String getAccessToken(String code, String state) {
+
+        HttpHeaders headers = makeAccessTokenRequestHeader();
+        MultiValueMap<String, String> params = makeAccessTokenRequestParams(code, state);
+
+        HttpEntity<?> request = makeAccessTokenRequest(headers, params);
+        NaverTokenResponse naverTokenResponse = restTemplate.postForObject(accessTokenUrl, request, NaverTokenResponse.class);
+
+        return naverTokenResponse.getAccessToken();
+    }
+
+    private HttpEntity<MultiValueMap<String, String>> makeAccessTokenRequest(HttpHeaders headers, MultiValueMap<String, String> params) {
+        return new HttpEntity<>(params, headers);
+    }
+
+    private MultiValueMap<String, String> makeAccessTokenRequestParams(String code, String state) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+
+        params.add("grant_type",grantType);
+        params.add("client_id", clientId);
+        params.add("client_secret", clinetSecret);
+        params.add("code", code);
+        params.add("state", state);
+
+        return params;
+    }
+
+    private HttpHeaders makeAccessTokenRequestHeader() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        return headers;
+    }
+
+    @Override
+    public OAuthProfileDto getProfile(String accessToken) {
+
+        HttpHeaders headers = makeUserInfoRequest(accessToken);
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+
+        HttpEntity<?> request = new HttpEntity<>(params, headers);
+        NaverInfoResponse naverInfoResponse = restTemplate.postForObject(profileUrl, request, NaverInfoResponse.class);
+        return OAuthProfileDto.of(naverInfoResponse);
+    }
+
+    private HttpHeaders makeUserInfoRequest(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.set(HttpHeaders.AUTHORIZATION, "Bearer "+accessToken);
+        return headers;
+    }
+}

--- a/src/main/java/com/cosain/trilo/auth/infra/oauth/naver/dto/NaverInfoResponse.java
+++ b/src/main/java/com/cosain/trilo/auth/infra/oauth/naver/dto/NaverInfoResponse.java
@@ -1,0 +1,33 @@
+package com.cosain.trilo.auth.infra.oauth.naver.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NaverInfoResponse {
+
+    @JsonProperty("response")
+    private Response response;
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class Response {
+        private String email;
+        private String name;
+        private String profile_image;
+    }
+
+    public String getEmail(){
+        return response.getEmail();
+    }
+
+    public String getName(){
+        return response.getName();
+    }
+
+    public String getImageUrl(){
+        return response.getProfile_image();
+    }
+}

--- a/src/main/java/com/cosain/trilo/auth/infra/oauth/naver/dto/NaverTokenResponse.java
+++ b/src/main/java/com/cosain/trilo/auth/infra/oauth/naver/dto/NaverTokenResponse.java
@@ -1,0 +1,32 @@
+package com.cosain.trilo.auth.infra.oauth.naver.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class NaverTokenResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("expires_in")
+    private Integer expiry;
+
+    @JsonProperty("error")
+    private String error;
+
+    @JsonProperty("error_description")
+    private String errorDescription;
+}

--- a/src/main/java/com/cosain/trilo/auth/presentation/AuthRestController.java
+++ b/src/main/java/com/cosain/trilo/auth/presentation/AuthRestController.java
@@ -42,7 +42,7 @@ public class AuthRestController {
     @PostMapping("/login/kakao")
     @ResponseStatus(HttpStatus.OK)
     public AuthResponse login(@Validated @RequestBody KakaoOAuthLoginRequest kakaoOAuthLoginRequest, HttpServletResponse response){
-        LoginResult loginResult = authService.login(KakaoLoginParams.of(kakaoOAuthLoginRequest.getCode(), kakaoOAuthLoginRequest.getRedirect_uri()));
+        LoginResult loginResult = authService.login(KakaoLoginParams.of(kakaoOAuthLoginRequest.getCode()));
         Cookie cookie = new Cookie("refreshToken", loginResult.getRefreshToken());
         cookie.setMaxAge(3600);
         cookie.setPath("/");

--- a/src/main/java/com/cosain/trilo/auth/presentation/AuthRestController.java
+++ b/src/main/java/com/cosain/trilo/auth/presentation/AuthRestController.java
@@ -3,8 +3,10 @@ package com.cosain.trilo.auth.presentation;
 import com.cosain.trilo.auth.application.AuthService;
 import com.cosain.trilo.auth.application.dto.KakaoLoginParams;
 import com.cosain.trilo.auth.application.dto.LoginResult;
+import com.cosain.trilo.auth.application.dto.NaverLoginParams;
 import com.cosain.trilo.auth.presentation.dto.AuthResponse;
 import com.cosain.trilo.auth.presentation.dto.KakaoOAuthLoginRequest;
+import com.cosain.trilo.auth.presentation.dto.NaverOAuthLoginRequest;
 import com.cosain.trilo.auth.presentation.dto.RefreshTokenStatusResponse;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
@@ -43,10 +45,24 @@ public class AuthRestController {
     @ResponseStatus(HttpStatus.OK)
     public AuthResponse login(@Validated @RequestBody KakaoOAuthLoginRequest kakaoOAuthLoginRequest, HttpServletResponse response){
         LoginResult loginResult = authService.login(KakaoLoginParams.of(kakaoOAuthLoginRequest.getCode()));
-        Cookie cookie = new Cookie("refreshToken", loginResult.getRefreshToken());
-        cookie.setMaxAge(3600);
-        cookie.setPath("/");
+        Cookie cookie = makeRefreshTokenCookie(loginResult.getRefreshToken());
         response.addCookie(cookie);
         return AuthResponse.from(loginResult.getAccessToken());
+    }
+
+    @PostMapping("/login/naver")
+    @ResponseStatus(HttpStatus.OK)
+    public AuthResponse login(@Validated @RequestBody NaverOAuthLoginRequest naverOAuthLoginRequest, HttpServletResponse response){
+        LoginResult loginResult = authService.login(NaverLoginParams.of(naverOAuthLoginRequest.getCode(), naverOAuthLoginRequest.getState()));
+        Cookie cookie = makeRefreshTokenCookie(loginResult.getRefreshToken());
+        response.addCookie(cookie);
+        return AuthResponse.from(loginResult.getAccessToken());
+    }
+
+    private Cookie makeRefreshTokenCookie(String refreshTokenStr){
+        Cookie cookie = new Cookie("refreshToken", refreshTokenStr);
+        cookie.setMaxAge(3600);
+        cookie.setPath("/");
+        return cookie;
     }
 }

--- a/src/main/java/com/cosain/trilo/auth/presentation/AuthRestController.java
+++ b/src/main/java/com/cosain/trilo/auth/presentation/AuthRestController.java
@@ -1,9 +1,10 @@
 package com.cosain.trilo.auth.presentation;
 
 import com.cosain.trilo.auth.application.AuthService;
+import com.cosain.trilo.auth.application.dto.KakaoLoginParams;
 import com.cosain.trilo.auth.application.dto.LoginResult;
 import com.cosain.trilo.auth.presentation.dto.AuthResponse;
-import com.cosain.trilo.auth.presentation.dto.OauthLoginRequest;
+import com.cosain.trilo.auth.presentation.dto.KakaoOAuthLoginRequest;
 import com.cosain.trilo.auth.presentation.dto.RefreshTokenStatusResponse;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
@@ -38,10 +39,10 @@ public class AuthRestController {
         authService.logout(authHeaderValue, refreshToken);
     }
 
-    @GetMapping("/login/{provider}")
+    @PostMapping("/login/kakao")
     @ResponseStatus(HttpStatus.OK)
-    public AuthResponse login(@Validated @ModelAttribute OauthLoginRequest oauthLoginRequest, @PathVariable String provider, HttpServletResponse response){
-        LoginResult loginResult = authService.login(oauthLoginRequest.getCode(), provider, oauthLoginRequest.getRedirect_uri());
+    public AuthResponse login(@Validated @RequestBody KakaoOAuthLoginRequest kakaoOAuthLoginRequest, HttpServletResponse response){
+        LoginResult loginResult = authService.login(KakaoLoginParams.of(kakaoOAuthLoginRequest.getCode(), kakaoOAuthLoginRequest.getRedirect_uri()));
         Cookie cookie = new Cookie("refreshToken", loginResult.getRefreshToken());
         cookie.setMaxAge(3600);
         cookie.setPath("/");

--- a/src/main/java/com/cosain/trilo/auth/presentation/AuthRestController.java
+++ b/src/main/java/com/cosain/trilo/auth/presentation/AuthRestController.java
@@ -44,7 +44,7 @@ public class AuthRestController {
     @PostMapping("/login/kakao")
     @ResponseStatus(HttpStatus.OK)
     public AuthResponse login(@Validated @RequestBody KakaoOAuthLoginRequest kakaoOAuthLoginRequest, HttpServletResponse response){
-        LoginResult loginResult = authService.login(KakaoLoginParams.of(kakaoOAuthLoginRequest.getCode()));
+        LoginResult loginResult = authService.login(KakaoLoginParams.of(kakaoOAuthLoginRequest.getCode(), kakaoOAuthLoginRequest.getRedirect_uri()));
         Cookie cookie = makeRefreshTokenCookie(loginResult.getRefreshToken());
         response.addCookie(cookie);
         return AuthResponse.from(loginResult.getAccessToken());

--- a/src/main/java/com/cosain/trilo/auth/presentation/dto/KakaoOAuthLoginRequest.java
+++ b/src/main/java/com/cosain/trilo/auth/presentation/dto/KakaoOAuthLoginRequest.java
@@ -3,15 +3,14 @@ package com.cosain.trilo.auth.presentation.dto;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class KakaoOAuthLoginRequest {
 
     @NotEmpty
     private String code;
-
-    @NotEmpty
-    private String redirect_uri;
 
 }

--- a/src/main/java/com/cosain/trilo/auth/presentation/dto/KakaoOAuthLoginRequest.java
+++ b/src/main/java/com/cosain/trilo/auth/presentation/dto/KakaoOAuthLoginRequest.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class OauthLoginRequest {
+public class KakaoOAuthLoginRequest {
 
     @NotEmpty
     private String code;

--- a/src/main/java/com/cosain/trilo/auth/presentation/dto/KakaoOAuthLoginRequest.java
+++ b/src/main/java/com/cosain/trilo/auth/presentation/dto/KakaoOAuthLoginRequest.java
@@ -13,4 +13,7 @@ public class KakaoOAuthLoginRequest {
     @NotEmpty
     private String code;
 
+    @NotEmpty
+    private String redirect_uri;
+
 }

--- a/src/main/java/com/cosain/trilo/auth/presentation/dto/NaverOAuthLoginRequest.java
+++ b/src/main/java/com/cosain/trilo/auth/presentation/dto/NaverOAuthLoginRequest.java
@@ -1,0 +1,16 @@
+package com.cosain.trilo.auth.presentation.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NaverOAuthLoginRequest {
+    @NotEmpty
+    private String code;
+    @NotEmpty
+    private String state;
+}

--- a/src/main/java/com/cosain/trilo/config/RestTemplateConfig.java
+++ b/src/main/java/com/cosain/trilo/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.cosain.trilo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate(){
+        return new RestTemplate();
+    }
+}

--- a/src/test/java/com/cosain/trilo/unit/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/auth/application/AuthServiceTest.java
@@ -1,11 +1,11 @@
 package com.cosain.trilo.unit.auth.application;
 
 import com.cosain.trilo.auth.application.AuthService;
+import com.cosain.trilo.auth.application.OAuthProfileRequestService;
 import com.cosain.trilo.auth.application.dto.KakaoLoginParams;
 import com.cosain.trilo.auth.application.dto.LoginResult;
 import com.cosain.trilo.auth.application.dto.OAuthLoginParams;
 import com.cosain.trilo.auth.domain.repository.TokenRepository;
-import com.cosain.trilo.auth.infra.OAuthClient;
 import com.cosain.trilo.auth.infra.OAuthProfileDto;
 import com.cosain.trilo.auth.infra.TokenAnalyzer;
 import com.cosain.trilo.auth.infra.TokenProvider;
@@ -42,8 +42,7 @@ class AuthServiceTest {
     @Mock
     private UserRepository userRepository;
     @Mock
-    private OAuthClient oAuthClient;
-
+    private OAuthProfileRequestService OAuthProfileRequestService;
     private final String ACCESS_TOKEN = "slkdfjasjeoifjse.siejfoajseifjasolef.sliejfaisjelfsjefsdcv";
     private final String REFRESH_TOKEN = "slkdfjasjeoifjse.siejfoajseifjasolef.dfaesgasegasefasdfase";
 
@@ -123,8 +122,7 @@ class AuthServiceTest {
                 .profileImageUrl("image_url")
                 .build();
         given(userRepository.findByEmail(eq(email))).willReturn(Optional.ofNullable(User.from(oAuthProfileDto)));
-        given(oAuthClient.getAccessToken(any(OAuthLoginParams.class))).willReturn(ACCESS_TOKEN);
-        given(oAuthClient.getProfile(eq(ACCESS_TOKEN))).willReturn(oAuthProfileDto);
+        given(OAuthProfileRequestService.request(any(OAuthLoginParams.class))).willReturn(oAuthProfileDto);
         given(tokenProvider.createAccessToken(anyString())).willReturn(ACCESS_TOKEN);
         given(tokenProvider.createRefreshToken(anyString())).willReturn(REFRESH_TOKEN);
 

--- a/src/test/java/com/cosain/trilo/unit/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/auth/application/AuthServiceTest.java
@@ -1,7 +1,9 @@
 package com.cosain.trilo.unit.auth.application;
 
 import com.cosain.trilo.auth.application.AuthService;
+import com.cosain.trilo.auth.application.dto.KakaoLoginParams;
 import com.cosain.trilo.auth.application.dto.LoginResult;
+import com.cosain.trilo.auth.application.dto.OAuthLoginParams;
 import com.cosain.trilo.auth.domain.repository.TokenRepository;
 import com.cosain.trilo.auth.infra.OAuthClient;
 import com.cosain.trilo.auth.infra.OAuthProfileDto;
@@ -113,7 +115,6 @@ class AuthServiceTest {
     void 로그인_정상_동작_확인_테스트(){
         // given
         String code = "Authorization Code";
-        String provider = "kakao";
         String redirect_uri = "http://localhost:3000/oauth2/callback";
         String email = "slifjelsijflsiej@nate.com";
         OAuthProfileDto oAuthProfileDto = OAuthProfileDto.builder()
@@ -123,13 +124,13 @@ class AuthServiceTest {
                 .profileImageUrl("image_url")
                 .build();
         given(userRepository.findByEmail(eq(email))).willReturn(Optional.ofNullable(User.from(oAuthProfileDto)));
-        given(oAuthClient.getAccessToken(eq(code), eq(redirect_uri))).willReturn(ACCESS_TOKEN);
+        given(oAuthClient.getAccessToken(any(OAuthLoginParams.class))).willReturn(ACCESS_TOKEN);
         given(oAuthClient.getProfile(eq(ACCESS_TOKEN))).willReturn(oAuthProfileDto);
         given(tokenProvider.createAccessToken(anyString())).willReturn(ACCESS_TOKEN);
         given(tokenProvider.createRefreshToken(anyString())).willReturn(REFRESH_TOKEN);
 
         // when
-        LoginResult loginResult = authService.login(code, provider, redirect_uri);
+        LoginResult loginResult = authService.login(KakaoLoginParams.of(code, redirect_uri));
 
         // then
         Assertions.assertThat(loginResult.getAccessToken()).isEqualTo(ACCESS_TOKEN);

--- a/src/test/java/com/cosain/trilo/unit/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/auth/application/AuthServiceTest.java
@@ -115,7 +115,6 @@ class AuthServiceTest {
     void 로그인_정상_동작_확인_테스트(){
         // given
         String code = "Authorization Code";
-        String redirect_uri = "http://localhost:3000/oauth2/callback";
         String email = "slifjelsijflsiej@nate.com";
         OAuthProfileDto oAuthProfileDto = OAuthProfileDto.builder()
                 .email(email)
@@ -130,7 +129,7 @@ class AuthServiceTest {
         given(tokenProvider.createRefreshToken(anyString())).willReturn(REFRESH_TOKEN);
 
         // when
-        LoginResult loginResult = authService.login(KakaoLoginParams.of(code, redirect_uri));
+        LoginResult loginResult = authService.login(KakaoLoginParams.of(code));
 
         // then
         Assertions.assertThat(loginResult.getAccessToken()).isEqualTo(ACCESS_TOKEN);

--- a/src/test/java/com/cosain/trilo/unit/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/auth/application/AuthServiceTest.java
@@ -114,6 +114,7 @@ class AuthServiceTest {
     void 로그인_정상_동작_확인_테스트(){
         // given
         String code = "Authorization Code";
+        String redirectUri = "redirect uri";
         String email = "slifjelsijflsiej@nate.com";
         OAuthProfileDto oAuthProfileDto = OAuthProfileDto.builder()
                 .email(email)
@@ -127,7 +128,7 @@ class AuthServiceTest {
         given(tokenProvider.createRefreshToken(anyString())).willReturn(REFRESH_TOKEN);
 
         // when
-        LoginResult loginResult = authService.login(KakaoLoginParams.of(code));
+        LoginResult loginResult = authService.login(KakaoLoginParams.of(code, redirectUri));
 
         // then
         Assertions.assertThat(loginResult.getAccessToken()).isEqualTo(ACCESS_TOKEN);

--- a/src/test/java/com/cosain/trilo/unit/auth/application/OAuthProfileRequestServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/auth/application/OAuthProfileRequestServiceTest.java
@@ -31,7 +31,7 @@ public class OAuthProfileRequestServiceTest {
         List<OAuthClient> oAuthClientList = Collections.singletonList(oAuthClientMock);
         OAuthProfileRequestService = new OAuthProfileRequestService(oAuthClientList);
 
-        OAuthLoginParams oAuthLoginParams = new KakaoLoginParams("code");
+        OAuthLoginParams oAuthLoginParams = KakaoLoginParams.of("code", "redirectUri");
         OAuthProfileRequestService.request(oAuthLoginParams);
 
         verify(oAuthClientMock).getAccessToken(any());

--- a/src/test/java/com/cosain/trilo/unit/auth/application/OAuthProfileRequestServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/auth/application/OAuthProfileRequestServiceTest.java
@@ -2,6 +2,7 @@ package com.cosain.trilo.unit.auth.application;
 
 import com.cosain.trilo.auth.application.OAuthProfileRequestService;
 import com.cosain.trilo.auth.application.dto.KakaoLoginParams;
+import com.cosain.trilo.auth.application.dto.NaverLoginParams;
 import com.cosain.trilo.auth.application.dto.OAuthLoginParams;
 import com.cosain.trilo.auth.infra.OAuthClient;
 import com.cosain.trilo.user.domain.AuthProvider;
@@ -36,4 +37,20 @@ public class OAuthProfileRequestServiceTest {
         verify(oAuthClientMock).getAccessToken(any());
         verify(oAuthClientMock).getProfile(any());
     }
+
+    @Test
+    public void 네이버_로그인_호출_테스트(){
+
+        given(oAuthClientMock.authProvider()).willReturn(AuthProvider.NAVER);
+        List<OAuthClient> oAuthClientList = Collections.singletonList(oAuthClientMock);
+        OAuthProfileRequestService = new OAuthProfileRequestService(oAuthClientList);
+
+        OAuthLoginParams oAuthLoginParams = new NaverLoginParams("code", "state");
+        OAuthProfileRequestService.request(oAuthLoginParams);
+
+        verify(oAuthClientMock).getAccessToken(any());
+        verify(oAuthClientMock).getProfile(any());
+    }
+
+
 }

--- a/src/test/java/com/cosain/trilo/unit/auth/application/OAuthProfileRequestServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/auth/application/OAuthProfileRequestServiceTest.java
@@ -1,0 +1,39 @@
+package com.cosain.trilo.unit.auth.application;
+
+import com.cosain.trilo.auth.application.OAuthProfileRequestService;
+import com.cosain.trilo.auth.application.dto.KakaoLoginParams;
+import com.cosain.trilo.auth.application.dto.OAuthLoginParams;
+import com.cosain.trilo.auth.infra.OAuthClient;
+import com.cosain.trilo.user.domain.AuthProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class OAuthProfileRequestServiceTest {
+    private OAuthProfileRequestService OAuthProfileRequestService;
+    @Mock
+    private OAuthClient oAuthClientMock;
+
+    @Test
+    public void 카카오_로그인_호출_테스트(){
+
+        given(oAuthClientMock.authProvider()).willReturn(AuthProvider.KAKAO);
+        List<OAuthClient> oAuthClientList = Collections.singletonList(oAuthClientMock);
+        OAuthProfileRequestService = new OAuthProfileRequestService(oAuthClientList);
+
+        OAuthLoginParams oAuthLoginParams = new KakaoLoginParams("code");
+        OAuthProfileRequestService.request(oAuthLoginParams);
+
+        verify(oAuthClientMock).getAccessToken(any());
+        verify(oAuthClientMock).getProfile(any());
+    }
+}

--- a/src/test/java/com/cosain/trilo/unit/auth/presentation/api/AuthRestControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/auth/presentation/api/AuthRestControllerTest.java
@@ -119,7 +119,7 @@ class AuthRestControllerTest extends RestControllerTest {
     @Test
     void 카카오_로그인_정상_동작_확인() throws Exception{
         given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
-        KakaoOAuthLoginRequest kakaoOAuthLoginRequest = new KakaoOAuthLoginRequest("code");
+        KakaoOAuthLoginRequest kakaoOAuthLoginRequest = new KakaoOAuthLoginRequest("code", "redirect_uri");
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/kakao")
                         .content(createJson(kakaoOAuthLoginRequest))
@@ -130,7 +130,18 @@ class AuthRestControllerTest extends RestControllerTest {
     @Test
     void 카카오_로그인_요청시_본문에_code가_존재하지_않으면_400_에러를_발생시킨다() throws Exception{
 
-        KakaoOAuthLoginRequest kakaoOAuthLoginRequest = new KakaoOAuthLoginRequest(null);
+        KakaoOAuthLoginRequest kakaoOAuthLoginRequest = new KakaoOAuthLoginRequest(null, "redirect_uri");
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
+
+        mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/kakao")
+                        .content(createJson(kakaoOAuthLoginRequest))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 카카오_로그인_요청시_쿼리_파라미터에_redirect_uri가_존재하지_않으면_400_에러를_발생시킨다() throws Exception{
+        KakaoOAuthLoginRequest kakaoOAuthLoginRequest = new KakaoOAuthLoginRequest("code", null);
         given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/kakao")

--- a/src/test/java/com/cosain/trilo/unit/auth/presentation/api/AuthRestControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/auth/presentation/api/AuthRestControllerTest.java
@@ -5,6 +5,7 @@ import com.cosain.trilo.auth.application.dto.LoginResult;
 import com.cosain.trilo.auth.application.dto.OAuthLoginParams;
 import com.cosain.trilo.auth.presentation.AuthRestController;
 import com.cosain.trilo.auth.presentation.dto.KakaoOAuthLoginRequest;
+import com.cosain.trilo.auth.presentation.dto.NaverOAuthLoginRequest;
 import com.cosain.trilo.auth.presentation.dto.RefreshTokenStatusResponse;
 import com.cosain.trilo.support.RestControllerTest;
 import jakarta.servlet.http.Cookie;
@@ -137,5 +138,41 @@ class AuthRestControllerTest extends RestControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest());
     }
+
+    @Test
+    void 네이버_로그인_정상_동작_확인() throws Exception{
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
+        NaverOAuthLoginRequest naverOAuthLoginRequest = new NaverOAuthLoginRequest("code", "state");
+
+        mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/naver")
+                        .content(createJson(naverOAuthLoginRequest))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void 네이버_로그인_요청시_본문에_code가_존재하지_않으면_400_에러를_발생시킨다() throws Exception{
+
+        NaverOAuthLoginRequest naverOAuthLoginRequest = new NaverOAuthLoginRequest(null, "state");
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
+
+        mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/naver")
+                        .content(createJson(naverOAuthLoginRequest))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 네이버_로그인_요청시_본문에_state가_존재하지_않으면_400_에러를_발생시킨다() throws Exception{
+
+        NaverOAuthLoginRequest naverOAuthLoginRequest = new NaverOAuthLoginRequest("code",null);
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
+
+        mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/naver")
+                        .content(createJson(naverOAuthLoginRequest))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
 
 }

--- a/src/test/java/com/cosain/trilo/unit/auth/presentation/api/AuthRestControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/auth/presentation/api/AuthRestControllerTest.java
@@ -127,7 +127,7 @@ class AuthRestControllerTest extends RestControllerTest {
     }
 
     @Test
-    void 카카오_로그인_요청시_쿼리_파라미터에_code가_존재하지_않으면_400_에러를_발생시킨다() throws Exception{
+    void 카카오_로그인_요청시_본문에_code가_존재하지_않으면_400_에러를_발생시킨다() throws Exception{
 
         KakaoOAuthLoginRequest kakaoOAuthLoginRequest = new KakaoOAuthLoginRequest(null);
         given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));

--- a/src/test/java/com/cosain/trilo/unit/auth/presentation/api/AuthRestControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/auth/presentation/api/AuthRestControllerTest.java
@@ -2,7 +2,9 @@ package com.cosain.trilo.unit.auth.presentation.api;
 
 import com.cosain.trilo.auth.application.AuthService;
 import com.cosain.trilo.auth.application.dto.LoginResult;
+import com.cosain.trilo.auth.application.dto.OAuthLoginParams;
 import com.cosain.trilo.auth.presentation.AuthRestController;
+import com.cosain.trilo.auth.presentation.dto.KakaoOAuthLoginRequest;
 import com.cosain.trilo.auth.presentation.dto.RefreshTokenStatusResponse;
 import com.cosain.trilo.support.RestControllerTest;
 import jakarta.servlet.http.Cookie;
@@ -114,35 +116,35 @@ class AuthRestControllerTest extends RestControllerTest {
     }
 
     @Test
-    void 로그인_정상_동작_확인() throws Exception{
-        String provider = "kakao";
-        given(authService.login(anyString(), anyString(), anyString())).willReturn(LoginResult.of("accessToken", "refreshToken"));
+    void 카카오_로그인_정상_동작_확인() throws Exception{
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
+        KakaoOAuthLoginRequest kakaoOAuthLoginRequest = new KakaoOAuthLoginRequest("code", "http://localhost:3000/oauth2/callback");
 
-        mockMvc.perform(RestDocumentationRequestBuilders.get(BASE_URL + "/login/{provider}", provider)
-                        .param("code", "Authorization code")
-                        .param("redirect_uri", "http://localhost:3000/oauth2/callback")
+        mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/kakao")
+                        .content(createJson(kakaoOAuthLoginRequest))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
     }
 
     @Test
-    void 로그인_요청시_쿼리_파라미터에_code가_존재하지_않으면_400_에러를_발생시킨다() throws Exception{
-        String provider = "kakao";
-        given(authService.login(anyString(), anyString(), anyString())).willReturn(LoginResult.of("accessToken", "refreshToken"));
+    void 카카오_로그인_요청시_쿼리_파라미터에_code가_존재하지_않으면_400_에러를_발생시킨다() throws Exception{
 
-        mockMvc.perform(RestDocumentationRequestBuilders.get(BASE_URL + "/login/{provider}", provider)
-                        .param("redirect_uri", "http://localhost:3000/oauth2/callback")
+        KakaoOAuthLoginRequest kakaoOAuthLoginRequest = new KakaoOAuthLoginRequest(null, "http://localhost:3000/oauth2/callback");
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
+
+        mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/kakao")
+                        .content(createJson(kakaoOAuthLoginRequest))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest());
     }
 
     @Test
-    void 로그인_요청시_쿼리_파라미터에_redirect_uri가_존재하지_않으면_400_에러를_발생시킨다() throws Exception{
-        String provider = "kakao";
-        given(authService.login(anyString(), anyString(), anyString())).willReturn(LoginResult.of("accessToken", "refreshToken"));
+    void 카카오_로그인_요청시_쿼리_파라미터에_redirect_uri가_존재하지_않으면_400_에러를_발생시킨다() throws Exception{
+        KakaoOAuthLoginRequest kakaoOAuthLoginRequest = new KakaoOAuthLoginRequest("code", null);
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
 
-        mockMvc.perform(RestDocumentationRequestBuilders.get(BASE_URL + "/login/{provider}", provider)
-                        .param("code", "Authorization code")
+        mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/kakao")
+                        .content(createJson(kakaoOAuthLoginRequest))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest());
     }

--- a/src/test/java/com/cosain/trilo/unit/auth/presentation/api/AuthRestControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/auth/presentation/api/AuthRestControllerTest.java
@@ -118,7 +118,7 @@ class AuthRestControllerTest extends RestControllerTest {
     @Test
     void 카카오_로그인_정상_동작_확인() throws Exception{
         given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
-        KakaoOAuthLoginRequest kakaoOAuthLoginRequest = new KakaoOAuthLoginRequest("code", "http://localhost:3000/oauth2/callback");
+        KakaoOAuthLoginRequest kakaoOAuthLoginRequest = new KakaoOAuthLoginRequest("code");
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/kakao")
                         .content(createJson(kakaoOAuthLoginRequest))
@@ -129,7 +129,7 @@ class AuthRestControllerTest extends RestControllerTest {
     @Test
     void 카카오_로그인_요청시_쿼리_파라미터에_code가_존재하지_않으면_400_에러를_발생시킨다() throws Exception{
 
-        KakaoOAuthLoginRequest kakaoOAuthLoginRequest = new KakaoOAuthLoginRequest(null, "http://localhost:3000/oauth2/callback");
+        KakaoOAuthLoginRequest kakaoOAuthLoginRequest = new KakaoOAuthLoginRequest(null);
         given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/kakao")
@@ -137,17 +137,5 @@ class AuthRestControllerTest extends RestControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest());
     }
-
-    @Test
-    void 카카오_로그인_요청시_쿼리_파라미터에_redirect_uri가_존재하지_않으면_400_에러를_발생시킨다() throws Exception{
-        KakaoOAuthLoginRequest kakaoOAuthLoginRequest = new KakaoOAuthLoginRequest("code", null);
-        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
-
-        mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/kakao")
-                        .content(createJson(kakaoOAuthLoginRequest))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest());
-    }
-
 
 }

--- a/src/test/java/com/cosain/trilo/unit/auth/presentation/docs/AuthRestControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/auth/presentation/docs/AuthRestControllerDocsTest.java
@@ -93,7 +93,7 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
     @Test
     void 카카오_로그인_요청() throws Exception{
 
-        KakaoOAuthLoginRequest kakaoOAuthLoginRequest = new KakaoOAuthLoginRequest("code");
+        KakaoOAuthLoginRequest kakaoOAuthLoginRequest = new KakaoOAuthLoginRequest("code", "redirect_uri");
         given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/kakao")
@@ -102,7 +102,8 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
                 .andExpect(status().isOk())
                 .andDo(restDocs.document(
                     requestFields(
-                            fieldWithPath("code").type(STRING).description("Authorization Code")
+                            fieldWithPath("code").type(STRING).description("Authorization Code"),
+                            fieldWithPath("redirect_uri").type(STRING).description("인증 코드 발급에 사용했던 Redirect Uri")
                     ),
                     responseFields(
                             fieldWithPath("authType").type(STRING).description("인증 타입 (Bearer)"),

--- a/src/test/java/com/cosain/trilo/unit/auth/presentation/docs/AuthRestControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/auth/presentation/docs/AuthRestControllerDocsTest.java
@@ -5,6 +5,7 @@ import com.cosain.trilo.auth.application.dto.LoginResult;
 import com.cosain.trilo.auth.application.dto.OAuthLoginParams;
 import com.cosain.trilo.auth.presentation.AuthRestController;
 import com.cosain.trilo.auth.presentation.dto.KakaoOAuthLoginRequest;
+import com.cosain.trilo.auth.presentation.dto.NaverOAuthLoginRequest;
 import com.cosain.trilo.auth.presentation.dto.RefreshTokenStatusResponse;
 import com.cosain.trilo.support.RestDocsTestSupport;
 import jakarta.servlet.http.Cookie;
@@ -13,13 +14,10 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.restdocs.cookies.CookieDocumentation;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
-
 import org.springframework.security.test.context.support.WithMockUser;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
 import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
@@ -27,8 +25,6 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(AuthRestController.class)
@@ -116,6 +112,31 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
                             headerWithName("Set-Cookie").description("RefreshToken")
                     )
 
+                ));
+    }
+
+    @Test
+    void 네이버_로그인_요청() throws Exception {
+
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
+        NaverOAuthLoginRequest naverOAuthLoginRequest = new NaverOAuthLoginRequest("code", "state");
+
+        mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/naver")
+                        .content(createJson(naverOAuthLoginRequest))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(restDocs.document(
+                   requestFields(
+                           fieldWithPath("code").type(STRING).description("Authorization Code"),
+                           fieldWithPath("state").type(STRING).description("")
+                   ),
+                   responseFields(
+                           fieldWithPath("authType").type(STRING).description("인증 타입 (Bearer)"),
+                           fieldWithPath("accessToken").description("AccessToken")
+                   ),
+                   responseHeaders(
+                           headerWithName("Set-Cookie").description("RefreshToken")
+                   )
                 ));
     }
 

--- a/src/test/java/com/cosain/trilo/unit/auth/presentation/docs/AuthRestControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/auth/presentation/docs/AuthRestControllerDocsTest.java
@@ -97,7 +97,7 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
     @Test
     void 카카오_로그인_요청() throws Exception{
 
-        KakaoOAuthLoginRequest kakaoOAuthLoginRequest = new KakaoOAuthLoginRequest("code", "http://localhost:3000/oauth2/callback");
+        KakaoOAuthLoginRequest kakaoOAuthLoginRequest = new KakaoOAuthLoginRequest("code");
         given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/kakao")
@@ -106,8 +106,7 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
                 .andExpect(status().isOk())
                 .andDo(restDocs.document(
                     requestFields(
-                            fieldWithPath("code").type(STRING).description("Authorization Code"),
-                            fieldWithPath("redirect_uri").type(STRING).description("처음 Authorization Code 를 발급 받을 때 지정한 Redirect URI")
+                            fieldWithPath("code").type(STRING).description("Authorization Code")
                     ),
                     responseFields(
                             fieldWithPath("authType").type(STRING).description("인증 타입 (Bearer)"),

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -86,9 +86,16 @@ jwt:
 
 oauth2:
   kakao:
-    client-id: secretsecretsecret
+    client-id: secret
     token-uri: https://kauth.kakao.com/oauth/token
     user-info-uri: https://kapi.kakao.com/v2/user/me
+
+  naver:
+    grant_type: authorization_code
+    client-id: secret
+    client-secret: secret
+    token_uri: https://nid.naver.com/oauth2.0/token
+    user-info-uri: https://openapi.naver.com/v1/nid/me
 
 deploy-module:
   version: 0.0.7


### PR DESCRIPTION
# JIRA 티켓
[TRL-302]

# 작업 내역
- [x] 네이버 OAuth2 로그인 기능 구현
- [x] 중복 로직(카카오, 네이버, 구글) 제거를 위해 기존 OAuth2 로그인 구조 리팩토링 
- [x] 기존 카카오 OAuth2 로그인 API ( GET -> POST ) 수정
- [x] 기존 카카오 OAuth2 로그인 API 문서 수정

# 설명

기존 OAuth2 로그인 기능은 카카오 하나만 지원했습니다. 따라서 단순하게 로직을 구성할 수 있었습니다.

하지만 구글, 네이버 OAuth2 로그인 기능을 추가하면서 동일한 중복 로직이 `AuthSerivce`에 발생하게 되었는데, 이를 해결하기 위해 `OAuthProfileRequestService` 를 추가적으로 정의했습니다.

## 확장 가능한 유연한 설계

`OAuthProfileRequestService`는 스프링 빈으로 관리되며 `OAuthClient` 구현 객체들을 주입받아 Map<AuthProvider, OAuthClient> 으로 관리하게 됩니다. 

- Key : OAuth2 로그인 제공자
- Value : 써드 파티 OAuth2 API Client (OAuthClient 구현체 ex KakaoClient, NaverClient ... )

`OAuthProfileRequestService` 는 원활한 재사용과 DI, 동시성 문제을 위해 스프링 빈으로 관리되며 때문에 stateless 하게 구성했습니다. 또 DI로 생성자 주입 방식을 사용하며 `OAuthClient` 구현체들을 주입받습니다. 즉, 바로 Map 타입으로 주입받지 못하므로 주입 받은 각각의 OAuthClient 구현 객체 안에 구현 되어 있는 authProvider() 의 반환값 기준으로 Map 으로 변환하여 의존 객체들을 관리합니다.

앞으로 구글이나, 페이스북 등의 다른 OAuth2 로그인 기능을 추가하게 되어도 OAuthClient 를 구현하는 구현체만 추가하게 되면 동일하게 Controller -> Service -> OAuthProfileRequestService -> OAuthClient 구현체 순서로 로그인 흐름이 진행됩니다. 

추가적으로 각각의 로그인 방식마다 AccessToken 발급 요청시 요구하는 조금씩 파라미터가 달라서  `OAuthLoginParams` 의 구현체를  매개변수로 전달하여 어떤 로그인 방식이든지 동일하게 하나의 public interface method 를 거치도록 구현했습니다.

# 참고 자료

[네이버 로그인 API 명세](https://developers.naver.com/docs/login/api/api.md)

[TRL-302]: https://cosain.atlassian.net/browse/TRL-302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ