### PR TITLE
[TRL-310] feat: Day의 DayColor 수정 API 구현

### DIFF
--- a/src/main/java/com/cosain/trilo/trip/application/day/command/dto/DayColorUpdateCommand.java
+++ b/src/main/java/com/cosain/trilo/trip/application/day/command/dto/DayColorUpdateCommand.java
@@ -1,0 +1,14 @@
+package com.cosain.trilo.trip.application.day.command.dto;
+
+import com.cosain.trilo.trip.domain.vo.DayColor;
+import lombok.Getter;
+
+@Getter
+public class DayColorUpdateCommand {
+
+    private DayColor dayColor;
+
+    public DayColorUpdateCommand(DayColor dayColor) {
+        this.dayColor = dayColor;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/application/day/command/dto/factory/DayColorUpdateCommandFactory.java
+++ b/src/main/java/com/cosain/trilo/trip/application/day/command/dto/factory/DayColorUpdateCommandFactory.java
@@ -1,0 +1,13 @@
+package com.cosain.trilo.trip.application.day.command.dto.factory;
+
+import com.cosain.trilo.trip.application.day.command.dto.DayColorUpdateCommand;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DayColorUpdateCommandFactory {
+
+    public DayColorUpdateCommand createCommand(String rawColorName) {
+        return null;
+    }
+
+}

--- a/src/main/java/com/cosain/trilo/trip/application/day/command/dto/factory/DayColorUpdateCommandFactory.java
+++ b/src/main/java/com/cosain/trilo/trip/application/day/command/dto/factory/DayColorUpdateCommandFactory.java
@@ -1,13 +1,34 @@
 package com.cosain.trilo.trip.application.day.command.dto.factory;
 
+import com.cosain.trilo.common.exception.CustomException;
+import com.cosain.trilo.common.exception.CustomValidationException;
 import com.cosain.trilo.trip.application.day.command.dto.DayColorUpdateCommand;
+import com.cosain.trilo.trip.domain.vo.DayColor;
 import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Component
 public class DayColorUpdateCommandFactory {
 
     public DayColorUpdateCommand createCommand(String rawColorName) {
-        return null;
+        List<CustomException> exceptions = new ArrayList<>();
+
+        DayColor dayColor = makeDayColor(rawColorName, exceptions);
+
+        if (!exceptions.isEmpty()) {
+            throw new CustomValidationException(exceptions);
+        }
+        return new DayColorUpdateCommand(dayColor);
     }
 
+    private DayColor makeDayColor(String rawColorName, List<CustomException> exceptions) {
+        try {
+            return DayColor.of(rawColorName);
+        } catch (CustomException e) {
+            exceptions.add(e);
+            return null;
+        }
+    }
 }

--- a/src/main/java/com/cosain/trilo/trip/application/day/command/service/DayColorUpdateService.java
+++ b/src/main/java/com/cosain/trilo/trip/application/day/command/service/DayColorUpdateService.java
@@ -1,0 +1,18 @@
+package com.cosain.trilo.trip.application.day.command.service;
+
+import com.cosain.trilo.trip.application.day.command.dto.DayColorUpdateCommand;
+import com.cosain.trilo.trip.application.day.command.usecase.DayColorUpdateUseCase;
+import com.cosain.trilo.trip.domain.repository.DayRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DayColorUpdateService implements DayColorUpdateUseCase {
+
+    private final DayRepository dayRepository;
+
+    @Override
+    public void updateDayColor(Long dayId, Long tripperId, DayColorUpdateCommand command) {
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/application/day/command/service/DayColorUpdateService.java
+++ b/src/main/java/com/cosain/trilo/trip/application/day/command/service/DayColorUpdateService.java
@@ -2,9 +2,13 @@ package com.cosain.trilo.trip.application.day.command.service;
 
 import com.cosain.trilo.trip.application.day.command.dto.DayColorUpdateCommand;
 import com.cosain.trilo.trip.application.day.command.usecase.DayColorUpdateUseCase;
+import com.cosain.trilo.trip.application.exception.DayNotFoundException;
+import com.cosain.trilo.trip.application.exception.NoDayUpdateAuthorityException;
+import com.cosain.trilo.trip.domain.entity.Day;
 import com.cosain.trilo.trip.domain.repository.DayRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -12,7 +16,26 @@ public class DayColorUpdateService implements DayColorUpdateUseCase {
 
     private final DayRepository dayRepository;
 
+    @Transactional
     @Override
     public void updateDayColor(Long dayId, Long tripperId, DayColorUpdateCommand command) {
+        Day day = findDay(dayId);
+
+        validateDayUpdateAuthority(day, tripperId);
+        day.changeColor(command.getDayColor());
     }
+
+    private Day findDay(Long dayId) {
+        return dayRepository.findByIdWithTrip(dayId)
+                .orElseThrow(() -> new DayNotFoundException("일치하는 식별자의 day를 찾지 못 함"));
+    }
+
+    private void validateDayUpdateAuthority(Day day, Long tripperId) {
+        Long realDayOwnerId = day.getTrip().getTripperId();
+
+        if (!tripperId.equals(realDayOwnerId)) {
+            throw new NoDayUpdateAuthorityException("Day를 수정할 권한이 없는 사람이 수정하려 시도함");
+        }
+    }
+
 }

--- a/src/main/java/com/cosain/trilo/trip/application/day/command/usecase/DayColorUpdateUseCase.java
+++ b/src/main/java/com/cosain/trilo/trip/application/day/command/usecase/DayColorUpdateUseCase.java
@@ -1,0 +1,8 @@
+package com.cosain.trilo.trip.application.day.command.usecase;
+
+import com.cosain.trilo.trip.application.day.command.dto.DayColorUpdateCommand;
+
+public interface DayColorUpdateUseCase {
+
+    void updateDayColor(Long dayId, Long tripperId, DayColorUpdateCommand command);
+}

--- a/src/main/java/com/cosain/trilo/trip/application/exception/NoDayUpdateAuthorityException.java
+++ b/src/main/java/com/cosain/trilo/trip/application/exception/NoDayUpdateAuthorityException.java
@@ -1,0 +1,36 @@
+package com.cosain.trilo.trip.application.exception;
+
+import com.cosain.trilo.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class NoDayUpdateAuthorityException extends CustomException {
+
+    private static final String ERROR_CODE = "day-0006";
+    private static final HttpStatus HTTP_STATUS = HttpStatus.FORBIDDEN;
+
+    public NoDayUpdateAuthorityException() {
+        super();
+    }
+
+    public NoDayUpdateAuthorityException(String debugMessage) {
+        super(debugMessage);
+    }
+
+    public NoDayUpdateAuthorityException(Throwable cause) {
+        super(cause);
+    }
+
+    public NoDayUpdateAuthorityException(String debugMessage, Throwable cause) {
+        super(debugMessage, cause);
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HTTP_STATUS;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/domain/entity/Day.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/entity/Day.java
@@ -64,6 +64,14 @@ public class Day {
     }
 
     /**
+     * Day의 색상을 변경합니다.
+     * @param dayColor : 변경할 색상
+     */
+    public void changeColor(DayColor dayColor) {
+        this.dayColor = dayColor;
+    }
+
+    /**
      * Day가 지정 TripPeriod에 속하는 지 여부를 반환합니다.
      * @param tripPeriod : 기간
      * @return 소속 여부

--- a/src/main/java/com/cosain/trilo/trip/presentation/day/command/DayColorUpdateController.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/day/command/DayColorUpdateController.java
@@ -1,6 +1,7 @@
 package com.cosain.trilo.trip.presentation.day.command;
 
 import com.cosain.trilo.common.LoginUser;
+import com.cosain.trilo.trip.application.day.command.dto.DayColorUpdateCommand;
 import com.cosain.trilo.trip.application.day.command.dto.factory.DayColorUpdateCommandFactory;
 import com.cosain.trilo.trip.application.day.command.usecase.DayColorUpdateUseCase;
 import com.cosain.trilo.trip.presentation.day.command.dto.DayColorUpdateRequest;
@@ -8,10 +9,8 @@ import com.cosain.trilo.trip.presentation.day.command.dto.DayColorUpdateResponse
 import com.cosain.trilo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -22,10 +21,17 @@ public class DayColorUpdateController {
     private final DayColorUpdateCommandFactory dayColorUpdateCommandFactory;
 
     @PutMapping("/api/days/{dayId}/color")
+    @ResponseStatus(HttpStatus.OK)
     public DayColorUpdateResponse updateDayColor(
             @PathVariable("dayId") Long dayId,
             @LoginUser User user,
             @RequestBody DayColorUpdateRequest request) {
-        return null;
+
+        Long tripperId = user.getId();
+
+        DayColorUpdateCommand command = dayColorUpdateCommandFactory.createCommand(request.getColorName());
+
+        dayColorUpdateUseCase.updateDayColor(dayId, tripperId, command);
+        return new DayColorUpdateResponse(dayId);
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/presentation/day/command/DayColorUpdateController.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/day/command/DayColorUpdateController.java
@@ -1,0 +1,31 @@
+package com.cosain.trilo.trip.presentation.day.command;
+
+import com.cosain.trilo.common.LoginUser;
+import com.cosain.trilo.trip.application.day.command.dto.factory.DayColorUpdateCommandFactory;
+import com.cosain.trilo.trip.application.day.command.usecase.DayColorUpdateUseCase;
+import com.cosain.trilo.trip.presentation.day.command.dto.DayColorUpdateRequest;
+import com.cosain.trilo.trip.presentation.day.command.dto.DayColorUpdateResponse;
+import com.cosain.trilo.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+public class DayColorUpdateController {
+
+    private final DayColorUpdateUseCase dayColorUpdateUseCase;
+    private final DayColorUpdateCommandFactory dayColorUpdateCommandFactory;
+
+    @PutMapping("/api/days/{dayId}/color")
+    public DayColorUpdateResponse updateDayColor(
+            @PathVariable("dayId") Long dayId,
+            @LoginUser User user,
+            @RequestBody DayColorUpdateRequest request) {
+        return null;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/presentation/day/command/dto/DayColorUpdateRequest.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/day/command/dto/DayColorUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.cosain.trilo.trip.presentation.day.command.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DayColorUpdateRequest {
+
+    private String colorName;
+
+    public DayColorUpdateRequest(String colorName) {
+        this.colorName = colorName;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/presentation/day/command/dto/DayColorUpdateResponse.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/day/command/dto/DayColorUpdateResponse.java
@@ -1,0 +1,13 @@
+package com.cosain.trilo.trip.presentation.day.command.dto;
+
+import lombok.Getter;
+
+@Getter
+public class DayColorUpdateResponse {
+
+    private Long dayId;
+
+    public DayColorUpdateResponse (Long dayId) {
+        this.dayId = dayId;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/presentation/trip/command/TripUpdateController.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/trip/command/TripUpdateController.java
@@ -10,6 +10,7 @@ import com.cosain.trilo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j

--- a/src/main/resources/exceptions/exception.yml
+++ b/src/main/resources/exceptions/exception.yml
@@ -111,7 +111,11 @@ day-0002:
 
 day-0003:
   message: Invalid Day Color Name
-  detail : Day의 색상 이름이 누락됐거나 유효하지 않습니다. 지원하는 색상 이름 목록을 확인하여 필수로 전달해주세요.
+  detail: Day의 색상 이름이 누락됐거나 유효하지 않습니다. 지원하는 색상 이름 목록을 확인하여 필수로 전달해주세요.
+
+day-0004:
+  message: NoDayUpdateAuthority
+  detail: 해당 Day를 수정할 권한이 없습니다.
 
 # 일정 관련
 schedule-0001:

--- a/src/main/resources/exceptions/exception_en.yml
+++ b/src/main/resources/exceptions/exception_en.yml
@@ -113,6 +113,10 @@ day-0003:
   message: Invalid Day Color Name
   detail: The color name of 'Day' is missing or invalid. Please provide a required color name by referring to the list of supported color names.
 
+day-0004:
+  message: NoDayUpdateAuthority
+  detail: You do not have permission to modify the specified day.
+
 # 일정 관련
 schedule-0001:
   message: ScheduleNotFound

--- a/src/test/java/com/cosain/trilo/unit/trip/application/day/command/dto/factory/DayColorUpdateCommandFactoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/day/command/dto/factory/DayColorUpdateCommandFactoryTest.java
@@ -1,0 +1,85 @@
+package com.cosain.trilo.unit.trip.application.day.command.dto.factory;
+
+import com.cosain.trilo.common.exception.CustomException;
+import com.cosain.trilo.common.exception.CustomValidationException;
+import com.cosain.trilo.trip.application.day.command.dto.DayColorUpdateCommand;
+import com.cosain.trilo.trip.application.day.command.dto.factory.DayColorUpdateCommandFactory;
+import com.cosain.trilo.trip.domain.exception.InvalidDayColorNameException;
+import com.cosain.trilo.trip.domain.vo.DayColor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+
+@DisplayName("DayColorUpdateCommandFactory 테스트")
+public class DayColorUpdateCommandFactoryTest {
+
+    private DayColorUpdateCommandFactory dayColorUpdateCommandFactory;
+
+    @BeforeEach
+    void setUp() {
+        this.dayColorUpdateCommandFactory = new DayColorUpdateCommandFactory();
+    }
+
+    @DisplayName("정상적인 색상명 -> command 생성됨")
+    @ValueSource(strings = {"BLACK", "RED", "Blue", "light_GREEN"})
+    @ParameterizedTest
+    void successTest(String rawColorName) {
+        // given : rawColorName
+
+        // when
+        DayColorUpdateCommand command = dayColorUpdateCommandFactory.createCommand(rawColorName);
+
+        // then
+        assertThat(command.getDayColor()).isNotNull();
+        assertThat(command.getDayColor().name()).isEqualToIgnoringCase(rawColorName);
+        assertThat(command.getDayColor()).isSameAs(DayColor.of(rawColorName));
+    }
+
+
+    @DisplayName("colorName null -> 검증 예외 발생")
+    @Test
+    void nullColorNameTest() {
+        // given
+        String rawColorName = null;
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> dayColorUpdateCommandFactory.createCommand(rawColorName),
+                CustomValidationException.class);
+
+        // then
+        List<CustomException> exceptions = cve.getExceptions();
+
+        assertThat(cve).isNotNull();
+        assertThat(exceptions.size()).isEqualTo(1);
+        assertThat(exceptions.get(0)).isInstanceOf(InvalidDayColorNameException.class);
+    }
+
+
+    @ValueSource(strings = {"adfadf", "rainbow", "pink", "", "999", "GOLD"})
+    @ParameterizedTest
+    @DisplayName("유효하지 않은 색상 이름 -> 검증예외 발생")
+    public void testInvalidDayColorName(String rawColorName) {
+        // given : rawColorName
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> dayColorUpdateCommandFactory.createCommand(rawColorName),
+                CustomValidationException.class);
+
+        // then
+        List<CustomException> exceptions = cve.getExceptions();
+
+        assertThat(cve).isNotNull();
+        assertThat(exceptions.size()).isEqualTo(1);
+        assertThat(exceptions.get(0)).isInstanceOf(InvalidDayColorNameException.class);
+    }
+
+}

--- a/src/test/java/com/cosain/trilo/unit/trip/application/day/command/service/DayColorUpdateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/day/command/service/DayColorUpdateServiceTest.java
@@ -1,0 +1,126 @@
+package com.cosain.trilo.unit.trip.application.day.command.service;
+
+import com.cosain.trilo.trip.application.day.command.dto.DayColorUpdateCommand;
+import com.cosain.trilo.trip.application.day.command.service.DayColorUpdateService;
+import com.cosain.trilo.trip.application.exception.DayNotFoundException;
+import com.cosain.trilo.trip.application.exception.NoDayUpdateAuthorityException;
+import com.cosain.trilo.trip.domain.entity.Day;
+import com.cosain.trilo.trip.domain.entity.Trip;
+import com.cosain.trilo.trip.domain.repository.DayRepository;
+import com.cosain.trilo.trip.domain.vo.DayColor;
+import com.cosain.trilo.trip.domain.vo.TripPeriod;
+import com.cosain.trilo.trip.domain.vo.TripStatus;
+import com.cosain.trilo.trip.domain.vo.TripTitle;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Day 색상 변경 서비스 테스트")
+public class DayColorUpdateServiceTest {
+
+    @InjectMocks
+    private DayColorUpdateService dayColorUpdateService;
+
+    @Mock
+    private DayRepository dayRepository;
+
+    @Test
+    @DisplayName("존재하지 않는 Day의 식별자 -> DayNotFoundException")
+    public void dayNotFoundTest() {
+        // given
+
+        Long dayId = 1L;
+        Long tripperId = 2L;
+        String rawColorName = "RED";
+        DayColorUpdateCommand updateCommand = new DayColorUpdateCommand(DayColor.of(rawColorName));
+
+        given(dayRepository.findByIdWithTrip(eq(dayId))).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> dayColorUpdateService.updateDayColor(dayId, tripperId, updateCommand))
+                .isInstanceOf(DayNotFoundException.class);
+
+        verify(dayRepository, times(1)).findByIdWithTrip(eq(dayId));
+    }
+
+    @Test
+    @DisplayName("권한 없는 사람이 색상 수정 시도 -> NoDayUpdateAuthorityException 발생")
+    public void noDayUpdateAuthorityTest() {
+        // given
+        Long dayId = 1L;
+        Long tripId = 2L;
+        Long tripOwnerId = 3L;
+        Long invalidTripperId = 4L;
+
+        DayColor beforeDayColor = DayColor.BLACK;
+        DayColor requestDayColor = DayColor.RED;
+
+        Day day = mockDay(tripId, tripOwnerId, beforeDayColor);
+        DayColorUpdateCommand updateCommand = new DayColorUpdateCommand(requestDayColor);
+
+        given(dayRepository.findByIdWithTrip(eq(dayId))).willReturn(Optional.of(day));
+
+        // when & then
+        assertThatThrownBy(() -> dayColorUpdateService.updateDayColor(dayId, invalidTripperId, updateCommand))
+                .isInstanceOf(NoDayUpdateAuthorityException.class);
+
+        verify(dayRepository, times(1)).findByIdWithTrip(eq(dayId));
+    }
+
+    @Test
+    @DisplayName("색상 수정 성공 테스트")
+    public void successTest() {
+        Long dayId = 1L;
+        Long tripId = 2L;
+        Long tripOwnerId = 3L;
+
+        DayColor beforeDayColor = DayColor.BLACK;
+        DayColor requestDayColor = DayColor.RED;
+
+        Day day = mockDay(tripId, tripOwnerId, beforeDayColor);
+        DayColorUpdateCommand updateCommand = new DayColorUpdateCommand(requestDayColor);
+
+        given(dayRepository.findByIdWithTrip(eq(dayId))).willReturn(Optional.of(day));
+
+        // when
+        dayColorUpdateService.updateDayColor(dayId, tripOwnerId, updateCommand);
+
+        // then
+        verify(dayRepository, times(1)).findByIdWithTrip(eq(dayId));
+        assertThat(day.getDayColor()).isSameAs(requestDayColor);
+    }
+
+
+    private Day mockDay(Long tripId, Long tripperId, DayColor dayColor) {
+        Trip trip = Trip.builder()
+                .id(tripId)
+                .tripperId(tripperId)
+                .tripTitle(TripTitle.of("여행 제목"))
+                .tripPeriod(TripPeriod.of(LocalDate.of(2023,3,1), LocalDate.of(2023,3,1)))
+                .status(TripStatus.DECIDED)
+                .build();
+        Day day = Day.builder()
+                .trip(trip)
+                .dayColor(dayColor)
+                .tripDate(LocalDate.of(2023,3,1))
+                .build();
+        trip.getDays().add(day);
+        return day;
+    }
+
+}

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/entity/DayTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/entity/DayTest.java
@@ -3,19 +3,35 @@ package com.cosain.trilo.unit.trip.domain.entity;
 import com.cosain.trilo.fixture.TripFixture;
 import com.cosain.trilo.trip.domain.entity.Day;
 import com.cosain.trilo.trip.domain.entity.Trip;
+import com.cosain.trilo.trip.domain.vo.DayColor;
 import com.cosain.trilo.trip.domain.vo.TripPeriod;
-import com.cosain.trilo.trip.domain.vo.TripTitle;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.LocalDate;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("[TripCommand] Day 테스트")
 public class DayTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"RED", "ORANGE", "PURPLE"})
+    @DisplayName("Day의 색상 변경 테스트")
+    public void changeColorTest(String colorName) {
+        Trip trip = TripFixture.DECIDED_TRIP.createDecided(1L, 1L, "제목", LocalDate.of(2023,5,1), LocalDate.of(2023,5,1));
+        Day day = trip.getDays().get(0);
+
+        DayColor color = DayColor.of(colorName);
+        day.changeColor(color);
+
+        assertThat(color.name()).isEqualTo(colorName);
+    }
 
     @Nested
     @DisplayName("isIn 메서드 테스트")

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/day/command/DayColorUpdateControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/day/command/DayColorUpdateControllerTest.java
@@ -1,0 +1,173 @@
+package com.cosain.trilo.unit.trip.presentation.day.command;
+
+
+import com.cosain.trilo.support.RestControllerTest;
+import com.cosain.trilo.trip.application.day.command.dto.DayColorUpdateCommand;
+import com.cosain.trilo.trip.application.day.command.dto.factory.DayColorUpdateCommandFactory;
+import com.cosain.trilo.trip.application.day.command.usecase.DayColorUpdateUseCase;
+import com.cosain.trilo.trip.domain.vo.DayColor;
+import com.cosain.trilo.trip.presentation.day.command.DayColorUpdateController;
+import com.cosain.trilo.trip.presentation.day.command.dto.DayColorUpdateRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@DisplayName("Day 색상 수정 컨트롤러 테스트")
+@WebMvcTest(DayColorUpdateController.class)
+public class DayColorUpdateControllerTest extends RestControllerTest {
+
+    @MockBean
+    private DayColorUpdateUseCase dayColorUpdateUseCase;
+
+    @MockBean
+    private DayColorUpdateCommandFactory dayColorUpdateCommandFactory;
+
+    private final static String ACCESS_TOKEN = "Bearer accessToken";
+
+    @Test
+    @DisplayName("인증된 사용자의 DayColor 수정 요청 -> 성공")
+    public void successTest() throws Exception {
+        mockingForLoginUserAnnotation();
+
+        // given
+        Long dayId = 1L;
+        String rawColorName = "RED";
+        DayColorUpdateRequest request = new DayColorUpdateRequest(rawColorName);
+
+        DayColor dayColor = DayColor.of(rawColorName);
+        DayColorUpdateCommand command = new DayColorUpdateCommand(dayColor);
+
+        // mocking
+        given(dayColorUpdateCommandFactory.createCommand(eq(rawColorName)))
+                .willReturn(command);
+
+        willDoNothing()
+                .given(dayColorUpdateUseCase)
+                .updateDayColor(eq(dayId), any(), any(DayColorUpdateCommand.class));
+
+
+        // when & then
+        mockMvc.perform(put("/api/days/{dayId}/color", dayId)
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(createJson(request))
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.dayId").value(dayId));
+
+        verify(dayColorUpdateCommandFactory, times(1)).createCommand(eq(rawColorName));
+        verify(dayColorUpdateUseCase, times(1)).updateDayColor(eq(dayId), any(), any(DayColorUpdateCommand.class));
+    }
+
+    @Test
+    @DisplayName("미인증 사용자 요청 -> 인증 실패 401")
+    @WithAnonymousUser
+    public void updateDayColor_with_unauthorizedUser() throws Exception {
+        Long dayId = 1L;
+        String rawColorName = "RED";
+        DayColorUpdateRequest request = new DayColorUpdateRequest(rawColorName);
+
+        mockMvc.perform(put("/api/days/{dayId}/color", dayId)
+                        .content(createJson(request))
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.errorCode").value("auth-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+
+        verify(dayColorUpdateCommandFactory, times(0)).createCommand(eq(rawColorName));
+        verify(dayColorUpdateUseCase, times(0)).updateDayColor(eq(dayId), any(), any(DayColorUpdateCommand.class));
+    }
+
+    @Test
+    @DisplayName("비어있는 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void updateDayColor_with_emptyContent() throws Exception {
+        mockingForLoginUserAnnotation();
+
+        // given
+        Long dayId = 1L;
+        String content = "";
+
+        mockMvc.perform(put("/api/days/{dayId}/color", dayId)
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(content)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
+    @Test
+    @DisplayName("형식이 올바르지 않은 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
+    public void createTrip_with_invalidContent() throws Exception {
+        mockingForLoginUserAnnotation();
+
+        Long dayId = 1L;
+        String content = """
+                {
+                    "colorName": 따옴표 안 감싼 색상명
+                }
+                """;
+
+        mockMvc.perform(put("/api/days/{dayId}/color", dayId)
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(content)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0001"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+
+
+    @Test
+    @DisplayName("DayId로 숫자가 아닌 문자열 주입 -> 올바르지 않은 경로 변수 타입 400 에러")
+    public void updateDayColor_with_notNumberDayId() throws Exception {
+        mockingForLoginUserAnnotation();
+
+        String notNumberDayId = "가가가";
+        DayColorUpdateRequest request = new DayColorUpdateRequest("RED");
+
+        mockMvc.perform(put("/api/days/{dayId}/color", notNumberDayId)
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .content(createJson(request))
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("request-0004"))
+                .andExpect(jsonPath("$.errorMessage").exists())
+                .andExpect(jsonPath("$.errorDetail").exists());
+    }
+}


### PR DESCRIPTION
# JIRA 티켓
- [TRL-310]

---

# 작업 내역
- [x] Day의 DayColor 수정 도메인 기능 구현
- [x] Day의 DayColor 수정 표현 계층 기능 구현
- [x] Day의 DayColor 수정 애플리케이션 계층 구현

---


[TRL-310]: https://cosain.atlassian.net/browse/TRL-310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ