### PR TITLE
[TRL-301] feat: OAuth2 로그인 기능 구현 - GOOGLE

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -14,7 +14,7 @@
 === 카카오 OAuth2 로그인
 
 ==== 기본 정보
-- 메서드 : GET
+- 메서드 : POST
 - URL : `/api/auth/login/kakao`
 
 ==== 요청
@@ -37,19 +37,45 @@ include::{snippets}/auth-rest-controller-docs-test/카카오_로그인_요청/ht
 
 ==== 기본 정보
 
-- 메서드 : GET
+- 메서드 : POST
 - URL : `/api/auth/login/naver`
 
 ==== 요청
 ===== 본문
 include::{snippets}/auth-rest-controller-docs-test/네이버_로그인_요청/request-fields.adoc[]
 ==== 응답
+===== 헤더
+include::{snippets}/auth-rest-controller-docs-test/네이버_로그인_요청/response-headers.adoc[]
+===== 본문
 include::{snippets}/auth-rest-controller-docs-test/네이버_로그인_요청/response-fields.adoc[]
 ==== 예제
 ===== 요청
 include::{snippets}/auth-rest-controller-docs-test/네이버_로그인_요청/http-request.adoc[]
 ===== 응답
 include::{snippets}/auth-rest-controller-docs-test/네이버_로그인_요청/http-response.adoc[]
+
+---
+
+=== 구글 OAuth2 로그인
+
+==== 기본 정보
+
+- 메서드 : POST
+- URL : `/api/auth/login/google`
+
+==== 요청
+===== 본문
+include::{snippets}/auth-rest-controller-docs-test/구글_로그인_요청/request-fields.adoc[]
+==== 응답
+===== 헤더
+include::{snippets}/auth-rest-controller-docs-test/구글_로그인_요청/response-headers.adoc[]
+===== 본문
+include::{snippets}/auth-rest-controller-docs-test/구글_로그인_요청/response-fields.adoc[]
+==== 예제
+===== 요청
+include::{snippets}/auth-rest-controller-docs-test/구글_로그인_요청/http-request.adoc[]
+===== 응답
+include::{snippets}/auth-rest-controller-docs-test/구글_로그인_요청/http-response.adoc[]
 
 ---
 

--- a/src/main/java/com/cosain/trilo/auth/application/dto/GoogleLoginParams.java
+++ b/src/main/java/com/cosain/trilo/auth/application/dto/GoogleLoginParams.java
@@ -1,0 +1,32 @@
+package com.cosain.trilo.auth.application.dto;
+
+import com.cosain.trilo.user.domain.AuthProvider;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+public class GoogleLoginParams implements OAuthLoginParams{
+
+    private String code;
+    private String redirectUri;
+
+    private GoogleLoginParams(String code, String redirectUri) {
+        this.code = code;
+        this.redirectUri = redirectUri;
+    }
+
+    public static GoogleLoginParams of(String code, String redirectUri){
+        return new GoogleLoginParams(code, redirectUri);
+    }
+    @Override
+    public AuthProvider authProvider() {
+        return AuthProvider.GOOGLE;
+    }
+
+    @Override
+    public MultiValueMap<String, String> getParams() {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("code", code.replace("%2F", "/"));
+        params.add("redirect_uri", redirectUri);;
+        return params;
+    }
+}

--- a/src/main/java/com/cosain/trilo/auth/infra/OAuthProfileDto.java
+++ b/src/main/java/com/cosain/trilo/auth/infra/OAuthProfileDto.java
@@ -1,5 +1,6 @@
 package com.cosain.trilo.auth.infra;
 
+import com.cosain.trilo.auth.infra.oauth.google.dto.GoogleInfoResponse;
 import com.cosain.trilo.auth.infra.oauth.kakao.dto.KakaoProfileResponse;
 import com.cosain.trilo.auth.infra.oauth.naver.dto.NaverInfoResponse;
 import com.cosain.trilo.user.domain.AuthProvider;
@@ -38,6 +39,15 @@ public class OAuthProfileDto {
                 .email(naverInfoResponse.getEmail())
                 .profileImageUrl(naverInfoResponse.getImageUrl())
                 .provider(AuthProvider.NAVER)
+                .build();
+    }
+
+    public static OAuthProfileDto of(GoogleInfoResponse googleInfoResponse){
+        return OAuthProfileDto.builder()
+                .name(googleInfoResponse.getName())
+                .email(googleInfoResponse.getEmail())
+                .profileImageUrl(googleInfoResponse.getImageUrl())
+                .provider(AuthProvider.GOOGLE)
                 .build();
     }
 }

--- a/src/main/java/com/cosain/trilo/auth/infra/oauth/google/GoogleClient.java
+++ b/src/main/java/com/cosain/trilo/auth/infra/oauth/google/GoogleClient.java
@@ -1,0 +1,86 @@
+package com.cosain.trilo.auth.infra.oauth.google;
+
+import com.cosain.trilo.auth.application.dto.OAuthLoginParams;
+import com.cosain.trilo.auth.infra.OAuthClient;
+import com.cosain.trilo.auth.infra.OAuthProfileDto;
+import com.cosain.trilo.auth.infra.oauth.google.dto.GoogleInfoResponse;
+import com.cosain.trilo.auth.infra.oauth.google.dto.GoogleTokenResponse;
+import com.cosain.trilo.user.domain.AuthProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GoogleClient implements OAuthClient {
+
+    @Value("${oauth2.google.grant_type}")
+    private String grantType;
+    @Value("${oauth2.google.client-id}")
+    private String clientId;
+    @Value("${oauth2.google.client-secret}")
+    private String clientSecret;
+    @Value("${oauth2.google.token-uri}")
+    private String accessTokenUrl;
+    @Value("${oauth2.google.user-info-uri}")
+    private String profileUrl;
+
+    private final RestTemplate restTemplate;
+
+    @Override
+    public AuthProvider authProvider() {
+        return AuthProvider.GOOGLE;
+    }
+
+    @Override
+    public String getAccessToken(OAuthLoginParams oAuthLoginParams) {
+        HttpHeaders headers = makeAccessTokenRequestHeader();
+        MultiValueMap<String, String> params = oAuthLoginParams.getParams();
+        params.add("grant_type",grantType);
+        params.add("client_id", clientId);
+        params.add("client_secret", clientSecret);
+
+        HttpEntity<?> request = makeAccessTokenRequest(headers, params);
+        GoogleTokenResponse googleTokenResponse = restTemplate.postForObject(accessTokenUrl, request, GoogleTokenResponse.class);
+
+        return googleTokenResponse.getAccessToken();
+    }
+
+    private HttpEntity<MultiValueMap<String, String>> makeAccessTokenRequest(HttpHeaders headers, MultiValueMap<String, String> params) {
+        return new HttpEntity<>(params, headers);
+    }
+
+    private HttpHeaders makeAccessTokenRequestHeader() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        return headers;
+    }
+
+    /**
+     * the reason why used exchange() : to add headers
+     */
+    @Override
+    public OAuthProfileDto getProfile(String accessToken) {
+        HttpHeaders headers = makeUserInfoRequest(accessToken);
+        HttpEntity<?> request = new HttpEntity<>(headers);
+
+        ResponseEntity<GoogleInfoResponse> exchange = restTemplate.exchange(profileUrl, HttpMethod.GET, request, GoogleInfoResponse.class);
+        GoogleInfoResponse googleInfoResponse = exchange.getBody();
+        return OAuthProfileDto.of(googleInfoResponse);
+    }
+
+
+
+    private HttpHeaders makeUserInfoRequest(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.set(HttpHeaders.AUTHORIZATION, "Bearer "+ accessToken);
+        return headers;
+    }
+
+}

--- a/src/main/java/com/cosain/trilo/auth/infra/oauth/google/dto/GoogleInfoResponse.java
+++ b/src/main/java/com/cosain/trilo/auth/infra/oauth/google/dto/GoogleInfoResponse.java
@@ -1,0 +1,20 @@
+package com.cosain.trilo.auth.infra.oauth.google.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GoogleInfoResponse {
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("email")
+    private String email;
+
+    @JsonProperty("picture")
+    private String imageUrl;
+
+}

--- a/src/main/java/com/cosain/trilo/auth/infra/oauth/google/dto/GoogleTokenResponse.java
+++ b/src/main/java/com/cosain/trilo/auth/infra/oauth/google/dto/GoogleTokenResponse.java
@@ -1,0 +1,20 @@
+package com.cosain.trilo.auth.infra.oauth.google.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GoogleTokenResponse {
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("expires_in")
+    private Integer expiry;
+
+}

--- a/src/main/java/com/cosain/trilo/auth/presentation/AuthRestController.java
+++ b/src/main/java/com/cosain/trilo/auth/presentation/AuthRestController.java
@@ -1,13 +1,11 @@
 package com.cosain.trilo.auth.presentation;
 
 import com.cosain.trilo.auth.application.AuthService;
+import com.cosain.trilo.auth.application.dto.GoogleLoginParams;
 import com.cosain.trilo.auth.application.dto.KakaoLoginParams;
 import com.cosain.trilo.auth.application.dto.LoginResult;
 import com.cosain.trilo.auth.application.dto.NaverLoginParams;
-import com.cosain.trilo.auth.presentation.dto.AuthResponse;
-import com.cosain.trilo.auth.presentation.dto.KakaoOAuthLoginRequest;
-import com.cosain.trilo.auth.presentation.dto.NaverOAuthLoginRequest;
-import com.cosain.trilo.auth.presentation.dto.RefreshTokenStatusResponse;
+import com.cosain.trilo.auth.presentation.dto.*;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -55,6 +53,16 @@ public class AuthRestController {
     @ResponseStatus(HttpStatus.OK)
     public AuthResponse login(@Valid @RequestBody NaverOAuthLoginRequest naverOAuthLoginRequest, HttpServletResponse response){
         LoginResult loginResult = authService.login(NaverLoginParams.of(naverOAuthLoginRequest.getCode(), naverOAuthLoginRequest.getState()));
+        Cookie cookie = makeRefreshTokenCookie(loginResult.getRefreshToken());
+        response.addCookie(cookie);
+        return AuthResponse.from(loginResult.getAccessToken());
+    }
+
+    @PostMapping("/login/google")
+    @ResponseBody
+    @ResponseStatus(HttpStatus.OK)
+    public AuthResponse login(@Valid @RequestBody GoogleOAuthLoginRequest googleOAuthLoginRequest, HttpServletResponse response){
+        LoginResult loginResult = authService.login(GoogleLoginParams.of(googleOAuthLoginRequest.getCode(), googleOAuthLoginRequest.getRedirect_uri()));
         Cookie cookie = makeRefreshTokenCookie(loginResult.getRefreshToken());
         response.addCookie(cookie);
         return AuthResponse.from(loginResult.getAccessToken());

--- a/src/main/java/com/cosain/trilo/auth/presentation/dto/GoogleOAuthLoginRequest.java
+++ b/src/main/java/com/cosain/trilo/auth/presentation/dto/GoogleOAuthLoginRequest.java
@@ -1,0 +1,18 @@
+package com.cosain.trilo.auth.presentation.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GoogleOAuthLoginRequest {
+
+    @NotEmpty
+    private String code;
+
+    @NotEmpty
+    private String redirect_uri;
+}

--- a/src/test/java/com/cosain/trilo/unit/auth/presentation/api/AuthRestControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/auth/presentation/api/AuthRestControllerTest.java
@@ -4,6 +4,7 @@ import com.cosain.trilo.auth.application.AuthService;
 import com.cosain.trilo.auth.application.dto.LoginResult;
 import com.cosain.trilo.auth.application.dto.OAuthLoginParams;
 import com.cosain.trilo.auth.presentation.AuthRestController;
+import com.cosain.trilo.auth.presentation.dto.GoogleOAuthLoginRequest;
 import com.cosain.trilo.auth.presentation.dto.KakaoOAuthLoginRequest;
 import com.cosain.trilo.auth.presentation.dto.NaverOAuthLoginRequest;
 import com.cosain.trilo.auth.presentation.dto.RefreshTokenStatusResponse;
@@ -185,5 +186,38 @@ class AuthRestControllerTest extends RestControllerTest {
                 .andExpect(status().isBadRequest());
     }
 
+
+    @Test
+    void 구글_로그인_정상_동작_확인() throws Exception{
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
+        GoogleOAuthLoginRequest googleOAuthLoginRequest = new GoogleOAuthLoginRequest("code", "redirect_uri");
+
+        mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/google")
+                        .content(createJson(googleOAuthLoginRequest))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void 구글_로그인_요청시_본문에_code가_존재하지_않으면_400_에러를_발생시킨다() throws Exception{
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
+        GoogleOAuthLoginRequest googleOAuthLoginRequest = new GoogleOAuthLoginRequest(null, "redirect_uri");
+
+        mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/google")
+                        .content(createJson(googleOAuthLoginRequest))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 구글_로그인_요청시_본문에_redirect_uri가_존재하지_않으면_400_에러를_발생시킨다() throws Exception{
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
+        GoogleOAuthLoginRequest googleOAuthLoginRequest = new GoogleOAuthLoginRequest("code", null);
+
+        mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/google")
+                        .content(createJson(googleOAuthLoginRequest))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
 
 }

--- a/src/test/java/com/cosain/trilo/unit/auth/presentation/docs/AuthRestControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/auth/presentation/docs/AuthRestControllerDocsTest.java
@@ -4,6 +4,7 @@ import com.cosain.trilo.auth.application.AuthService;
 import com.cosain.trilo.auth.application.dto.LoginResult;
 import com.cosain.trilo.auth.application.dto.OAuthLoginParams;
 import com.cosain.trilo.auth.presentation.AuthRestController;
+import com.cosain.trilo.auth.presentation.dto.GoogleOAuthLoginRequest;
 import com.cosain.trilo.auth.presentation.dto.KakaoOAuthLoginRequest;
 import com.cosain.trilo.auth.presentation.dto.NaverOAuthLoginRequest;
 import com.cosain.trilo.auth.presentation.dto.RefreshTokenStatusResponse;
@@ -129,7 +130,7 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
                 .andDo(restDocs.document(
                    requestFields(
                            fieldWithPath("code").type(STRING).description("Authorization Code"),
-                           fieldWithPath("state").type(STRING).description("")
+                           fieldWithPath("state").type(STRING).description("Authorization Code 발급시 전달했던 redirect_uri")
                    ),
                    responseFields(
                            fieldWithPath("authType").type(STRING).description("인증 타입 (Bearer)"),
@@ -138,6 +139,31 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
                    responseHeaders(
                            headerWithName("Set-Cookie").description("RefreshToken")
                    )
+                ));
+    }
+
+    @Test
+    void 구글_로그인_요청() throws Exception {
+
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
+        GoogleOAuthLoginRequest googleOAuthLoginRequest = new GoogleOAuthLoginRequest("code", "redirectUrl");
+
+        mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/google")
+                        .content(createJson(googleOAuthLoginRequest))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(restDocs.document(
+                        requestFields(
+                                fieldWithPath("code").type(STRING).description("Authorization Code"),
+                                fieldWithPath("redirect_uri").type(STRING).description("Authorization Code 발급시 전달했던 redirect_uri")
+                        ),
+                        responseFields(
+                                fieldWithPath("authType").type(STRING).description("인증 타입 (Bearer)"),
+                                fieldWithPath("accessToken").description("AccessToken")
+                        ),
+                        responseHeaders(
+                                headerWithName("Set-Cookie").description("RefreshToken")
+                        )
                 ));
     }
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -97,5 +97,12 @@ oauth2:
     token_uri: https://nid.naver.com/oauth2.0/token
     user-info-uri: https://openapi.naver.com/v1/nid/me
 
+  google:
+    grant_type: authorization_code
+    client-id: secret
+    client-secret: secret
+    token-uri: https://oauth2.googleapis.com/token
+    user-info-uri: https://www.googleapis.com/oauth2/v1/userinfo
+
 deploy-module:
   version: 0.0.7


### PR DESCRIPTION
# JIRA 티켓
[TRL-301]

# 작업 내역

- [x] 구글 OAuth2.0 로그인을 위한 API Client 구현
- [x] 구글 OAuth2.0 로그인 EndPoint 추가 - `/api/auth/login/google`
- [x] 구글 OAuth2.0 로그인 API 문서화

[TRL-301]: https://cosain.atlassian.net/browse/TRL-301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ