### PR TITLE
[TRL-318] fix: 특정 사용자 여행 목록 조회 시 커서 기반 페이지네이션 방식으로 조회하도록 변경

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -341,7 +341,7 @@ include::{snippets}/single-trip-query-controller-docs-test/여행_단건_조회/
 ==== 기본 정보
 
 - 메서드 : GET
-- URL : `/api/trips?tripper-id={여행자 ID}`
+- URL : `/api/trips?tripper-id={여행자 ID}&size={요청 데이터 개수}&tripId={조회 기준이 되는 여행 ID}`
 - 인증 방식 : 엑세스 토큰
 
 ==== 요청
@@ -349,6 +349,10 @@ include::{snippets}/single-trip-query-controller-docs-test/여행_단건_조회/
 include::{snippets}/tripper-trip-list-query-controller-docs-test/사용자_여행_목록_조회/request-headers.adoc[]
 ===== 쿼리 변수
 include::{snippets}/tripper-trip-list-query-controller-docs-test/사용자_여행_목록_조회/query-parameters.adoc[]
+
+- 첫 페이지 조회 요청 시 커서, 즉 tripId를 쿼리 파라미터에 포함하지 않습니다. 여행 정보들이 size 만큼 조회됩니다.
+- 이후 페이지 조회 요청 시 tripId 를 쿼리 파라미터에 포함하게 되면 해당 tripId 보다 작은 tripId 를 갖는 여행 정보들이 size 만큼 조회됩니다.
+
 ==== 응답
 ===== 본문
 include::{snippets}/tripper-trip-list-query-controller-docs-test/사용자_여행_목록_조회/response-fields.adoc[]

--- a/src/main/java/com/cosain/trilo/trip/application/trip/query/service/TripListSearchService.java
+++ b/src/main/java/com/cosain/trilo/trip/application/trip/query/service/TripListSearchService.java
@@ -4,6 +4,7 @@ import com.cosain.trilo.trip.application.exception.TripperNotFoundException;
 import com.cosain.trilo.trip.application.trip.query.usecase.TripListSearchUseCase;
 import com.cosain.trilo.trip.infra.dto.TripSummary;
 import com.cosain.trilo.trip.infra.repository.trip.TripQueryRepository;
+import com.cosain.trilo.trip.presentation.trip.query.dto.request.TripPageCondition;
 import com.cosain.trilo.user.domain.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,10 +23,10 @@ public class TripListSearchService implements TripListSearchUseCase {
     private final UserRepository userRepository;
 
     @Override
-    public Slice<TripSummary> searchTripSummaries(Long tripperId, Pageable pageable) {
+    public Slice<TripSummary> searchTripSummaries(TripPageCondition tripPageCondition, Pageable pageable) {
 
-        verifyTripperExists(tripperId);
-        Slice<TripSummary> tripSummaries = findTripSummaries(tripperId, pageable);
+        verifyTripperExists(tripPageCondition.getTripperId());
+        Slice<TripSummary> tripSummaries = findTripSummaries(tripPageCondition, pageable);
         return tripSummaries;
     }
 
@@ -33,8 +34,8 @@ public class TripListSearchService implements TripListSearchUseCase {
         userRepository.findById(tripperId).orElseThrow(TripperNotFoundException::new);
     }
 
-    private Slice<TripSummary> findTripSummaries(Long tripperId, Pageable pageable){
-        return tripQueryRepository.findTripSummariesByTripperId(tripperId, pageable);
+    private Slice<TripSummary> findTripSummaries(TripPageCondition tripPageCondition, Pageable pageable){
+        return tripQueryRepository.findTripSummariesByTripperId(tripPageCondition, pageable);
     }
 
 }

--- a/src/main/java/com/cosain/trilo/trip/application/trip/query/usecase/TripListSearchUseCase.java
+++ b/src/main/java/com/cosain/trilo/trip/application/trip/query/usecase/TripListSearchUseCase.java
@@ -1,9 +1,10 @@
 package com.cosain.trilo.trip.application.trip.query.usecase;
 
 import com.cosain.trilo.trip.infra.dto.TripSummary;
+import com.cosain.trilo.trip.presentation.trip.query.dto.request.TripPageCondition;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface TripListSearchUseCase {
-    Slice<TripSummary> searchTripSummaries(Long tripperId, Pageable pageable);
+    Slice<TripSummary> searchTripSummaries(TripPageCondition tripPageCondition, Pageable pageable);
 }

--- a/src/main/java/com/cosain/trilo/trip/infra/repository/trip/TripQueryRepository.java
+++ b/src/main/java/com/cosain/trilo/trip/infra/repository/trip/TripQueryRepository.java
@@ -59,6 +59,15 @@ public class TripQueryRepository{
         return new SliceImpl<>(result, pageable, hasNext);
     }
 
+    /**
+     * @param result
+     * @param pageable
+     *
+     * 다음 요청값이 있는지 없는지를 반환해주는 메서드입니다. 메서드를 호출하기 전에 실제 요청 size + 1 만큼 조회 쿼리를 날린 다음
+     * 실제 size + 1 만큼의 데이터를 결과(result)로 가져온다면 결국 다음 요청할 데이터가 존재한다는 것이므로 hasNext 를 true로
+     * 설정한다음 반환하게 됩니다. 동시에 실제 요청 크기(pageable.getPageSize())보다 +1 만큼 조회했으므로
+     * remove() 메서드를 통해 리스트에 담긴 중에서 마지막 데이터를 제거합니다.
+     */
     private boolean isHasNext(List<?> result, Pageable pageable){
         boolean hasNext = false;
         if(result.size() > pageable.getPageSize()){

--- a/src/main/java/com/cosain/trilo/trip/presentation/trip/query/TripperTripListQueryController.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/trip/query/TripperTripListQueryController.java
@@ -2,16 +2,14 @@ package com.cosain.trilo.trip.presentation.trip.query;
 
 import com.cosain.trilo.trip.application.trip.query.usecase.TripListSearchUseCase;
 import com.cosain.trilo.trip.infra.dto.TripSummary;
+import com.cosain.trilo.trip.presentation.trip.query.dto.request.TripPageCondition;
 import com.cosain.trilo.trip.presentation.trip.query.dto.response.TripPageResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -21,8 +19,8 @@ public class TripperTripListQueryController {
     private final TripListSearchUseCase tripListSearchUseCase;
     @GetMapping("/api/trips")
     @ResponseStatus(HttpStatus.OK)
-    public TripPageResponse findTripperTripList(@RequestParam("tripper-id") Long tripperId, Pageable pageable) {
-        Slice<TripSummary> tripSummaries = tripListSearchUseCase.searchTripSummaries(tripperId, pageable);
+    public TripPageResponse findTripperTripList(@ModelAttribute TripPageCondition tripPageCondition, Pageable pageable) {
+        Slice<TripSummary> tripSummaries = tripListSearchUseCase.searchTripSummaries(tripPageCondition, pageable);
         return TripPageResponse.from(tripSummaries);
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/presentation/trip/query/dto/request/TripPageCondition.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/trip/query/dto/request/TripPageCondition.java
@@ -1,0 +1,18 @@
+package com.cosain.trilo.trip.presentation.trip.query.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class TripPageCondition {
+
+    @NotBlank
+    private Long tripperId;
+
+    private Long tripId;
+
+    public TripPageCondition(Long tripperId, Long tripId){
+        this.tripperId = tripperId;
+        this.tripId = tripId;
+    }
+}

--- a/src/test/java/com/cosain/trilo/unit/trip/application/trip/query/service/TripListSearchServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/trip/query/service/TripListSearchServiceTest.java
@@ -5,6 +5,7 @@ import com.cosain.trilo.trip.application.trip.query.service.TripListSearchServic
 import com.cosain.trilo.trip.domain.vo.TripStatus;
 import com.cosain.trilo.trip.infra.dto.TripSummary;
 import com.cosain.trilo.trip.infra.repository.trip.TripQueryRepository;
+import com.cosain.trilo.trip.presentation.trip.query.dto.request.TripPageCondition;
 import com.cosain.trilo.user.domain.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -49,11 +50,12 @@ public class TripListSearchServiceTest {
 
         Slice<TripSummary> tripSummaries = new PageImpl<>(List.of(tripSummary1, tripSummary2));
 
+        TripPageCondition tripPageCondition = new TripPageCondition(1L, 1L);
         given(userRepository.findById(eq(1L))).willReturn(Optional.of(KAKAO_MEMBER.create()));
-        given(tripQueryRepository.findTripSummariesByTripperId(tripperId, pageable)).willReturn(tripSummaries);
+        given(tripQueryRepository.findTripSummariesByTripperId(tripPageCondition, pageable)).willReturn(tripSummaries);
 
         // when
-        Slice<TripSummary> searchTripSummaries = tripListSearchService.searchTripSummaries(tripperId, pageable);
+        Slice<TripSummary> searchTripSummaries = tripListSearchService.searchTripSummaries(tripPageCondition, pageable);
 
         // then
         assertThat(searchTripSummaries).isNotNull();
@@ -70,10 +72,11 @@ public class TripListSearchServiceTest {
         // given
         Long tripperId = 1L;
         Pageable pageable = PageRequest.of(0, 10);
+        TripPageCondition tripPageCondition = new TripPageCondition(1L, 1L);
         given(userRepository.findById(tripperId)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> tripListSearchService.searchTripSummaries(tripperId, pageable)).isInstanceOf(TripperNotFoundException.class);
+        assertThatThrownBy(() -> tripListSearchService.searchTripSummaries(tripPageCondition, pageable)).isInstanceOf(TripperNotFoundException.class);
 
     }
 

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/query/TripperTripListQueryControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/query/TripperTripListQueryControllerTest.java
@@ -6,6 +6,7 @@ import com.cosain.trilo.trip.application.trip.query.usecase.TripListSearchUseCas
 import com.cosain.trilo.trip.domain.vo.TripStatus;
 import com.cosain.trilo.trip.infra.dto.TripSummary;
 import com.cosain.trilo.trip.presentation.trip.query.TripperTripListQueryController;
+import com.cosain.trilo.trip.presentation.trip.query.dto.request.TripPageCondition;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -49,9 +50,9 @@ class TripperTripListQueryControllerTest extends RestControllerTest {
         TripSummary tripSummary2 = new TripSummary(2L, 1L, "제목 2", TripStatus.UNDECIDED, null, null);
         TripSummary tripSummary3 = new TripSummary(3L, 1L, "제목 3", TripStatus.DECIDED, LocalDate.of(2023, 4,4), LocalDate.of(2023, 4, 5));
         Pageable pageable = PageRequest.of(0, 3);
-        SliceImpl<TripSummary> tripDetails = new SliceImpl<>(List.of(tripSummary1, tripSummary2, tripSummary3), pageable, true);
+        SliceImpl<TripSummary> tripDetails = new SliceImpl<>(List.of(tripSummary3, tripSummary2, tripSummary1), pageable, true);
 
-        given(tripListSearchUseCase.searchTripSummaries(eq(1L), any(Pageable.class))).willReturn(tripDetails);
+        given(tripListSearchUseCase.searchTripSummaries(any(TripPageCondition.class), any(Pageable.class))).willReturn(tripDetails);
 
         // when & then
         mockMvc.perform(get("/api/trips?tripper-id=1")

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/query/docs/TripperTripListQueryControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/query/docs/TripperTripListQueryControllerDocsTest.java
@@ -5,6 +5,7 @@ import com.cosain.trilo.trip.application.trip.query.usecase.TripListSearchUseCas
 import com.cosain.trilo.trip.domain.vo.TripStatus;
 import com.cosain.trilo.trip.infra.dto.TripSummary;
 import com.cosain.trilo.trip.presentation.trip.query.TripperTripListQueryController;
+import com.cosain.trilo.trip.presentation.trip.query.dto.request.TripPageCondition;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -43,20 +44,20 @@ public class TripperTripListQueryControllerDocsTest extends RestDocsTestSupport 
         mockingForLoginUserAnnotation();
 
         Long tripperId = 1L;
-        int page = 0;
+        Long tripId = 5L;
         int size = 3;
-        TripSummary tripSummary1 = new TripSummary(1L, tripperId, "제목 1", TripStatus.DECIDED, LocalDate.of(2023, 3,4), LocalDate.of(2023, 4, 1));
-        TripSummary tripSummary2 = new TripSummary(2L, tripperId, "제목 2", TripStatus.UNDECIDED, null, null);
-        TripSummary tripSummary3 = new TripSummary(3L, tripperId, "제목 3", TripStatus.DECIDED, LocalDate.of(2023, 4,4), LocalDate.of(2023, 4, 5));
-        Pageable pageable = PageRequest.of(page, size);
+        TripSummary tripSummary1 = new TripSummary(4L, tripperId, "제목 1", TripStatus.DECIDED, LocalDate.of(2023, 3,4), LocalDate.of(2023, 4, 1));
+        TripSummary tripSummary2 = new TripSummary(3L, tripperId, "제목 2", TripStatus.UNDECIDED, null, null);
+        TripSummary tripSummary3 = new TripSummary(2L, tripperId, "제목 3", TripStatus.DECIDED, LocalDate.of(2023, 4,4), LocalDate.of(2023, 4, 5));
+        Pageable pageable = PageRequest.ofSize(size);
         SliceImpl<TripSummary> tripDetails = new SliceImpl<>(List.of(tripSummary1, tripSummary2, tripSummary3), pageable, true);
 
-        given(tripListSearchUseCase.searchTripSummaries(eq(tripperId), eq(pageable))).willReturn(tripDetails);
+        given(tripListSearchUseCase.searchTripSummaries(any(TripPageCondition.class), eq(pageable))).willReturn(tripDetails);
 
         // when & then
         mockMvc.perform(RestDocumentationRequestBuilders.get(BASE_URL)
-                        .param("tripper-id", String.valueOf(tripperId))
-                        .param("page", String.valueOf(page))
+                        .param("tripperId", String.valueOf(tripperId))
+                        .param("tripId", String.valueOf(tripId))
                         .param("size", String.valueOf(size))
                         .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
                         .characterEncoding(StandardCharsets.UTF_8)
@@ -68,8 +69,8 @@ public class TripperTripListQueryControllerDocsTest extends RestDocsTestSupport 
                                         .description("Bearer 타입 AccessToken")
                         ),
                         queryParameters(
-                                parameterWithName("tripper-id").description("여행자 ID"),
-                                parameterWithName("page").description("요청할 페이지"),
+                                parameterWithName("tripperId").description("여행자 ID"),
+                                parameterWithName("tripId").optional().description("커서에 해당하는 tripId"),
                                 parameterWithName("size").description("가져올 데이터의 개수")
                         ),
                         responseFields(

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/query/docs/TripperTripListQueryControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/query/docs/TripperTripListQueryControllerDocsTest.java
@@ -70,7 +70,7 @@ public class TripperTripListQueryControllerDocsTest extends RestDocsTestSupport 
                         ),
                         queryParameters(
                                 parameterWithName("tripperId").description("여행자 ID"),
-                                parameterWithName("tripId").optional().description("커서에 해당하는 tripId"),
+                                parameterWithName("tripId").optional().description("기준이 되는 여행 ID (하단 설명 참고)"),
                                 parameterWithName("size").description("가져올 데이터의 개수")
                         ),
                         responseFields(

--- a/src/test/resources/org/springframework/restdocs/templates/query-parameters.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/query-parameters.snippet
@@ -1,0 +1,8 @@
+|===
+|파라미터명|설명|필수여부
+{{#parameters}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{#optional}}false{{/optional}}{{/tableCellContent}}
+{{/parameters}}
+|===


### PR DESCRIPTION
# JIRA 티켓
[TRL-318]

# 작업 내역

기존 오프셋 기반 페이지네이션 방식으로 구현되어있던 여행 목록 페이징 조회 기능을 커서 기반 페이지네이션 (No-Offset) 방식으로 변경하였습니다.  

변경한 이유는 다음과 같습니다. 

### 변경 이유

1. 현재 Trip 목록의 경우, 테이터 추가와 삭제가 이루어지는데 오프셋 방식으로 페이지네이션을 구현하게 되면 다음과 같이 데이터의 중복, 누락 조회가 발생할 수 있습니다.

![image](https://github.com/teamCoSaIn/trilo-be/assets/53935439/1a60f93d-abbf-42d4-b3ed-2ff804465c7a)

2. 오프셋 방식의 경우 결국 offset 부터 limit 까지 모든 row 를 읽어야합니다. 따라서 offset 이 커지면 커질 수록 성능이 저하됩니다.
 
3. 커서 기반 페이지네이션 방식을 도입하면 위와 같은 문제점들을 해결할 수 있습니다. 더불어 저희 서비스의 여행 목록 조회의 경우 순차적으로 조회가 이루어지는 무한 스크롤 방식이므로 커서 기반 페이지네이션 방식을 도입하는데 문제가 없습니다.
 

# 참고 자료

[ 페이징 성능 개선하기 - No Offset 사용하기 - 이동욱님의 블로그](https://jojoldu.tistory.com/528)

[TRL-318]: https://cosain.atlassian.net/browse/TRL-318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ