### PR TITLE
[TRL-319] fix: 임시보관함 목록 페이징 조회 시 커서 기반 페이지네이션 방식으로 조회하도록 변경

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -341,7 +341,7 @@ include::{snippets}/single-trip-query-controller-docs-test/여행_단건_조회/
 ==== 기본 정보
 
 - 메서드 : GET
-- URL : `/api/trips?tripper-id={여행자 ID}&size={요청 데이터 개수}&tripId={조회 기준이 되는 여행 ID}`
+- URL : `/api/trips`
 - 인증 방식 : 엑세스 토큰
 
 ==== 요청
@@ -394,6 +394,9 @@ include::{snippets}/trip-temporary-storage-query-controller-docs-test/임시보�
 include::{snippets}/trip-temporary-storage-query-controller-docs-test/임시보관함_조회/http-request.adoc[]
 ===== 응답
 include::{snippets}/trip-temporary-storage-query-controller-docs-test/임시보관함_조회/http-response.adoc[]
+
+- 첫 페이지 조회 요청 시 커서, 즉 scheduleId를 쿼리 파라미터에 포함하지 않습니다. 일정 정보들이 size 만큼 조회됩니다.
+- 이후 페이지 조회 요청 시 scheduleId 를 쿼리 파라미터에 포함하게 되면 해당 ID에 해당하는 일정보다 큰 순서값을 갖는 일정들이 size 만큼 조회됩니다.
 
 '''
 

--- a/src/main/java/com/cosain/trilo/trip/application/trip/query/service/TemporarySearchService.java
+++ b/src/main/java/com/cosain/trilo/trip/application/trip/query/service/TemporarySearchService.java
@@ -1,10 +1,12 @@
 package com.cosain.trilo.trip.application.trip.query.service;
 
+import com.cosain.trilo.trip.application.exception.ScheduleNotFoundException;
 import com.cosain.trilo.trip.application.exception.TripNotFoundException;
 import com.cosain.trilo.trip.application.trip.query.usecase.TemporarySearchUseCase;
 import com.cosain.trilo.trip.infra.dto.ScheduleSummary;
 import com.cosain.trilo.trip.infra.repository.schedule.ScheduleQueryRepository;
 import com.cosain.trilo.trip.infra.repository.trip.TripQueryRepository;
+import com.cosain.trilo.trip.presentation.trip.query.dto.request.TempSchedulePageCondition;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -18,11 +20,17 @@ public class TemporarySearchService implements TemporarySearchUseCase {
     private final ScheduleQueryRepository scheduleQueryRepository;
 
     @Override
-    public Slice<ScheduleSummary> searchTemporary(Long tripId, Pageable pageable) {
+    public Slice<ScheduleSummary> searchTemporary(Long tripId, TempSchedulePageCondition tempSchedulePageCondition, Pageable pageable) {
 
         verifyTripExists(tripId);
-        Slice<ScheduleSummary> scheduleSummaries = findTemporaryScheduleListByTripId(tripId, pageable);
+        verifyScheduleExists(tempSchedulePageCondition.getScheduleId());
+        Slice<ScheduleSummary> scheduleSummaries = findTemporaryScheduleListByTripId(tripId, tempSchedulePageCondition,pageable);
         return scheduleSummaries;
+    }
+
+    private void verifyScheduleExists(Long scheduleId) {
+        if(scheduleId != null && !scheduleQueryRepository.existById(scheduleId))
+            throw new ScheduleNotFoundException();
     }
 
     private void verifyTripExists(Long tripId) {
@@ -31,8 +39,9 @@ public class TemporarySearchService implements TemporarySearchUseCase {
         }
     }
 
-    private Slice<ScheduleSummary> findTemporaryScheduleListByTripId(Long tripId, Pageable pageable){
-        return scheduleQueryRepository.findTemporaryScheduleListByTripId(tripId, pageable);
+
+    private Slice<ScheduleSummary> findTemporaryScheduleListByTripId(Long tripId, TempSchedulePageCondition tempSchedulePageCondition, Pageable pageable){
+        return scheduleQueryRepository.findTemporaryScheduleListByTripId(tripId, tempSchedulePageCondition, pageable);
     }
 
 

--- a/src/main/java/com/cosain/trilo/trip/application/trip/query/usecase/TemporarySearchUseCase.java
+++ b/src/main/java/com/cosain/trilo/trip/application/trip/query/usecase/TemporarySearchUseCase.java
@@ -1,9 +1,10 @@
 package com.cosain.trilo.trip.application.trip.query.usecase;
 
 import com.cosain.trilo.trip.infra.dto.ScheduleSummary;
+import com.cosain.trilo.trip.presentation.trip.query.dto.request.TempSchedulePageCondition;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface TemporarySearchUseCase {
-    Slice<ScheduleSummary> searchTemporary(Long tripId, Pageable pageable);
+    Slice<ScheduleSummary> searchTemporary(Long tripId, TempSchedulePageCondition tempSchedulePageCondition, Pageable pageable);
 }

--- a/src/main/java/com/cosain/trilo/trip/infra/repository/schedule/ScheduleQueryRepository.java
+++ b/src/main/java/com/cosain/trilo/trip/infra/repository/schedule/ScheduleQueryRepository.java
@@ -50,7 +50,7 @@ public class ScheduleQueryRepository {
                 .from(schedule)
                 .where(schedule.trip.id.eq(tripId),
                         schedule.day.id.isNull(),
-                        ltScheduleIndex(scheduleIndex)
+                        gtScheduleIndex(scheduleIndex)
                 )
                 .orderBy(schedule.scheduleIndex.value.asc())
                 .limit(pageable.getPageSize() + 1);
@@ -61,7 +61,7 @@ public class ScheduleQueryRepository {
         return new SliceImpl<>(results, pageable, hasNext);
     }
 
-    private BooleanExpression ltScheduleIndex(ScheduleIndex scheduleIndex){
+    private BooleanExpression gtScheduleIndex(ScheduleIndex scheduleIndex){
         if(scheduleIndex == null) return null;
         return schedule.scheduleIndex.value.gt(scheduleIndex.getValue());
     }

--- a/src/main/java/com/cosain/trilo/trip/infra/repository/schedule/ScheduleQueryRepository.java
+++ b/src/main/java/com/cosain/trilo/trip/infra/repository/schedule/ScheduleQueryRepository.java
@@ -1,20 +1,25 @@
 package com.cosain.trilo.trip.infra.repository.schedule;
 
+import com.cosain.trilo.trip.domain.vo.ScheduleIndex;
 import com.cosain.trilo.trip.infra.dto.QScheduleDetail;
 import com.cosain.trilo.trip.infra.dto.QScheduleSummary;
 import com.cosain.trilo.trip.infra.dto.ScheduleDetail;
 import com.cosain.trilo.trip.infra.dto.ScheduleSummary;
+import com.cosain.trilo.trip.presentation.trip.query.dto.request.TempSchedulePageCondition;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import static com.cosain.trilo.trip.domain.entity.QSchedule.schedule;
+import static com.cosain.trilo.trip.domain.entity.QTrip.trip;
 
 @Repository
 @RequiredArgsConstructor
@@ -30,18 +35,52 @@ public class ScheduleQueryRepository {
                 .fetchOne());
     }
 
-    public Slice<ScheduleSummary> findTemporaryScheduleListByTripId(Long tripId, Pageable pageable) {
+    public Slice<ScheduleSummary> findTemporaryScheduleListByTripId(Long tripId, TempSchedulePageCondition tempSchedulePageCondition, Pageable pageable) {
+
+        Long scheduleId = tempSchedulePageCondition.getScheduleId();
+        ScheduleIndex scheduleIndex = null;
+        if(scheduleId != null){
+             scheduleIndex = query.select(schedule.scheduleIndex)
+                    .from(schedule)
+                    .where(schedule.id.eq(scheduleId))
+                    .fetchOne();
+        }
+
         JPAQuery<ScheduleSummary> jpaQuery = query.select(new QScheduleSummary(schedule.id, schedule.scheduleTitle.value, schedule.place.placeName, schedule.place.placeId, schedule.place.coordinate.latitude, schedule.place.coordinate.longitude))
                 .from(schedule)
-                .where(schedule.trip.id.eq(tripId).and(schedule.day.id.isNull()))
+                .where(schedule.trip.id.eq(tripId),
+                        schedule.day.id.isNull(),
+                        ltScheduleIndex(scheduleIndex)
+                )
                 .orderBy(schedule.scheduleIndex.value.asc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize());
+                .limit(pageable.getPageSize() + 1);
 
-        long totalCount = query.from(schedule)
-                .where(schedule.trip.id.eq(tripId).and(schedule.day.id.isNull()))
-                .fetchCount();
+        List<ScheduleSummary> results = jpaQuery.fetch();
+        boolean hasNext = isHasNext(results, pageable);
 
-        return new PageImpl<>(jpaQuery.fetch(), pageable, totalCount);
+        return new SliceImpl<>(results, pageable, hasNext);
+    }
+
+    private BooleanExpression ltScheduleIndex(ScheduleIndex scheduleIndex){
+        if(scheduleIndex == null) return null;
+        return schedule.scheduleIndex.value.gt(scheduleIndex.getValue());
+    }
+
+    private boolean isHasNext(List<?> results, Pageable pageable){
+        boolean hasNext = false;
+        if(results.size() > pageable.getPageSize()){
+            hasNext = true;
+            results.remove(pageable.getPageSize());
+        }
+        return hasNext;
+    }
+
+    public boolean existById(Long scheduleId) {
+        Integer fetchOne = query.selectOne()
+                .from(schedule)
+                .where(schedule.id.eq(scheduleId))
+                .fetchFirst();
+
+        return fetchOne != null;
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/presentation/trip/query/TripTemporaryStorageQueryController.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/trip/query/TripTemporaryStorageQueryController.java
@@ -2,16 +2,15 @@ package com.cosain.trilo.trip.presentation.trip.query;
 
 import com.cosain.trilo.trip.application.trip.query.usecase.TemporarySearchUseCase;
 import com.cosain.trilo.trip.infra.dto.ScheduleSummary;
+import com.cosain.trilo.trip.presentation.trip.query.dto.request.TempSchedulePageCondition;
 import com.cosain.trilo.trip.presentation.trip.query.dto.response.TemporaryPageResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,8 +20,8 @@ public class TripTemporaryStorageQueryController {
 
     @GetMapping("/api/trips/{tripId}/temporary-storage")
     @ResponseStatus(HttpStatus.OK)
-    public TemporaryPageResponse findTripTemporaryStorage(@PathVariable Long tripId, Pageable pageable) {
-        Slice<ScheduleSummary> scheduleSummaries = temporarySearchUseCase.searchTemporary(tripId, pageable);
+    public TemporaryPageResponse findTripTemporaryStorage(@PathVariable Long tripId, @ModelAttribute @Valid TempSchedulePageCondition tempSchedulePageCondition, Pageable pageable) {
+        Slice<ScheduleSummary> scheduleSummaries = temporarySearchUseCase.searchTemporary(tripId,tempSchedulePageCondition,pageable);
         return TemporaryPageResponse.from(scheduleSummaries);
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/presentation/trip/query/dto/request/TempSchedulePageCondition.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/trip/query/dto/request/TempSchedulePageCondition.java
@@ -1,0 +1,13 @@
+package com.cosain.trilo.trip.presentation.trip.query.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class TempSchedulePageCondition {
+
+    private Long scheduleId;
+
+    public TempSchedulePageCondition(Long scheduleId){
+        this.scheduleId = scheduleId;
+    }
+}

--- a/src/test/java/com/cosain/trilo/unit/trip/application/trip/query/service/TemporarySearchServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/trip/query/service/TemporarySearchServiceTest.java
@@ -1,11 +1,13 @@
 package com.cosain.trilo.unit.trip.application.trip.query.service;
 
+import com.cosain.trilo.trip.application.exception.ScheduleNotFoundException;
 import com.cosain.trilo.trip.application.exception.TripNotFoundException;
 import com.cosain.trilo.trip.application.trip.query.service.TemporarySearchService;
 import com.cosain.trilo.trip.infra.dto.ScheduleSummary;
 import com.cosain.trilo.trip.infra.repository.schedule.ScheduleQueryRepository;
 import com.cosain.trilo.trip.infra.dto.ScheduleDetail;
 import com.cosain.trilo.trip.infra.repository.trip.TripQueryRepository;
+import com.cosain.trilo.trip.presentation.trip.query.dto.request.TempSchedulePageCondition;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -15,13 +17,13 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
+import org.springframework.security.core.parameters.P;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -39,15 +41,19 @@ public class TemporarySearchServiceTest {
     @Test
     void tripId가_유효하고_임시보관함이_비어있지_않으면_페이지_요청의_크기만큼의_ScheduleDetail들을_반환한다(){
         // given
-        Pageable pageable = PageRequest.of(0, 3);
-        ScheduleDetail scheduleDetail1 = new ScheduleDetail(1L, 1L, "제목", "장소", 33.33, 33.33, 1L, "내용");
-        ScheduleDetail scheduleDetail2 = new ScheduleDetail(2L, 1L, "제목", "장소", 33.33, 33.33, 1L, "내용");
-        ScheduleDetail scheduleDetail3 = new ScheduleDetail(3L, 1L, "제목", "장소", 33.33, 33.33, 1L, "내용");
-        given(tripQueryRepository.existById(anyLong())).willReturn(true);
-        given(scheduleQueryRepository.findTemporaryScheduleListByTripId(anyLong(), any())).willReturn(new SliceImpl(List.of(scheduleDetail1, scheduleDetail2, scheduleDetail3)));
+        int size = 3;
+        Long tripId = 1L;
+        Pageable pageable = Pageable.ofSize(size);
+        TempSchedulePageCondition tempSchedulePageCondition = new TempSchedulePageCondition(1L);
+        ScheduleDetail scheduleDetail1 = new ScheduleDetail(2L, 1L, "제목", "장소", 33.33, 33.33, 1L, "내용");
+        ScheduleDetail scheduleDetail2 = new ScheduleDetail(3L, 1L, "제목", "장소", 33.33, 33.33, 1L, "내용");
+        ScheduleDetail scheduleDetail3 = new ScheduleDetail(4L, 1L, "제목", "장소", 33.33, 33.33, 1L, "내용");
+        given(tripQueryRepository.existById(eq(tripId))).willReturn(true);
+        given(scheduleQueryRepository.existById(eq(tempSchedulePageCondition.getScheduleId()))).willReturn(true);
+        given(scheduleQueryRepository.findTemporaryScheduleListByTripId(eq(tripId), eq(tempSchedulePageCondition) ,eq(pageable))).willReturn(new SliceImpl(List.of(scheduleDetail1, scheduleDetail2, scheduleDetail3)));
 
         // when
-        Slice<ScheduleSummary> scheduleSummaries = temporarySearchService.searchTemporary(1L, pageable);
+        Slice<ScheduleSummary> scheduleSummaries = temporarySearchService.searchTemporary(tripId,tempSchedulePageCondition,pageable);
 
         // then
         assertThat(scheduleSummaries.getSize()).isEqualTo(3);
@@ -55,12 +61,28 @@ public class TemporarySearchServiceTest {
     @Test
     void tripId가_유효하지_않다면_TripNotFoundException을_발생시킨다(){
         // given
-        PageRequest pageRequest = PageRequest.of(0, 3);
+        Pageable pageable = PageRequest.of(0, 3);
+        TempSchedulePageCondition tempSchedulePageCondition = new TempSchedulePageCondition(1L);
         given(tripQueryRepository.existById(anyLong())).willReturn(false);
 
         // when & then
-        assertThatThrownBy(() -> temporarySearchService.searchTemporary(1L, pageRequest))
+        assertThatThrownBy(() -> temporarySearchService.searchTemporary(1L, tempSchedulePageCondition, pageable))
                 .isInstanceOf(TripNotFoundException.class);
+    }
+
+    @Test
+    void scheduleId에_해당하는_Schedule이_존재하지_않는다면_ScheduleNotFoundException_에러를_발생시킨다(){
+
+        // given
+        Pageable pageable = Pageable.ofSize(3);
+        TempSchedulePageCondition tempSchedulePageCondition = new TempSchedulePageCondition(1L);
+        given(tripQueryRepository.existById(any())).willReturn(true);
+        given(scheduleQueryRepository.existById(any())).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> temporarySearchService.searchTemporary(1L, tempSchedulePageCondition, pageable))
+                .isInstanceOf(ScheduleNotFoundException.class);
+
     }
 
 

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/query/TripTemporaryStorageQueryControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/query/TripTemporaryStorageQueryControllerTest.java
@@ -4,10 +4,12 @@ import com.cosain.trilo.support.RestControllerTest;
 import com.cosain.trilo.trip.application.trip.query.usecase.TemporarySearchUseCase;
 import com.cosain.trilo.trip.infra.dto.ScheduleSummary;
 import com.cosain.trilo.trip.presentation.trip.query.TripTemporaryStorageQueryController;
+import com.cosain.trilo.trip.presentation.trip.query.dto.request.TempSchedulePageCondition;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.http.HttpHeaders;
@@ -39,15 +41,20 @@ class TripTemporaryStorageQueryControllerTest extends RestControllerTest {
     public void findTripTemporaryStorage_with_authorizedUser() throws Exception {
 
         // given
+        int size = 2;
         Long tripId = 1L;
+        Long scheduleId = 1L;
         mockingForLoginUserAnnotation();
-        ScheduleSummary scheduleSummary1 = new ScheduleSummary(1L, null, "제목","장소 식별자", 33.33, 33.33);
-        ScheduleSummary scheduleSummary2 = new ScheduleSummary(2L, null, "제목","장소 식별자",33.33, 33.33);
+        ScheduleSummary scheduleSummary1 = new ScheduleSummary(2L, null, "제목","장소 식별자", 33.33, 33.33);
+        ScheduleSummary scheduleSummary2 = new ScheduleSummary(3L, null, "제목","장소 식별자",33.33, 33.33);
         SliceImpl<ScheduleSummary> scheduleSummaries = new SliceImpl<>(List.of(scheduleSummary1, scheduleSummary2));
-        given(temporarySearchUseCase.searchTemporary(eq(tripId), any(Pageable.class))).willReturn(scheduleSummaries);
+        Pageable pageable = PageRequest.ofSize(size);
+        given(temporarySearchUseCase.searchTemporary(eq(tripId), any(TempSchedulePageCondition.class), eq(pageable))).willReturn(scheduleSummaries);
 
         mockMvc.perform(get("/api/trips/1/temporary-storage")
                         .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .param("size", String.valueOf(size))
+                        .param("scheduleId", String.valueOf(scheduleId))
                         .characterEncoding(StandardCharsets.UTF_8)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.tempSchedules").isArray())

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/query/docs/TripTemporaryStorageQueryControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/query/docs/TripTemporaryStorageQueryControllerDocsTest.java
@@ -4,6 +4,8 @@ import com.cosain.trilo.support.RestDocsTestSupport;
 import com.cosain.trilo.trip.application.trip.query.usecase.TemporarySearchUseCase;
 import com.cosain.trilo.trip.infra.dto.ScheduleSummary;
 import com.cosain.trilo.trip.presentation.trip.query.TripTemporaryStorageQueryController;
+import com.cosain.trilo.trip.presentation.trip.query.dto.request.TempSchedulePageCondition;
+import com.cosain.trilo.trip.presentation.trip.query.dto.request.TripPageCondition;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -35,20 +37,22 @@ public class TripTemporaryStorageQueryControllerDocsTest extends RestDocsTestSup
 
     @Test
     void 임시보관함_조회() throws Exception{
+
+        // given
         Long tripId = 1L;
-        int page = 0;
+        Long scheduleId = 1L;
         int size = 2;
         mockingForLoginUserAnnotation();
-        ScheduleSummary scheduleSummary1 = new ScheduleSummary(1L, "제목", "장소 이름","장소 식별자", 33.33, 33.33);
-        ScheduleSummary scheduleSummary2 = new ScheduleSummary(2L, "제목", "장소 이름","장소 식별자",33.33, 33.33);
+        ScheduleSummary scheduleSummary1 = new ScheduleSummary(2L, "제목", "장소 이름","장소 식별자", 33.33, 33.33);
+        ScheduleSummary scheduleSummary2 = new ScheduleSummary(3L, "제목", "장소 이름","장소 식별자",33.33, 33.33);
         SliceImpl<ScheduleSummary> scheduleSummaries = new SliceImpl<>(List.of(scheduleSummary1, scheduleSummary2));
-        Pageable pageable = PageRequest.of(page, size);
-        given(temporarySearchUseCase.searchTemporary(eq(tripId), eq(pageable))).willReturn(scheduleSummaries);
+        Pageable pageable = PageRequest.ofSize(size);
+        given(temporarySearchUseCase.searchTemporary(eq(tripId), any(TempSchedulePageCondition.class),eq(pageable))).willReturn(scheduleSummaries);
 
         mockMvc.perform(RestDocumentationRequestBuilders.get("/api/trips/{tripId}/temporary-storage", tripId)
                 .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
-                .param("page", String.valueOf(page))
                 .param("size", String.valueOf(size))
+                .param("scheduleId", String.valueOf(scheduleId))
                 .characterEncoding(StandardCharsets.UTF_8)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(restDocs.document(
@@ -57,7 +61,7 @@ public class TripTemporaryStorageQueryControllerDocsTest extends RestDocsTestSup
                                         .description("Bearer 타입 AccessToken")
                         ),
                         queryParameters(
-                                parameterWithName("page").description("요청할 페이지"),
+                                parameterWithName("scheduleId").description("기준이 되는 일정 ID (하단 설명 참고)"),
                                 parameterWithName("size").description("가져올 데이터 개수")
                         ),
                         pathParameters(

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/query/docs/TripTemporaryStorageQueryControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/query/docs/TripTemporaryStorageQueryControllerDocsTest.java
@@ -61,7 +61,7 @@ public class TripTemporaryStorageQueryControllerDocsTest extends RestDocsTestSup
                                         .description("Bearer 타입 AccessToken")
                         ),
                         queryParameters(
-                                parameterWithName("scheduleId").description("기준이 되는 일정 ID (하단 설명 참고)"),
+                                parameterWithName("scheduleId").optional().description("기준이 되는 일정 ID (하단 설명 참고)"),
                                 parameterWithName("size").description("가져올 데이터 개수")
                         ),
                         pathParameters(


### PR DESCRIPTION
# JIRA 티켓
[TRL-319]

# 변경사항

- [x] 임시보관함 목록 조회 페이징 조회 시 커서 기반 페이지네이션 방식으로 조회하도록 변경
- [x] API 문서에 설명 추가

# 추가 설명

앞서 PR #111  과 동일하게 임시보관함 목록 조회도 원래 오프셋 기반 페이지네이션 방식으로 구현이 되어 있었습니다. 하지만 아래와 같은 이유로 커서 기반 페이지네이션 방식으로 변경하게 되었습니다.

### 변경 이유

1. Drag & Drop 및 삭제 가능으로 인해 데이터 추가 변경이 잦으므로 다음 페이지 요청시 데이터 중복 및 누락 조회 가능성이 있습니다.
2. OffSet 이 증가하면 증가할 수록 조회 성능 저하가 일어나게 됩니다.


구현에 있어서 특이 사항은 다음과 같습니다.

### 특이 사항

- 임시 보관함 조회의 경우 API 컨슈머 입장에서 `cursor` 에 해당하는 `schedule_index` 알지 못합니다. 따라서 `scheduleId` 값을 쿼리 파라미터로 받아와서 `schedule_index` 를 조회하여 찾아오는 쿼리 한방이 추가로 날아가게 됩니다. ( PK 값이라 인덱스를 탈 수있어서 추가적인 index 테이블 구성을 필요하지 않을 것 같습니다 ). 

- 가독성을 위해 BooleanExpression 을 사용했습니다.


[TRL-319]: https://cosain.atlassian.net/browse/TRL-319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ