### PR TITLE
[TRL-319] fix: 사용자 여행 목록 조회 시 여행 ID 를 id 가 아닌 tripId 로 반환

### DIFF
--- a/src/main/java/com/cosain/trilo/trip/infra/dto/TripSummary.java
+++ b/src/main/java/com/cosain/trilo/trip/infra/dto/TripSummary.java
@@ -8,7 +8,7 @@ import java.time.LocalDate;
 @Getter
 public class TripSummary {
 
-    private long id;
+    private long tripId;
     private long tripperId;
     private String title;
     private String status;
@@ -16,8 +16,8 @@ public class TripSummary {
     private LocalDate endDate;
 
     @QueryProjection
-    public TripSummary(long id, long tripperId, String title, Enum status, LocalDate startDate, LocalDate endDate) {
-        this.id = id;
+    public TripSummary(long tripId, long tripperId, String title, Enum status, LocalDate startDate, LocalDate endDate) {
+        this.tripId = tripId;
         this.tripperId = tripperId;
         this.title = title;
         this.status = status.name();

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/query/docs/TripperTripListQueryControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/query/docs/TripperTripListQueryControllerDocsTest.java
@@ -79,7 +79,7 @@ public class TripperTripListQueryControllerDocsTest extends RestDocsTestSupport 
                         )
                 )).andDo(restDocs.document(
                         responseFields(beneathPath("trips").withSubsectionId("trips"),
-                                fieldWithPath("id").type(NUMBER).description("여행 ID"),
+                                fieldWithPath("tripId").type(NUMBER).description("여행 ID"),
                                 fieldWithPath("tripperId").type(NUMBER).description("여행자 ID"),
                                 fieldWithPath("title").type(STRING).description("제목"),
                                 fieldWithPath("status").type(STRING).description("여행 상태"),

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/query/docs/TripperTripListQueryControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/query/docs/TripperTripListQueryControllerDocsTest.java
@@ -81,7 +81,7 @@ public class TripperTripListQueryControllerDocsTest extends RestDocsTestSupport 
                         responseFields(beneathPath("trips").withSubsectionId("trips"),
                                 fieldWithPath("tripId").type(NUMBER).description("여행 ID"),
                                 fieldWithPath("tripperId").type(NUMBER).description("여행자 ID"),
-                                fieldWithPath("title").type(STRING).description("제목"),
+                                fieldWithPath("title").type(STRING).description("여행 제목"),
                                 fieldWithPath("status").type(STRING).description("여행 상태"),
                                 fieldWithPath("startDate").type(STRING).description("여행 시작 날짜"),
                                 fieldWithPath("endDate").type(STRING).description("여행 끝 날짜")


### PR DESCRIPTION
# JIRA 티켓
[TRL-329]

# 작업 내역

사용자 여행 목록 조회 시 여행 ID 를 id 가 아닌 tripId 로 반환하도록 수정했습니다.

[TRL-329]: https://cosain.atlassian.net/browse/TRL-329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ