### PR TITLE
[TRL-331] fix: Auth 응답에서 사용자 ID 를 userId 로 반환하도록 수정

### DIFF
--- a/src/main/java/com/cosain/trilo/auth/application/AuthService.java
+++ b/src/main/java/com/cosain/trilo/auth/application/AuthService.java
@@ -36,9 +36,9 @@ public class AuthService {
     public ReIssueAccessTokenResult reissueAccessToken(String refreshToken){
         checkIfValidTokenOrThrow(refreshToken);
         checkTokenExistenceOrThrow(refreshToken);
-        Long id = tokenAnalyzer.getUserIdFromToken(refreshToken);
-        String accessToken = tokenProvider.createAccessTokenById(id);
-        return ReIssueAccessTokenResult.of(accessToken, id);
+        Long userId = tokenAnalyzer.getUserIdFromToken(refreshToken);
+        String accessToken = tokenProvider.createAccessTokenById(userId);
+        return ReIssueAccessTokenResult.of(accessToken, userId);
     }
     private void checkIfValidTokenOrThrow(String refreshToken){
         if(!tokenAnalyzer.validateToken(refreshToken)){

--- a/src/main/java/com/cosain/trilo/auth/application/dto/ReIssueAccessTokenResult.java
+++ b/src/main/java/com/cosain/trilo/auth/application/dto/ReIssueAccessTokenResult.java
@@ -6,13 +6,13 @@ import lombok.Getter;
 public class ReIssueAccessTokenResult {
 
     private String accessToken;
-    private Long id;
+    private Long userId;
 
-    private ReIssueAccessTokenResult(String accessToken, Long id) {
+    private ReIssueAccessTokenResult(String accessToken, Long userId) {
         this.accessToken = accessToken;
-        this.id = id;
+        this.userId = userId;
     }
-    public static ReIssueAccessTokenResult of(String accessToken, Long id) {
-        return new ReIssueAccessTokenResult(accessToken, id);
+    public static ReIssueAccessTokenResult of(String accessToken, Long userId) {
+        return new ReIssueAccessTokenResult(accessToken, userId);
     }
 }

--- a/src/main/java/com/cosain/trilo/auth/presentation/dto/AuthResponse.java
+++ b/src/main/java/com/cosain/trilo/auth/presentation/dto/AuthResponse.java
@@ -9,19 +9,19 @@ public class AuthResponse {
 
     private String authType;
     private String accessToken;
-    private Long id;
+    private Long userId;
 
     public static AuthResponse from(LoginResult result) {
         return new AuthResponse(result.getAccessToken(), result.getId());
     }
 
     public static AuthResponse from(ReIssueAccessTokenResult result){
-        return new AuthResponse(result.getAccessToken(), result.getId());
+        return new AuthResponse(result.getAccessToken(), result.getUserId());
     }
 
-    private AuthResponse(String accessToken, Long id){
+    private AuthResponse(String accessToken, Long userId){
         this.authType = "Bearer";
         this.accessToken = accessToken;
-        this.id = id;
+        this.userId = userId;
     }
 }

--- a/src/test/java/com/cosain/trilo/unit/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/auth/application/AuthServiceTest.java
@@ -56,7 +56,7 @@ class AuthServiceTest {
         given(tokenProvider.createAccessTokenById(anyLong())).willReturn(ACCESS_TOKEN);
 
         ReIssueAccessTokenResult result = authService.reissueAccessToken(any());
-        Assertions.assertThat(result.getId()).isEqualTo(id);
+        Assertions.assertThat(result.getUserId()).isEqualTo(id);
         Assertions.assertThat(result.getAccessToken()).isEqualTo(ACCESS_TOKEN);
     }
 

--- a/src/test/java/com/cosain/trilo/unit/auth/presentation/docs/AuthRestControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/auth/presentation/docs/AuthRestControllerDocsTest.java
@@ -50,7 +50,7 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
                                 cookieWithName("refreshToken").description("접근 토큰 발급에 사용될 재발급 토큰")
                         ),
                         responseFields(
-                                fieldWithPath("id").type(NUMBER).description("사용자 ID"),
+                                fieldWithPath("userId").type(NUMBER).description("사용자 ID"),
                                 fieldWithPath("authType").type(STRING).description("인증 타입 (Bearer)"),
                                 fieldWithPath("accessToken").type(STRING).description("재발급한 접근 토큰")
                         )
@@ -110,7 +110,7 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
                             fieldWithPath("redirect_uri").type(STRING).description("인증 코드 발급에 사용했던 Redirect Uri")
                     ),
                     responseFields(
-                            fieldWithPath("id").type(NUMBER).description("사용자 ID"),
+                            fieldWithPath("userId").type(NUMBER).description("사용자 ID"),
                             fieldWithPath("authType").type(STRING).description("인증 타입 (Bearer)"),
                             fieldWithPath("accessToken").description("AccessToken")
                     ),
@@ -138,7 +138,7 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
                            fieldWithPath("state").type(STRING).description("Authorization Code 발급시 전달했던 redirect_uri")
                    ),
                    responseFields(
-                           fieldWithPath("id").type(NUMBER).description("사용자 ID"),
+                           fieldWithPath("userId").type(NUMBER).description("사용자 ID"),
                            fieldWithPath("authType").type(STRING).description("인증 타입 (Bearer)"),
                            fieldWithPath("accessToken").description("AccessToken")
                    ),
@@ -165,7 +165,7 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
                                 fieldWithPath("redirect_uri").type(STRING).description("Authorization Code 발급시 전달했던 redirect_uri")
                         ),
                         responseFields(
-                                fieldWithPath("id").type(NUMBER).description("사용자 ID"),
+                                fieldWithPath("userId").type(NUMBER).description("사용자 ID"),
                                 fieldWithPath("authType").type(STRING).description("인증 타입 (Bearer)"),
                                 fieldWithPath("accessToken").description("AccessToken")
                         ),


### PR DESCRIPTION
# JIRA 티켓
[TRL-331] 

# 작업 내역

Auth 응답에서 사용자 ID 를 userId 로 반환하도록 수정했습니다.

[TRL-331]: https://cosain.atlassian.net/browse/TRL-331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ