### PR TITLE
[TRL-332] docs: 일정 조회 API 문서 scheduleId 설명 수정

### DIFF
--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/query/docs/SingleScheduleQueryControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/query/docs/SingleScheduleQueryControllerDocsTest.java
@@ -58,7 +58,7 @@ public class SingleScheduleQueryControllerDocsTest extends RestDocsTestSupport {
                                 parameterWithName("scheduleId").description("조회할 일정 ID")
                         ),
                         responseFields(
-                                fieldWithPath("scheduleId").type(NUMBER).description("여행 ID"),
+                                fieldWithPath("scheduleId").type(NUMBER).description("일정 ID"),
                                 fieldWithPath("dayId").type(NUMBER).description("Day ID"),
                                 fieldWithPath("title").type(STRING).description("일정 제목"),
                                 fieldWithPath("placeName").type(STRING).description("장소 이름"),


### PR DESCRIPTION
# JIRA 티켓
[TRL-332]

# 작업 내역

API 문서에서 일정 상세 조회 response-field 의  `scheduleId` 에 대한 설명이 **여행 ID** 라고 잘못 표기되어 있었습니다. 따라서 **일정 ID** 로 수정했습니다. 

[TRL-332]: https://cosain.atlassian.net/browse/TRL-332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ