### PR TITLE
[TRL-306] fix: 일정 상세 정보 조회 시 시작 시간, 끝 시간 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -687,6 +687,10 @@ include::{snippets}/single-schedule-query-controller-docs-test/일정_단건_조
 ==== 응답
 ===== 본문
 include::{snippets}/single-schedule-query-controller-docs-test/일정_단건_조회/response-fields.adoc[]
+===== Coordinate
+include::{snippets}/single-schedule-query-controller-docs-test/일정_단건_조회/response-fields-coordinate.adoc[]
+===== ScheduleTime
+include::{snippets}/single-schedule-query-controller-docs-test/일정_단건_조회/response-fields-scheduleTime.adoc[]
 
 ==== 예제
 ===== 요청

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -688,10 +688,9 @@ include::{snippets}/single-schedule-query-controller-docs-test/일정_단건_조
 ===== 본문
 include::{snippets}/single-schedule-query-controller-docs-test/일정_단건_조회/response-fields.adoc[]
 ===== Coordinate
-include::{snippets}/single-schedule-query-controller-docs-test/일정_단건_조회/response-fields-coordinate.adoc[]
+include::{snippets}/single-schedule-query-controller-docs-test/일정_단건_조회/response-fields-beneath-coordinate.adoc[]
 ===== ScheduleTime
-include::{snippets}/single-schedule-query-controller-docs-test/일정_단건_조회/response-fields-scheduleTime.adoc[]
-
+include::{snippets}/single-schedule-query-controller-docs-test/일정_단건_조회/response-fields-beneath-scheduleTime.adoc[]
 ==== 예제
 ===== 요청
 include::{snippets}/single-schedule-query-controller-docs-test/일정_단건_조회/http-request.adoc[]

--- a/src/main/java/com/cosain/trilo/trip/infra/dto/ScheduleDetail.java
+++ b/src/main/java/com/cosain/trilo/trip/infra/dto/ScheduleDetail.java
@@ -3,6 +3,8 @@ package com.cosain.trilo.trip.infra.dto;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 
+import java.time.LocalTime;
+
 @Getter
 public class ScheduleDetail {
     private long scheduleId;
@@ -12,9 +14,10 @@ public class ScheduleDetail {
     private Coordinate coordinate;
     private long order;
     private String content;
+    private ScheduleTime scheduleTime;
 
     @QueryProjection
-    public ScheduleDetail(long scheduleId, Long dayId, String title, String placeName, double latitude, double longitude, long order, String content) {
+    public ScheduleDetail(long scheduleId, Long dayId, String title, String placeName, double latitude, double longitude, long order, String content, LocalTime startTime, LocalTime endTime) {
         this.scheduleId = scheduleId;
         this.dayId = dayId;
         this.title = title;
@@ -22,5 +25,6 @@ public class ScheduleDetail {
         this.coordinate = Coordinate.from(latitude, longitude);
         this.order = order;
         this.content = content;
+        this.scheduleTime = ScheduleTime.of(startTime, endTime);
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/infra/dto/ScheduleTime.java
+++ b/src/main/java/com/cosain/trilo/trip/infra/dto/ScheduleTime.java
@@ -1,0 +1,20 @@
+package com.cosain.trilo.trip.infra.dto;
+
+import lombok.Getter;
+
+import java.time.LocalTime;
+
+@Getter
+public class ScheduleTime {
+    private LocalTime startTime;
+    private LocalTime endTime;
+
+    private ScheduleTime(LocalTime startTime, LocalTime endTime){
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    public static ScheduleTime of(LocalTime startTime, LocalTime endTime){
+        return new ScheduleTime(startTime, endTime);
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/infra/repository/schedule/ScheduleQueryRepository.java
+++ b/src/main/java/com/cosain/trilo/trip/infra/repository/schedule/ScheduleQueryRepository.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.cosain.trilo.trip.domain.entity.QSchedule.schedule;
-import static com.cosain.trilo.trip.domain.entity.QTrip.trip;
 
 @Repository
 @RequiredArgsConstructor
@@ -29,7 +28,7 @@ public class ScheduleQueryRepository {
 
     public Optional<ScheduleDetail> findScheduleDetailById(Long scheduleId) {
         return Optional.ofNullable(query.select(
-            new QScheduleDetail(schedule.id, schedule.day.id, schedule.scheduleTitle.value, schedule.place.placeName, schedule.place.coordinate.latitude, schedule.place.coordinate.longitude, schedule.scheduleIndex.value, schedule.scheduleContent.value))
+            new QScheduleDetail(schedule.id, schedule.day.id, schedule.scheduleTitle.value, schedule.place.placeName, schedule.place.coordinate.latitude, schedule.place.coordinate.longitude, schedule.scheduleIndex.value, schedule.scheduleContent.value, schedule.scheduleTime.startTime, schedule.scheduleTime.endTime))
                 .from(schedule)
                 .where(schedule.id.eq(scheduleId))
                 .fetchOne());

--- a/src/test/java/com/cosain/trilo/unit/trip/application/schedule/query/service/ScheduleDetailSearchServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/schedule/query/service/ScheduleDetailSearchServiceTest.java
@@ -12,6 +12,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,7 +33,7 @@ public class ScheduleDetailSearchServiceTest {
     @DisplayName("정상 호출 및 반환 테스트")
     void searchScheduleDetailTest(){
         // given
-        ScheduleDetail scheduleDetail = new ScheduleDetail(1L, 1L, "제목", "장소 이름", 24.24, 24.24, 3L, "내용");
+        ScheduleDetail scheduleDetail = new ScheduleDetail(1L, 1L, "제목", "장소 이름", 24.24, 24.24, 3L, "내용", LocalTime.of(15, 30), LocalTime.of(16, 0));
         given(scheduleQueryRepository.findScheduleDetailById(anyLong())).willReturn(Optional.of(scheduleDetail));
 
         // when

--- a/src/test/java/com/cosain/trilo/unit/trip/application/trip/query/service/TemporarySearchServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/trip/query/service/TemporarySearchServiceTest.java
@@ -3,9 +3,9 @@ package com.cosain.trilo.unit.trip.application.trip.query.service;
 import com.cosain.trilo.trip.application.exception.ScheduleNotFoundException;
 import com.cosain.trilo.trip.application.exception.TripNotFoundException;
 import com.cosain.trilo.trip.application.trip.query.service.TemporarySearchService;
+import com.cosain.trilo.trip.infra.dto.ScheduleDetail;
 import com.cosain.trilo.trip.infra.dto.ScheduleSummary;
 import com.cosain.trilo.trip.infra.repository.schedule.ScheduleQueryRepository;
-import com.cosain.trilo.trip.infra.dto.ScheduleDetail;
 import com.cosain.trilo.trip.infra.repository.trip.TripQueryRepository;
 import com.cosain.trilo.trip.presentation.trip.query.dto.request.TempSchedulePageCondition;
 import org.junit.jupiter.api.Test;
@@ -17,8 +17,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
-import org.springframework.security.core.parameters.P;
 
+import java.time.LocalTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,9 +45,9 @@ public class TemporarySearchServiceTest {
         Long tripId = 1L;
         Pageable pageable = Pageable.ofSize(size);
         TempSchedulePageCondition tempSchedulePageCondition = new TempSchedulePageCondition(1L);
-        ScheduleDetail scheduleDetail1 = new ScheduleDetail(2L, 1L, "제목", "장소", 33.33, 33.33, 1L, "내용");
-        ScheduleDetail scheduleDetail2 = new ScheduleDetail(3L, 1L, "제목", "장소", 33.33, 33.33, 1L, "내용");
-        ScheduleDetail scheduleDetail3 = new ScheduleDetail(4L, 1L, "제목", "장소", 33.33, 33.33, 1L, "내용");
+        ScheduleDetail scheduleDetail1 = new ScheduleDetail(2L, 1L, "제목", "장소", 33.33, 33.33, 1L, "내용", LocalTime.of(12, 10), LocalTime.of(13, 30));
+        ScheduleDetail scheduleDetail2 = new ScheduleDetail(3L, 1L, "제목", "장소", 33.33, 33.33, 1L, "내용", LocalTime.of(15, 0 ), LocalTime.of(16, 0));
+        ScheduleDetail scheduleDetail3 = new ScheduleDetail(4L, 1L, "제목", "장소", 33.33, 33.33, 1L, "내용", LocalTime.of(16, 0), LocalTime.of(17, 0));
         given(tripQueryRepository.existById(eq(tripId))).willReturn(true);
         given(scheduleQueryRepository.existById(eq(tempSchedulePageCondition.getScheduleId()))).willReturn(true);
         given(scheduleQueryRepository.findTemporaryScheduleListByTripId(eq(tripId), eq(tempSchedulePageCondition) ,eq(pageable))).willReturn(new SliceImpl(List.of(scheduleDetail1, scheduleDetail2, scheduleDetail3)));

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/query/SingleScheduleQueryControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/query/SingleScheduleQueryControllerTest.java
@@ -13,6 +13,8 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithAnonymousUser;
 
 import java.nio.charset.StandardCharsets;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
@@ -34,11 +36,12 @@ class SingleScheduleQueryControllerTest extends RestControllerTest {
     @DisplayName("인증된 사용자 요청 -> 일정 단건 조회")
     public void findSingleSchedule_with_authorizedUser() throws Exception {
 
+        Long scheduleId = 1L;
         mockingForLoginUserAnnotation();
-        ScheduleDetail scheduleDetail = new ScheduleDetail(1L, 1L, "제목", "장소 이름", 23.23, 23.23, 1L, "내용");
+        ScheduleDetail scheduleDetail = new ScheduleDetail(scheduleId, 1L, "제목", "장소 이름", 23.23, 23.23, 1L, "내용", LocalTime.of(15, 0), LocalTime.of(15, 30));
         given(scheduleDetailSearchUseCase.searchScheduleDetail(anyLong())).willReturn(scheduleDetail);
 
-        mockMvc.perform(get("/api/schedules/1")
+        mockMvc.perform(get("/api/schedules/{scheduleId}", scheduleId)
                         .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
                         .characterEncoding(StandardCharsets.UTF_8)
                         .contentType(MediaType.APPLICATION_JSON))
@@ -48,7 +51,9 @@ class SingleScheduleQueryControllerTest extends RestControllerTest {
                 .andExpect(jsonPath("$.title").value(scheduleDetail.getTitle()))
                 .andExpect(jsonPath("$.dayId").value(scheduleDetail.getDayId()))
                 .andExpect(jsonPath("$.coordinate.latitude").value(scheduleDetail.getCoordinate().getLatitude()))
-                .andExpect(jsonPath("$.coordinate.longitude").value(scheduleDetail.getCoordinate().getLongitude()));
+                .andExpect(jsonPath("$.coordinate.longitude").value(scheduleDetail.getCoordinate().getLongitude()))
+                .andExpect(jsonPath("$.scheduleTime.startTime").value(scheduleDetail.getScheduleTime().getStartTime().format(DateTimeFormatter.ofPattern("HH:mm:ss"))))
+                .andExpect(jsonPath("$.scheduleTime.endTime").value(scheduleDetail.getScheduleTime().getEndTime().format(DateTimeFormatter.ofPattern("HH:mm:ss"))));
 
     }
 

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/query/docs/SingleScheduleQueryControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/query/docs/SingleScheduleQueryControllerDocsTest.java
@@ -12,19 +12,16 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 
 import java.nio.charset.StandardCharsets;
+import java.time.LocalTime;
 
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
-import static org.springframework.restdocs.payload.JsonFieldType.STRING;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(SingleScheduleQueryController.class)
@@ -41,7 +38,7 @@ public class SingleScheduleQueryControllerDocsTest extends RestDocsTestSupport {
 
         Long scheduleId = 1L;
         mockingForLoginUserAnnotation();
-        ScheduleDetail scheduleDetail = new ScheduleDetail(scheduleId, 1L, "제목", "장소 이름", 23.23, 23.23, 1L, "내용");
+        ScheduleDetail scheduleDetail = new ScheduleDetail(scheduleId, 1L, "제목", "장소 이름", 23.23, 23.23, 1L, "내용", LocalTime.of(15, 0), LocalTime.of(15, 30));
         given(scheduleDetailSearchUseCase.searchScheduleDetail(anyLong())).willReturn(scheduleDetail);
 
         mockMvc.perform(RestDocumentationRequestBuilders.get(BASE_URL + "/{scheduleId}", scheduleId)
@@ -62,11 +59,20 @@ public class SingleScheduleQueryControllerDocsTest extends RestDocsTestSupport {
                                 fieldWithPath("dayId").type(NUMBER).description("Day ID"),
                                 fieldWithPath("title").type(STRING).description("일정 제목"),
                                 fieldWithPath("placeName").type(STRING).description("장소 이름"),
-                                fieldWithPath("coordinate.latitude").type(NUMBER).description("위도"),
-                                fieldWithPath("coordinate.longitude").type(NUMBER).description("경도"),
                                 fieldWithPath("order").type(NUMBER).description("일정 순서"),
-                                fieldWithPath("content").type(STRING).description("일정 내용")
-
+                                fieldWithPath("content").type(STRING).description("일정 내용"),
+                                subsectionWithPath("coordinate").type(OBJECT).description("장소의 좌표"),
+                                subsectionWithPath("scheduleTime").type(OBJECT).description("일정 시간 계획")
+                        ),
+                        responseFields(
+                                beneathPath("coordinate").withSubsectionId("coordinate"),
+                                fieldWithPath("latitude").type(NUMBER).description("위도"),
+                                fieldWithPath("longitude").type(NUMBER).description("경도")
+                        ),
+                        responseFields(
+                                beneathPath("scheduleTime").withSubsectionId("scheduleTime"),
+                                fieldWithPath("startTime").type(STRING).description("일정 시작 시간"),
+                                fieldWithPath("endTime").type(STRING).description("일정 종료 시간")
                         )
                 ));
     }

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/query/docs/SingleScheduleQueryControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/query/docs/SingleScheduleQueryControllerDocsTest.java
@@ -61,19 +61,23 @@ public class SingleScheduleQueryControllerDocsTest extends RestDocsTestSupport {
                                 fieldWithPath("placeName").type(STRING).description("장소 이름"),
                                 fieldWithPath("order").type(NUMBER).description("일정 순서"),
                                 fieldWithPath("content").type(STRING).description("일정 내용"),
-                                subsectionWithPath("coordinate").type(OBJECT).description("장소의 좌표"),
-                                subsectionWithPath("scheduleTime").type(OBJECT).description("일정 시간 계획")
+                                fieldWithPath("coordinate").type("Coordinate").description("장소의 좌표"),
+                                fieldWithPath("coordinate.latitude").ignored(),
+                                fieldWithPath("coordinate.longitude").ignored(),
+                                fieldWithPath("scheduleTime").type("ScheduleTime").description("일정 시간 계획"),
+                                fieldWithPath("scheduleTime.startTime").ignored(),
+                                fieldWithPath("scheduleTime.endTime").ignored()
                         ),
-                        responseFields(
-                                beneathPath("coordinate").withSubsectionId("coordinate"),
+                        responseFields(beneathPath("coordinate"),
                                 fieldWithPath("latitude").type(NUMBER).description("위도"),
                                 fieldWithPath("longitude").type(NUMBER).description("경도")
-                        ),
-                        responseFields(
-                                beneathPath("scheduleTime").withSubsectionId("scheduleTime"),
+                        )
+                        ,responseFields(beneathPath("scheduleTime"),
                                 fieldWithPath("startTime").type(STRING).description("일정 시작 시간"),
                                 fieldWithPath("endTime").type(STRING).description("일정 종료 시간")
                         )
+
                 ));
+
     }
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/query/docs/SingleScheduleQueryControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/query/docs/SingleScheduleQueryControllerDocsTest.java
@@ -61,10 +61,10 @@ public class SingleScheduleQueryControllerDocsTest extends RestDocsTestSupport {
                                 fieldWithPath("placeName").type(STRING).description("장소 이름"),
                                 fieldWithPath("order").type(NUMBER).description("일정 순서"),
                                 fieldWithPath("content").type(STRING).description("일정 내용"),
-                                fieldWithPath("coordinate").type("Coordinate").description("장소의 좌표"),
+                                fieldWithPath("coordinate").type("Coordinate").description("장소의 좌표 ( 하단 표 참고 )"),
                                 fieldWithPath("coordinate.latitude").ignored(),
                                 fieldWithPath("coordinate.longitude").ignored(),
-                                fieldWithPath("scheduleTime").type("ScheduleTime").description("일정 시간 계획"),
+                                fieldWithPath("scheduleTime").type("ScheduleTime").description("일정 시간 계획 ( 하단 표 참고 )"),
                                 fieldWithPath("scheduleTime.startTime").ignored(),
                                 fieldWithPath("scheduleTime.endTime").ignored()
                         ),


### PR DESCRIPTION
# JIRA 티켓
[TRL-306] 

# 작업 내역

FE 요구사항에 맞춰 일정 상세 정보 조회 시 일정 시작 시간과 일정 끝 시간과 함께 반환하도록 수정했습니다.

[TRL-306]: https://cosain.atlassian.net/browse/TRL-306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ