### PR TITLE
[TRL-347] refactor: 여행 이미지 전체 경로를 가져오는 메서드 분리

### DIFF
--- a/src/main/java/com/cosain/trilo/trip/application/trip/command/service/TripImageUpdateService.java
+++ b/src/main/java/com/cosain/trilo/trip/application/trip/command/service/TripImageUpdateService.java
@@ -44,10 +44,10 @@ public class TripImageUpdateService implements TripImageUpdateUseCase {
         validateTripUpdateAuthority(trip, tripperId); // 이미지를 수정할 권한이 있는 지 검증
 
         String uploadName = makeUploadFileName(tripId, file); // 이미지 저장소에 올릴 이름 구성
-        String fullPath = tripImageOutputAdapter.uploadImage(file, uploadName); // 이미지 저장소에 업로드 후, 전체 이미지 경로(fullPath)를 구성
-        trip.changeImage(TripImage.of(uploadName)); // 여행이미지 도메인의 실제 이미지 변경
+        tripImageOutputAdapter.uploadImage(file, uploadName); // 이미지 저장소에 업로드 후, 전체 이미지 경로(fullPath)를 구성
 
-        return fullPath; // 이미지 전체 경로를 반환
+        trip.changeImage(TripImage.of(uploadName)); // 여행이미지 도메인의 실제 이미지 변경
+        return tripImageOutputAdapter.getTripImageFullPath(uploadName); // 이미지 전체 경로를 반환
     }
 
     /**

--- a/src/main/java/com/cosain/trilo/trip/infra/adapter/TripImageOutputAdapter.java
+++ b/src/main/java/com/cosain/trilo/trip/infra/adapter/TripImageOutputAdapter.java
@@ -26,7 +26,7 @@ public class TripImageOutputAdapter {
         this.bucketPath = bucketPath;
     }
 
-    public String uploadImage(ImageFile imageFile, String uploadFileName) {
+    public void uploadImage(ImageFile imageFile, String uploadFileName) {
         ObjectMetadata objectMetadata = makeMetaData(imageFile);
         try {
             amazonS3.putObject(bucketName, uploadFileName, imageFile.getInputStream(), objectMetadata);
@@ -34,7 +34,6 @@ public class TripImageOutputAdapter {
             log.error("[S3] 여행 이미지 업로드 실패", e);
             throw new TripImageUploadFailedException("[S3] 여행 이미지 업로드 실패", e);
         }
-        return getTripImageFullPath(uploadFileName);
     }
 
     /**

--- a/src/main/java/com/cosain/trilo/trip/infra/adapter/TripImageOutputAdapter.java
+++ b/src/main/java/com/cosain/trilo/trip/infra/adapter/TripImageOutputAdapter.java
@@ -9,8 +9,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
-
 @Slf4j
 @Component
 public class TripImageOutputAdapter {
@@ -28,15 +26,24 @@ public class TripImageOutputAdapter {
         this.bucketPath = bucketPath;
     }
 
-    public String uploadImage(ImageFile file, String uploadFileName) {
-        ObjectMetadata objectMetadata = makeMetaData(file);
+    public String uploadImage(ImageFile imageFile, String uploadFileName) {
+        ObjectMetadata objectMetadata = makeMetaData(imageFile);
         try {
-            amazonS3.putObject(bucketName, uploadFileName, file.getInputStream(), objectMetadata);
+            amazonS3.putObject(bucketName, uploadFileName, imageFile.getInputStream(), objectMetadata);
         } catch (SdkClientException e) {
             log.error("[S3] 여행 이미지 업로드 실패", e);
             throw new TripImageUploadFailedException("[S3] 여행 이미지 업로드 실패", e);
         }
-        return bucketPath + uploadFileName;
+        return getTripImageFullPath(uploadFileName);
+    }
+
+    /**
+     * 여행 이미지의 전체 경로(URL)을 얻어옵니다.
+     * @param uploadedFileName
+     * @return
+     */
+    public String getTripImageFullPath(String uploadedFileName) {
+        return bucketPath.concat(uploadedFileName);
     }
 
     private ObjectMetadata makeMetaData(ImageFile file) {

--- a/src/test/java/com/cosain/trilo/unit/trip/application/trip/command/service/TripImageUpdateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/trip/command/service/TripImageUpdateServiceTest.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -57,9 +58,11 @@ public class TripImageUpdateServiceTest {
         Trip trip = unDecidedTripFixture(tripId, tripperId);
         given(tripRepository.findById(eq(tripId))).willReturn(Optional.of(trip));
 
+        willDoNothing().given(tripImageOutputAdapter).uploadImage(any(ImageFile.class), anyString());
+
+
         String fullPath = String.format("https://{여행 이미지 저장소}/trips/%d/{uuid 파일명}.jpeg", tripId);
-        given(tripImageOutputAdapter.uploadImage(any(ImageFile.class), anyString()))
-                .willReturn(fullPath);
+        given(tripImageOutputAdapter.getTripImageFullPath(anyString())).willReturn(fullPath);
 
         // when
         String returnFullPath = tripImageUpdateService.updateTripImage(tripId, tripperId, imageFile);
@@ -69,6 +72,7 @@ public class TripImageUpdateServiceTest {
         assertThat(returnFullPath).isEqualTo(fullPath);
         verify(tripRepository, times(1)).findById(eq(tripId));
         verify(tripImageOutputAdapter, times(1)).uploadImage(any(ImageFile.class), anyString());
+        verify(tripImageOutputAdapter, times(1)).getTripImageFullPath(anyString());
     }
 
     @DisplayName("일치하는 식별자의 여행이 없으면 -> TripNotFoundException")

--- a/src/test/java/com/cosain/trilo/unit/trip/infra/adapter/TripImageOutputAdapterTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/infra/adapter/TripImageOutputAdapterTest.java
@@ -48,12 +48,10 @@ public class TripImageOutputAdapterTest {
 
         String fileName = "xxx/{랜덤 uuid}.jpeg";
 
-        // when
-        String fullPath = tripImageOutputAdapter.uploadImage(imageFile, fileName);
+        tripImageOutputAdapter.uploadImage(imageFile, fileName);
 
         // then
         verify(amazonS3, times(1)).putObject(eq(bucketName), eq(fileName), any(InputStream.class), any(ObjectMetadata.class));
-        assertThat(fullPath).isEqualTo(bucketPath.concat(fileName));
     }
 
     @Test

--- a/src/test/java/com/cosain/trilo/unit/trip/infra/adapter/TripImageOutputAdapterTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/infra/adapter/TripImageOutputAdapterTest.java
@@ -72,6 +72,19 @@ public class TripImageOutputAdapterTest {
         verify(amazonS3, times(1)).putObject(eq(bucketName), eq(fileName), any(InputStream.class), any(ObjectMetadata.class));
     }
 
+    @Test
+    @DisplayName("getTripImageFullPath -> 여행 이미지의 전체 경로를 얻어온다.")
+    void testGetTripImageFullPath() {
+        // given
+        String fileName = "trips/1/12760-fa712554-123.jpeg";
+
+        // when
+        String fullImagePath = tripImageOutputAdapter.getTripImageFullPath(fileName);
+
+        // then
+        assertThat(fullImagePath).isEqualTo(bucketPath.concat(fileName));
+    }
+
     private ImageFile imageFileFixture(String testImageResourceFileName) throws IOException {
         String name = "image";
         String filePath = TEST_RESOURCE_PATH + testImageResourceFileName;


### PR DESCRIPTION
# JIRA 티켓
- [TRL-347]

---

# 작업 내역
- [x] TripImageUpdateOutputAdapter - 이미지 업로드 메서드로부터, 여행 이미지 전체 경로 얻어오는 메서드를 분리 호출하도록 변경

---

# 설명
- 기존에는 여행 이미지를 업로드하는 메서드에서, 여행 이미지의 전체 경로도 함께 얻어오도록 함
- 하지만, 여행 이미지의 전체 경로를 획득하는 기능은 다른 모듈들에서도 필요함
- 이에 따라 여행 이미지를 업로드하는 부분과, 여행 이미지의 전체 경로를 얻어오는 부분을 분리하도록 함


[TRL-347]: https://cosain.atlassian.net/browse/TRL-347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ