### PR TITLE
[TRL-348] feat: 일정 제목/본문 제약 조건 수정

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -476,6 +476,7 @@ include::{snippets}/trip-temporary-storage-query-controller-docs-test/임시보�
 
 ===== 기본값
 - 생성된 일정의 시작시간, 종료시간의 초깃값은 각각 0시 0분입니다.
+- 생성된 일정의 본문은 기본적으로 빈 문자열입니다.
 
 ==== 요청
 ===== 헤더

--- a/src/main/java/com/cosain/trilo/trip/domain/entity/Schedule.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/entity/Schedule.java
@@ -47,6 +47,7 @@ public class Schedule {
                 .day(day)
                 .trip(trip)
                 .scheduleTitle(scheduleTitle)
+                .scheduleContent(ScheduleContent.defaultContent())
                 .place(place)
                 .scheduleIndex(scheduleIndex)
                 .scheduleTime(ScheduleTime.defaultTime())
@@ -62,7 +63,7 @@ public class Schedule {
         this.day = day;
         this.trip = trip;
         this.scheduleTitle = scheduleTitle;
-        this.scheduleContent = scheduleContent;
+        this.scheduleContent = scheduleContent == null ? ScheduleContent.defaultContent() : scheduleContent;
         this.scheduleTime = scheduleTime == null ? ScheduleTime.defaultTime() : scheduleTime;
         this.place = place;
         this.scheduleIndex = scheduleIndex;

--- a/src/main/java/com/cosain/trilo/trip/domain/exception/InvalidScheduleContentException.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/exception/InvalidScheduleContentException.java
@@ -1,0 +1,35 @@
+package com.cosain.trilo.trip.domain.exception;
+
+import com.cosain.trilo.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidScheduleContentException extends CustomException {
+
+    private static final String ERROR_CODE = "schedule-0012";
+    private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+    public InvalidScheduleContentException() {
+    }
+
+    public InvalidScheduleContentException(String debugMessage) {
+        super(debugMessage);
+    }
+
+    public InvalidScheduleContentException(Throwable cause) {
+        super(cause);
+    }
+
+    public InvalidScheduleContentException(String debugMessage, Throwable cause) {
+        super(debugMessage, cause);
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HTTP_STATUS;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/domain/vo/ScheduleContent.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/vo/ScheduleContent.java
@@ -1,5 +1,6 @@
 package com.cosain.trilo.trip.domain.vo;
 
+import com.cosain.trilo.trip.domain.exception.InvalidScheduleContentException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.*;
@@ -11,12 +12,20 @@ import lombok.*;
 @Embeddable
 public class ScheduleContent {
 
+    private static final ScheduleContent DEFAULT_CONTENT = ScheduleContent.of("");
+
     @Column(name = "content")
     private String value;
 
     public static ScheduleContent of(String rawContent) {
-        // 추후 검증이 필요한 부분이 있으면 여기에
+        if (rawContent == null) {
+            throw new InvalidScheduleContentException("일정의 본문이 null");
+        }
         return new ScheduleContent(rawContent);
+    }
+
+    public static ScheduleContent defaultContent() {
+        return DEFAULT_CONTENT;
     }
 
     private ScheduleContent(String value) {

--- a/src/main/java/com/cosain/trilo/trip/domain/vo/ScheduleTitle.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/vo/ScheduleTitle.java
@@ -1,7 +1,6 @@
 package com.cosain.trilo.trip.domain.vo;
 
 import com.cosain.trilo.trip.domain.exception.InvalidScheduleTitleException;
-import com.cosain.trilo.trip.domain.exception.InvalidTripTitleException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.*;
@@ -13,25 +12,16 @@ import lombok.*;
 @Embeddable
 public class ScheduleTitle {
 
-    public static final int MIN_LENGTH = 1;
-    public static final int MAX_LENGTH = 20;
+    private static final int MAX_LENGTH = 20;
 
     @Column(name = "title")
     private String value;
 
     public static ScheduleTitle of(String value) {
-        if (isNullOrBlank(value) || hasInvalidLength(value)) {
+        if (value == null || value.length() > MAX_LENGTH) {
             throw new InvalidScheduleTitleException("null 또는 공백이거나, 길이 조건에 맞지 않는 여행 제목");
         }
         return new ScheduleTitle(value);
-    }
-
-    private static boolean isNullOrBlank(String value) {
-        return value == null || value.isBlank();
-    }
-
-    private static boolean hasInvalidLength(String value) {
-        return value.length() < MIN_LENGTH || value.length() > MAX_LENGTH;
     }
 
     private ScheduleTitle(String value) {

--- a/src/main/resources/exceptions/exception.yml
+++ b/src/main/resources/exceptions/exception.yml
@@ -168,6 +168,10 @@ schedule-0011:
   message: Invalid Schedule Time
   detail: 일정의 시작 시간(startTime), 종료 시간(endTime)은 null 일 수 없음
 
+schedule-0012:
+  message: Invalid Schedule Content
+  detail: 일정의 본문은 null일 수 없습니다.
+
 # 장소 관련
 place-0001:
   message: InvalidCoordinate

--- a/src/main/resources/exceptions/exception.yml
+++ b/src/main/resources/exceptions/exception.yml
@@ -154,7 +154,7 @@ schedule-0007:
 
 schedule-0008:
   message: Invalid Schedule Title
-  detail: 일정 제목이 올바르지 않습니다. 일정 제목은 null 또는 공백으로만 구성된 문자열일 수 없고, 길이는 1자 이상 20자 이하여야 합니다.
+  detail: 일정 제목이 올바르지 않습니다. 일정 제목은 null 일 수 없고, 20자 이하여야 합니다.(공백, 빈 문자열 허용)
 
 schedule-0009:
   message: Too Many Trip Schedule Count

--- a/src/main/resources/exceptions/exception_en.yml
+++ b/src/main/resources/exceptions/exception_en.yml
@@ -170,6 +170,10 @@ schedule-0011:
   message: Invalid Schedule Time
   detail: The startTime and endTime of a schedule cannot be null.
 
+schedule-0012:
+  message: Invalid Schedule Content
+  detail: The schedule content cannot be null;
+
 # 장소 관련
 place-0001:
   message: InvalidCoordinate

--- a/src/main/resources/exceptions/exception_en.yml
+++ b/src/main/resources/exceptions/exception_en.yml
@@ -156,7 +156,7 @@ schedule-0007:
 
 schedule-0008:
   message: Invalid Schedule Title
-  detail: The ScheduleTitle is not valid. The ScheduleTitle cannot be a null or empty string, and its length must be between 1 and 20 characters
+  detail: The schedule title is invalid. The schedule title cannot be null and must be within 20 characters (allowing empty spaces and blank strings).
 
 schedule-0009:
   message: Too Many Trip Schedule Count

--- a/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/dto/factory/ScheduleUpdateCommandFactoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/dto/factory/ScheduleUpdateCommandFactoryTest.java
@@ -3,6 +3,7 @@ package com.cosain.trilo.unit.trip.application.schedule.command.dto.factory;
 import com.cosain.trilo.common.exception.CustomValidationException;
 import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleUpdateCommand;
 import com.cosain.trilo.trip.application.schedule.command.usecase.dto.factory.ScheduleUpdateCommandFactory;
+import com.cosain.trilo.trip.domain.exception.InvalidScheduleContentException;
 import com.cosain.trilo.trip.domain.exception.InvalidScheduleTimeException;
 import com.cosain.trilo.trip.domain.exception.InvalidScheduleTitleException;
 import com.cosain.trilo.trip.domain.vo.ScheduleContent;
@@ -41,46 +42,6 @@ public class ScheduleUpdateCommandFactoryTest {
         assertThat(scheduleUpdateCommand.getScheduleTime()).isEqualTo(ScheduleTime.of(startTime, endTime));
     }
 
-
-    @DisplayName("일정 제목 null -> 검증 예외 발생")
-    @Test
-    void nullScheduleTitleTest() {
-        // given
-        String rawScheduleTitle = null;
-        String rawScheduleContent = "일정 본문";
-        LocalTime startTime = LocalTime.of(13,0);
-        LocalTime endTime = LocalTime.of(13,5);
-
-        // when
-        CustomValidationException cve = catchThrowableOfType(
-                () -> scheduleUpdateCommandFactory.createCommand(rawScheduleTitle, rawScheduleContent, startTime, endTime),
-                CustomValidationException.class);
-
-        // then
-        assertThat(cve).isNotNull();
-        assertThat(cve.getExceptions()).hasSize(1);
-        assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidScheduleTitleException.class);
-    }
-
-    @DisplayName("일정 제목 빈 문자열 -> 정상 생성")
-    @Test
-    void emptyScheduleTitleTest() {
-        // given
-        String rawScheduleTitle = "";
-        String rawScheduleContent = "일정 본문";
-        LocalTime startTime = LocalTime.of(13,0);
-        LocalTime endTime = LocalTime.of(13,5);
-
-        // when
-        ScheduleUpdateCommand scheduleUpdateCommand = scheduleUpdateCommandFactory.createCommand(
-                rawScheduleTitle, rawScheduleContent, startTime, endTime);
-
-        // then
-        assertThat(scheduleUpdateCommand.getScheduleTitle()).isEqualTo(ScheduleTitle.of(rawScheduleTitle));
-        assertThat(scheduleUpdateCommand.getScheduleContent()).isEqualTo(ScheduleContent.of(rawScheduleContent));
-        assertThat(scheduleUpdateCommand.getScheduleTime()).isEqualTo(ScheduleTime.of(startTime, endTime));
-    }
-
     @DisplayName("제목이 20자보다 긴 문자열 -> 검증 예외 발생")
     @Test
     void tooLongScheduleTitleTest() {
@@ -100,6 +61,27 @@ public class ScheduleUpdateCommandFactoryTest {
         assertThat(cve.getExceptions()).hasSize(1);
         assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidScheduleTitleException.class);
     }
+
+    @DisplayName("일정의 본문이 null -> 검증 예외 발생")
+    @Test
+    void nullContentTest() {
+        // given
+        String rawScheduleTitle = "일정 제목";
+        String rawScheduleContent = null;
+        LocalTime startTime = LocalTime.of(13,0);
+        LocalTime endTime = LocalTime.of(13,5);
+
+        // when
+        CustomValidationException cve = catchThrowableOfType(
+                () -> scheduleUpdateCommandFactory.createCommand(rawScheduleTitle, rawScheduleContent, startTime, endTime),
+                CustomValidationException.class);
+
+        // then
+        assertThat(cve).isNotNull();
+        assertThat(cve.getExceptions()).hasSize(1);
+        assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidScheduleContentException.class);
+    }
+
 
     @DisplayName("일정의 시작 시점이 null -> 검증 예외 발생")
     @Test

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/entity/TripTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/entity/TripTest.java
@@ -695,6 +695,10 @@ public class TripTest {
                 // 생성된 일정시간들은 디폴트 시간
                 assertThat(schedule1.getScheduleTime()).isEqualTo(ScheduleTime.defaultTime());
                 assertThat(schedule2.getScheduleTime()).isEqualTo(ScheduleTime.defaultTime());
+
+                // 생성된 일정제목들은 디폴트 제목
+                assertThat(schedule1.getScheduleContent()).isEqualTo(ScheduleContent.defaultContent());
+                assertThat(schedule2.getScheduleContent()).isEqualTo(ScheduleContent.defaultContent());
             }
         }
 
@@ -808,6 +812,10 @@ public class TripTest {
                 // 생성된 일정시간들은 디폴트 시간
                 assertThat(schedule1.getScheduleTime()).isEqualTo(ScheduleTime.defaultTime());
                 assertThat(schedule2.getScheduleTime()).isEqualTo(ScheduleTime.defaultTime());
+
+                // 생성된 일정제목들은 디폴트 제목
+                assertThat(schedule1.getScheduleContent()).isEqualTo(ScheduleContent.defaultContent());
+                assertThat(schedule2.getScheduleContent()).isEqualTo(ScheduleContent.defaultContent());
             }
         }
     }

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/vo/ScheduleContentTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/vo/ScheduleContentTest.java
@@ -1,0 +1,65 @@
+package com.cosain.trilo.unit.trip.domain.vo;
+
+import com.cosain.trilo.trip.domain.exception.InvalidScheduleContentException;
+import com.cosain.trilo.trip.domain.vo.ScheduleContent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("ScheduleContent(일정 본문) 테스트")
+public class ScheduleContentTest {
+
+    @DisplayName("일정 본문이 null 이 아닌 문자열(공백 허용) -> 정상 생성")
+    @ValueSource(strings = {"일정 본문", "", "     "})
+    @ParameterizedTest
+    void successCreateTest(String rawContent) {
+        // given : rawTitle
+
+        // when
+        ScheduleContent scheduleContent = ScheduleContent.of(rawContent);
+
+        // then
+        assertThat(scheduleContent).isEqualTo(ScheduleContent.of(rawContent));
+    }
+
+    @DisplayName("일정 본문이 null -> InvalidScheduleContentException")
+    @Test
+    void nullContentTest() {
+        // given
+        String rawContent = null;
+
+        // when & then
+        assertThatThrownBy(() -> ScheduleContent.of(rawContent))
+                .isInstanceOf(InvalidScheduleContentException.class);
+    }
+
+    @Test
+    @DisplayName("디폴트 ScheduleContents는 빈 문자열이다.")
+    void testDefault() {
+        // when
+        ScheduleContent scheduleContent = ScheduleContent.defaultContent();
+
+        // then
+        assertThat(scheduleContent.getValue()).isEqualTo("");
+    }
+
+    @Test
+    @DisplayName("본문 내용이 같으면 동등하다.")
+    void testEquality() {
+        // given
+        String rawContent1 = "일정본문";
+        String rawContent2 = "일정본문";
+
+        // when
+        ScheduleContent scheduleContent1 = ScheduleContent.of(rawContent1);
+        ScheduleContent scheduleContent2 = ScheduleContent.of(rawContent2);
+
+        // then
+        assertThat(scheduleContent1).isEqualTo(scheduleContent2);
+    }
+
+}

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/vo/ScheduleTitleTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/vo/ScheduleTitleTest.java
@@ -4,6 +4,8 @@ import com.cosain.trilo.trip.domain.exception.InvalidScheduleTitleException;
 import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -11,6 +13,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("ScheduleTitle 테스트")
 public class ScheduleTitleTest {
+
+    @DisplayName("일정 제목이 null 아니고 20자 이하(공백 허용) -> 정상 생성")
+    @ValueSource(strings = {"일정 제목", "", "     "})
+    @ParameterizedTest
+    void successCreateTest(String rawTitle) {
+        // given : rawTitle
+
+        // when
+        ScheduleTitle title = ScheduleTitle.of(rawTitle);
+
+        // then
+        assertThat(title.getValue()).isEqualTo(rawTitle);
+    }
 
     @Test
     @DisplayName("null 제목 -> InvalidScheduleTitleException 발생")
@@ -24,49 +39,14 @@ public class ScheduleTitleTest {
     }
 
     @Test
-    @DisplayName("빈 문자열 제목 -> InvalidScheduleTitleException 발생")
-    void emptyScheduleTitleTest() {
-        // given
-        String emptyTitle = "";
-
-        // when
-        assertThatThrownBy(() -> ScheduleTitle.of(emptyTitle))
-                .isInstanceOf(InvalidScheduleTitleException.class);
-    }
-
-    @Test
-    @DisplayName("공백만으로 구성된 제목 -> InvalidScheduleTitleException 발생")
-    void whiteSpaceScheduleTitleTest() {
-        // given
-        String whiteSpaceTitle = "   ";
-
-        // when
-        assertThatThrownBy(() -> ScheduleTitle.of(whiteSpaceTitle))
-                .isInstanceOf(InvalidScheduleTitleException.class);
-    }
-
-    @Test
-    @DisplayName("제한 길이보다 긴 제목 -> InvalidScheduleTitleException 발생")
+    @DisplayName("20자보다 긴 제목 -> InvalidScheduleTitleException 발생")
     void tooLongScheduleTitleTest() {
         // given
-        String tooLongTitle = "A".repeat(ScheduleTitle.MAX_LENGTH + 1);
+        String tooLongTitle = "A".repeat(21);
 
         // when
         assertThatThrownBy(() -> ScheduleTitle.of(tooLongTitle))
                 .isInstanceOf(InvalidScheduleTitleException.class);
-    }
-
-    @Test
-    @DisplayName("정상적인 길이의 비어있지 않은 여행제목 -> 생성 성공")
-    void createScheduleTitleSuccessTest() {
-        // given
-        String normalTitle = "정상적인 제목";
-
-        // when
-        ScheduleTitle title = ScheduleTitle.of(normalTitle);
-
-        // then
-        assertThat(title.getValue()).isEqualTo(normalTitle);
     }
 
     @Test

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/docs/ScheduleCreateControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/docs/ScheduleCreateControllerDocsTest.java
@@ -108,7 +108,7 @@ public class ScheduleCreateControllerDocsTest extends RestDocsTestSupport {
                                 fieldWithPath("title")
                                         .type(STRING)
                                         .description("일정의 제목")
-                                        .attributes(key("constraints").value("null 또는 공백일 수 없으며, 길이는 1-20자까지만 허용됩니다.")),
+                                        .attributes(key("constraints").value("null일 수 없으며, 길이는 20자 이하까지 허용됩니다. (공백, 빈 문자열 허용)")),
                                 fieldWithPath("tripId")
                                         .type(NUMBER)
                                         .description("소속된 여행(Trip)의 식별자")

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/docs/ScheduleUpdateControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/docs/ScheduleUpdateControllerDocsTest.java
@@ -91,7 +91,7 @@ public class ScheduleUpdateControllerDocsTest extends RestDocsTestSupport {
                                 fieldWithPath("title")
                                         .type(STRING)
                                         .description("일정의 제목")
-                                        .attributes(key("constraints").value("null 또는 공백일 수 없으며, 길이는 1-20자까지만 허용됩니다.")),
+                                        .attributes(key("constraints").value("null 일 수 없으며, 길이는 20자 이하까지 허용됩니다. (공백, 빈 문자열 허용)")),
                                 fieldWithPath("content")
                                         .type(STRING)
                                         .optional()

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/docs/ScheduleUpdateControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/docs/ScheduleUpdateControllerDocsTest.java
@@ -60,8 +60,8 @@ public class ScheduleUpdateControllerDocsTest extends RestDocsTestSupport {
         Long scheduleId = 1L;
         String rawTitle = "수정 일정제목";
         String rawContent = "수정 일정내용";
-        LocalTime startTime = LocalTime.of(13,0);
-        LocalTime endTime = LocalTime.of(13,5);
+        LocalTime startTime = LocalTime.of(13, 0);
+        LocalTime endTime = LocalTime.of(13, 5);
 
         ScheduleUpdateRequest request = new ScheduleUpdateRequest(rawTitle, rawContent, startTime, endTime);
         ScheduleUpdateCommand command = new ScheduleUpdateCommand(ScheduleTitle.of(rawContent), ScheduleContent.of(rawContent), ScheduleTime.of(startTime, endTime));
@@ -94,8 +94,8 @@ public class ScheduleUpdateControllerDocsTest extends RestDocsTestSupport {
                                         .attributes(key("constraints").value("null 일 수 없으며, 길이는 20자 이하까지 허용됩니다. (공백, 빈 문자열 허용)")),
                                 fieldWithPath("content")
                                         .type(STRING)
-                                        .optional()
-                                        .description("일정의 본문"),
+                                        .description("일정의 본문")
+                                        .attributes(key("constraints").value("null을 허용하지 않습니다. (공백, 빈문자열 허용)")),
                                 fieldWithPath("startTime")
                                         .type(STRING)
                                         .description("일정의 시작시간. 필수."),


### PR DESCRIPTION
# JIRA 티켓
- [TRL-348]

---

# 작업 내역
- [x] 일정 제목 제약 조건 수정 : null 허용, 빈문자열 또는 공백 허용, 20자 이하
- [x] 일정 본문 기본값 설정 : 빈 문자열
- [x] 일정 본문 제약 조건 수정 : null 금지

[TRL-348]: https://cosain.atlassian.net/browse/TRL-348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ