### PR TITLE
[TRL-308] fix: 전체 Day 목록 조회 시 응답에 Color 값(code, name) 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -771,7 +771,7 @@ include::{snippets}/single-day-query-controller-docs-test/day_단건_조회/path
 include::{snippets}/single-day-query-controller-docs-test/day_단건_조회/response-fields.adoc[]
 ===== DayColor
 include::{snippets}/single-day-query-controller-docs-test/day_단건_조회/response-fields-beneath-dayColor.adoc[]
-===== Schedules
+===== Schedule
 include::{snippets}/single-day-query-controller-docs-test/day_단건_조회/response-fields-schedules.adoc[]
 ===== Coordinate
 include::{snippets}/single-day-query-controller-docs-test/day_단건_조회/response-fields-coordinate.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -769,6 +769,8 @@ include::{snippets}/single-day-query-controller-docs-test/day_단건_조회/path
 ==== 응답
 ===== 본문
 include::{snippets}/single-day-query-controller-docs-test/day_단건_조회/response-fields.adoc[]
+===== DayColor
+include::{snippets}/single-day-query-controller-docs-test/day_단건_조회/response-fields-beneath-dayColor.adoc[]
 ===== Schedules
 include::{snippets}/single-day-query-controller-docs-test/day_단건_조회/response-fields-schedules.adoc[]
 ===== Coordinate
@@ -800,7 +802,9 @@ include::{snippets}/trip-day-list-query-controller-docs-test/day_목록_조회/p
 include::{snippets}/trip-day-list-query-controller-docs-test/day_목록_조회/response-fields.adoc[]
 ===== Days
 include::{snippets}/trip-day-list-query-controller-docs-test/day_목록_조회/response-fields-days.adoc[]
-===== Schedules
+===== DayColor
+include::{snippets}/trip-day-list-query-controller-docs-test/day_목록_조회/response-fields-dayColor.adoc[]
+===== Schedule
 include::{snippets}/trip-day-list-query-controller-docs-test/day_목록_조회/response-fields-schedules.adoc[]
 ===== Coordinate
 include::{snippets}/trip-day-list-query-controller-docs-test/day_목록_조회/response-fields-coordinate.adoc[]

--- a/src/main/java/com/cosain/trilo/trip/infra/dto/DayColorDto.java
+++ b/src/main/java/com/cosain/trilo/trip/infra/dto/DayColorDto.java
@@ -1,0 +1,18 @@
+package com.cosain.trilo.trip.infra.dto;
+
+import lombok.Getter;
+
+@Getter
+public class DayColorDto {
+    private String name;
+    private String code;
+
+    private DayColorDto(String name, String code){
+        this.name = name;
+        this.code = code;
+    }
+
+    public static DayColorDto of(String name, String code){
+        return new DayColorDto(name, code);
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/infra/dto/DayScheduleDetail.java
+++ b/src/main/java/com/cosain/trilo/trip/infra/dto/DayScheduleDetail.java
@@ -1,5 +1,6 @@
 package com.cosain.trilo.trip.infra.dto;
 
+import com.cosain.trilo.trip.domain.vo.DayColor;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.*;
 
@@ -11,13 +12,15 @@ public class DayScheduleDetail {
     private Long dayId;
     private Long tripId;
     private LocalDate date;
+    private DayColorDto dayColor;
     private List<ScheduleSummary> schedules;
 
     @QueryProjection
-    public DayScheduleDetail(Long dayId, Long tripId, LocalDate date, List<ScheduleSummary> scheduleSummaries) {
+    public DayScheduleDetail(Long dayId, Long tripId, LocalDate date, DayColor dayColor, List<ScheduleSummary> scheduleSummaries) {
         this.dayId = dayId;
         this.tripId = tripId;
         this.date = date;
+        this.dayColor = DayColorDto.of(dayColor.name(), dayColor.getValue());
         this.schedules = scheduleSummaries;
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/infra/repository/day/DayQueryRepository.java
+++ b/src/main/java/com/cosain/trilo/trip/infra/repository/day/DayQueryRepository.java
@@ -33,6 +33,7 @@ public class DayQueryRepository {
                         day.id,
                         day.trip.id,
                         day.tripDate,
+                        day.dayColor,
                         GroupBy.list(new QScheduleSummary(
                                 schedule.id,
                                 schedule.scheduleTitle.value,
@@ -57,6 +58,7 @@ public class DayQueryRepository {
                                 day.id,
                                 day.trip.id,
                                 day.tripDate,
+                                day.dayColor,
                                 list(new QScheduleSummary(
                                         schedule.id,
                                         schedule.scheduleTitle.value,

--- a/src/test/java/com/cosain/trilo/unit/trip/application/day/query/DaySearchServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/day/query/DaySearchServiceTest.java
@@ -2,6 +2,7 @@ package com.cosain.trilo.unit.trip.application.day.query;
 
 import com.cosain.trilo.trip.application.day.query.service.DaySearchService;
 import com.cosain.trilo.trip.application.exception.DayNotFoundException;
+import com.cosain.trilo.trip.domain.vo.DayColor;
 import com.cosain.trilo.trip.infra.dto.DayScheduleDetail;
 import com.cosain.trilo.trip.infra.dto.ScheduleSummary;
 import com.cosain.trilo.trip.infra.repository.day.DayQueryRepository;
@@ -41,7 +42,7 @@ public class DaySearchServiceTest {
         // given
         Long dayId = 1L;
         ScheduleSummary scheduleSummary = new ScheduleSummary(1L, "제목", "장소","장소 식별자", 33.33, 33.33);
-        DayScheduleDetail dayScheduleDetail = new DayScheduleDetail(dayId, 1L, LocalDate.of(2023, 5, 5), List.of(scheduleSummary));
+        DayScheduleDetail dayScheduleDetail = new DayScheduleDetail(dayId, 1L, LocalDate.of(2023, 5, 5), DayColor.RED, List.of(scheduleSummary));
         given(dayQueryRepository.findDayWithSchedulesByDayId(1L)).willReturn(Optional.of(dayScheduleDetail));
 
         // when

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/day/query/SingleDayQueryControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/day/query/SingleDayQueryControllerTest.java
@@ -2,6 +2,7 @@ package com.cosain.trilo.unit.trip.presentation.day.query;
 
 import com.cosain.trilo.support.RestControllerTest;
 import com.cosain.trilo.trip.application.day.query.usecase.DaySearchUseCase;
+import com.cosain.trilo.trip.domain.vo.DayColor;
 import com.cosain.trilo.trip.infra.dto.DayScheduleDetail;
 import com.cosain.trilo.trip.infra.dto.ScheduleSummary;
 import com.cosain.trilo.trip.presentation.day.query.SingleDayQueryController;
@@ -39,7 +40,7 @@ class SingleDayQueryControllerTest extends RestControllerTest {
         ScheduleSummary scheduleSummary1 = new ScheduleSummary(1L, "제목", "장소 이름","장소 식별자1", 33.33, 33.33);
         ScheduleSummary scheduleSummary2 = new ScheduleSummary(2L, "제목2", "장소 이름2","장소 식별자2", 33.33, 33.33);
 
-        DayScheduleDetail dayScheduleDetail = new DayScheduleDetail(1L, 1L, LocalDate.of(2023, 2, 3), List.of(scheduleSummary1, scheduleSummary2));
+        DayScheduleDetail dayScheduleDetail = new DayScheduleDetail(1L, 1L, LocalDate.of(2023, 2, 3), DayColor.RED, List.of(scheduleSummary1, scheduleSummary2));
         given(daySearchUseCase.searchDeySchedule(eq(1L))).willReturn(dayScheduleDetail);
 
         mockMvc.perform(get("/api/days/1")

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/day/query/TripDayListQueryControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/day/query/TripDayListQueryControllerTest.java
@@ -2,6 +2,7 @@ package com.cosain.trilo.unit.trip.presentation.day.query;
 
 import com.cosain.trilo.support.RestControllerTest;
 import com.cosain.trilo.trip.application.day.query.usecase.DaySearchUseCase;
+import com.cosain.trilo.trip.domain.vo.DayColor;
 import com.cosain.trilo.trip.infra.dto.DayScheduleDetail;
 import com.cosain.trilo.trip.infra.dto.ScheduleSummary;
 import com.cosain.trilo.trip.presentation.day.query.TripDayListQueryController;
@@ -41,7 +42,7 @@ class TripDayListQueryControllerTest extends RestControllerTest {
         Long tripId = 1L;
         mockingForLoginUserAnnotation();
         ScheduleSummary scheduleSummary = new ScheduleSummary(1L, "제목", "장소 이름", "장소 식별자", 33.33, 33.33);
-        DayScheduleDetail dayScheduleDetail = new DayScheduleDetail(1L, 1L, LocalDate.of(2023, 5, 13), List.of(scheduleSummary));
+        DayScheduleDetail dayScheduleDetail = new DayScheduleDetail(1L, 1L, LocalDate.of(2023, 5, 13), DayColor.BLACK, List.of(scheduleSummary));
         List<DayScheduleDetail> dayScheduleDetails = List.of(dayScheduleDetail);
 
         given(daySearchUseCase.searchDaySchedules(tripId)).willReturn(dayScheduleDetails);

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/day/query/docs/SingleDayQueryControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/day/query/docs/SingleDayQueryControllerDocsTest.java
@@ -3,6 +3,7 @@ package com.cosain.trilo.unit.trip.presentation.day.query.docs;
 
 import com.cosain.trilo.support.RestDocsTestSupport;
 import com.cosain.trilo.trip.application.day.query.usecase.DaySearchUseCase;
+import com.cosain.trilo.trip.domain.vo.DayColor;
 import com.cosain.trilo.trip.infra.dto.DayScheduleDetail;
 import com.cosain.trilo.trip.infra.dto.ScheduleSummary;
 import com.cosain.trilo.trip.presentation.day.query.SingleDayQueryController;
@@ -41,7 +42,7 @@ public class SingleDayQueryControllerDocsTest extends RestDocsTestSupport {
         ScheduleSummary scheduleSummary2 = new ScheduleSummary(2L, "제목2", "장소 이름2","장소 식별자2", 33.33, 33.33);
 
         Long dayId = 1L;
-        DayScheduleDetail dayScheduleDetail = new DayScheduleDetail(dayId, 1L, LocalDate.of(2023, 2, 3), List.of(scheduleSummary1, scheduleSummary2));
+        DayScheduleDetail dayScheduleDetail = new DayScheduleDetail(dayId, 1L, LocalDate.of(2023, 2, 3), DayColor.BLACK, List.of(scheduleSummary1, scheduleSummary2));
         given(daySearchUseCase.searchDeySchedule(eq(dayId))).willReturn(dayScheduleDetail);
 
         mockMvc.perform(RestDocumentationRequestBuilders.get("/api/days"+"/{dayId}",dayId)
@@ -61,15 +62,21 @@ public class SingleDayQueryControllerDocsTest extends RestDocsTestSupport {
                                 fieldWithPath("dayId").type(NUMBER).description("Day ID"),
                                 fieldWithPath("tripId").type(NUMBER).description("여행 ID"),
                                 fieldWithPath("date").type(STRING).description("여행 날짜"),
-                                subsectionWithPath("schedules").type(ARRAY).description("일정 목록")
+                                fieldWithPath("dayColor").type("DayColor").description("Day 색상 (하단 표 참고)"),
+                                fieldWithPath("dayColor.name").ignored(),
+                                fieldWithPath("dayColor.code").ignored(),
+                                subsectionWithPath("schedules").type(ARRAY).description("일정 목록 (하단 표 참고)")
                         ),
-                        responseFields(
-                                beneathPath("schedules").withSubsectionId("schedules"),
+                        responseFields(beneathPath("dayColor"),
+                                fieldWithPath("name").type(STRING).description("색상 이름"),
+                                fieldWithPath("code").type(STRING).description("색상 코드")
+                        ),
+                        responseFields(beneathPath("schedules").withSubsectionId("schedules"),
                                 fieldWithPath("scheduleId").type(NUMBER).description("일정 ID"),
                                 fieldWithPath("title").type(STRING).description("일정 제목"),
                                 fieldWithPath("placeName").type(STRING).description("장소 이름"),
                                 fieldWithPath("placeId").type(STRING).description("장소 ID"),
-                                subsectionWithPath("coordinate").type(OBJECT).description("장소의 좌표")
+                                subsectionWithPath("coordinate").type(OBJECT).description("장소의 좌표 (하단 표 참고)")
                         ),
                         responseFields(beneathPath("schedules[].coordinate").withSubsectionId("coordinate"),
                                 fieldWithPath("latitude").type(NUMBER).description("위도"),

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/day/query/docs/SingleDayQueryControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/day/query/docs/SingleDayQueryControllerDocsTest.java
@@ -62,7 +62,7 @@ public class SingleDayQueryControllerDocsTest extends RestDocsTestSupport {
                                 fieldWithPath("dayId").type(NUMBER).description("Day ID"),
                                 fieldWithPath("tripId").type(NUMBER).description("여행 ID"),
                                 fieldWithPath("date").type(STRING).description("여행 날짜"),
-                                fieldWithPath("dayColor").type("DayColor").description("Day 색상 (하단 표 참고)"),
+                                fieldWithPath("dayColor").type("DayColor").description("색상 정보 (하단 표 참고)"),
                                 fieldWithPath("dayColor.name").ignored(),
                                 fieldWithPath("dayColor.code").ignored(),
                                 subsectionWithPath("schedules").type(ARRAY).description("일정 목록 (하단 표 참고)")

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/day/query/docs/TripDayListQueryControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/day/query/docs/TripDayListQueryControllerDocsTest.java
@@ -2,6 +2,7 @@ package com.cosain.trilo.unit.trip.presentation.day.query.docs;
 
 import com.cosain.trilo.support.RestDocsTestSupport;
 import com.cosain.trilo.trip.application.day.query.usecase.DaySearchUseCase;
+import com.cosain.trilo.trip.domain.vo.DayColor;
 import com.cosain.trilo.trip.infra.dto.Coordinate;
 import com.cosain.trilo.trip.infra.dto.DayScheduleDetail;
 import com.cosain.trilo.trip.infra.dto.ScheduleSummary;
@@ -38,7 +39,7 @@ public class TripDayListQueryControllerDocsTest extends RestDocsTestSupport {
         Long tripId = 1L;
         mockingForLoginUserAnnotation();
         ScheduleSummary scheduleSummary = new ScheduleSummary(1L, "제목", "장소 이름", "장소 식별자", 33.33, 33.33);
-        DayScheduleDetail dayScheduleDetail = new DayScheduleDetail(1L, 1L, LocalDate.of(2023, 5, 13), List.of(scheduleSummary));
+        DayScheduleDetail dayScheduleDetail = new DayScheduleDetail(1L, 1L, LocalDate.of(2023, 5, 13), DayColor.BLACK, List.of(scheduleSummary));
         List<DayScheduleDetail> dayScheduleDetails = List.of(dayScheduleDetail);
 
         given(daySearchUseCase.searchDaySchedules(tripId)).willReturn(dayScheduleDetails);
@@ -59,20 +60,23 @@ public class TripDayListQueryControllerDocsTest extends RestDocsTestSupport {
                         responseFields(
                                 subsectionWithPath("days").type(ARRAY).description("Day 목록")
                         ),
-                        responseFields(
-                                beneathPath("days").withSubsectionId("days"),
+                        responseFields(beneathPath("days").withSubsectionId("days"),
                                 fieldWithPath("dayId").type(NUMBER).description("Day ID"),
                                 fieldWithPath("tripId").type(NUMBER).description("여행 ID"),
                                 fieldWithPath("date").description(STRING).description("여행 날짜"),
-                                subsectionWithPath("schedules").type(ARRAY).description("일정 목록")
+                                subsectionWithPath("dayColor").type("DayColor").description("하단 표 참고"),
+                                subsectionWithPath("schedules").type("Schedule[]").description("일정 목록 (하단 표 참고)")
                         ),
-                        responseFields(
-                                beneathPath("days[].schedules").withSubsectionId("schedules"),
+                        responseFields(beneathPath("days[].dayColor").withSubsectionId("dayColor"),
+                                fieldWithPath("name").type(STRING).description("색상 이름"),
+                                fieldWithPath("code").type(STRING).description("색상 코드")
+                        ),
+                        responseFields(beneathPath("days[].schedules").withSubsectionId("schedules"),
                                 fieldWithPath("[].scheduleId").type(NUMBER).description("일정 ID"),
                                 fieldWithPath("[].title").type(STRING).description("일정 제목"),
                                 fieldWithPath("[].placeName").type(STRING).description("장소 이름"),
                                 fieldWithPath("[].placeId").type(STRING).description("장소 ID"),
-                                subsectionWithPath("[].coordinate").type(OBJECT).description("장소의 좌표")
+                                subsectionWithPath("[].coordinate").type("Coordinate").description("장소의 좌표 (하단 표 참고)")
                         ),
                         responseFields(beneathPath("days[].schedules[].coordinate").withSubsectionId("coordinate"),
                                 fieldWithPath("latitude").type(NUMBER).description("위도"),

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/day/query/docs/TripDayListQueryControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/day/query/docs/TripDayListQueryControllerDocsTest.java
@@ -64,7 +64,7 @@ public class TripDayListQueryControllerDocsTest extends RestDocsTestSupport {
                                 fieldWithPath("dayId").type(NUMBER).description("Day ID"),
                                 fieldWithPath("tripId").type(NUMBER).description("여행 ID"),
                                 fieldWithPath("date").description(STRING).description("여행 날짜"),
-                                subsectionWithPath("dayColor").type("DayColor").description("하단 표 참고"),
+                                subsectionWithPath("dayColor").type("DayColor").description("색상 정보 (하단 표 참고)"),
                                 subsectionWithPath("schedules").type("Schedule[]").description("일정 목록 (하단 표 참고)")
                         ),
                         responseFields(beneathPath("days[].dayColor").withSubsectionId("dayColor"),


### PR DESCRIPTION
# JIRA 티켓
[TRL-308]

# 작업 내역

전체 Day 목록 조회 시 응답에 Color 관련 응답 필드를 추가했습니다.


### 변경된 API 명세

![image](https://github.com/teamCoSaIn/trilo-be/assets/53935439/3c2e1953-b828-4951-95a1-bb6117faff1b)



[TRL-308]: https://cosain.atlassian.net/browse/TRL-308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ