### PR TITLE
[TRL-349] chore: 일정 이동 API 엔드포인트 수정

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -548,8 +548,8 @@ include::{snippets}/schedule-update-controller-docs-test/schedule-update-doc-tes
 === Schedule 이동
 
 ==== 기본정보
-- 메서드 : PATCH
-- URL : `/api/schedules/{scheduleId}`
+- 메서드 : PUT
+- URL : `/api/schedules/{scheduleId}/position`
 - 인증방식 : 액세스 토큰
 
 요청한 일정을 이동합니다. 여행의 소유자(== 일정의 소유자)만 일정을 이동할 수 있고, 일정이 실제로 존재해야합니다. (일정이 존재하지 않을 경우 예외가 발생합니다.)

--- a/src/main/java/com/cosain/trilo/trip/presentation/schedule/command/ScheduleMoveController.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/schedule/command/ScheduleMoveController.java
@@ -1,9 +1,9 @@
 package com.cosain.trilo.trip.presentation.schedule.command;
 
 import com.cosain.trilo.common.LoginUser;
+import com.cosain.trilo.trip.application.schedule.command.usecase.ScheduleMoveUseCase;
 import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleMoveCommand;
 import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleMoveResult;
-import com.cosain.trilo.trip.application.schedule.command.usecase.ScheduleMoveUseCase;
 import com.cosain.trilo.trip.application.schedule.command.usecase.dto.factory.ScheduleMoveCommandFactory;
 import com.cosain.trilo.trip.presentation.schedule.command.dto.request.ScheduleMoveRequest;
 import com.cosain.trilo.trip.presentation.schedule.command.dto.response.ScheduleMoveResponse;
@@ -21,7 +21,7 @@ public class ScheduleMoveController {
     private final ScheduleMoveUseCase scheduleMoveUseCase;
     private final ScheduleMoveCommandFactory scheduleMoveCommandFactory;
 
-    @PatchMapping("/api/schedules/{scheduleId}")
+    @PutMapping("/api/schedules/{scheduleId}/position")
     @ResponseStatus(HttpStatus.OK)
     public ScheduleMoveResponse moveSchedule(@LoginUser User user, @PathVariable Long scheduleId, @RequestBody ScheduleMoveRequest request) {
         Long moveTripperId = user.getId();

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/ScheduleMoveControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/ScheduleMoveControllerTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -39,6 +40,8 @@ public class ScheduleMoveControllerTest extends RestControllerTest {
     private ScheduleMoveCommandFactory scheduleMoveCommandFactory;
 
     private final static String ACCESS_TOKEN = "Bearer accessToken";
+
+    private static final String ENDPOINT_URL_TEMPLATE = "/api/schedules/{scheduleId}/position";
 
     @Test
     @DisplayName("인증된 사용자의 올바른 요청 -> 일정 이동됨")
@@ -64,7 +67,7 @@ public class ScheduleMoveControllerTest extends RestControllerTest {
         given(scheduleMoveUseCase.moveSchedule(eq(scheduleId), any(), any(ScheduleMoveCommand.class)))
                 .willReturn(moveResult);
 
-        mockMvc.perform(patch("/api/schedules/" + scheduleId)
+        mockMvc.perform(put(ENDPOINT_URL_TEMPLATE, scheduleId)
                         .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
                         .content(createJson(request))
                         .characterEncoding(StandardCharsets.UTF_8)
@@ -91,7 +94,7 @@ public class ScheduleMoveControllerTest extends RestControllerTest {
 
         ScheduleMoveRequest request = new ScheduleMoveRequest(targetDayId, targetOrder);
 
-        mockMvc.perform(patch("/api/schedules/" + scheduleId)
+        mockMvc.perform(put(ENDPOINT_URL_TEMPLATE, scheduleId)
                         .content(createJson(request))
                         .characterEncoding(StandardCharsets.UTF_8)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -110,8 +113,9 @@ public class ScheduleMoveControllerTest extends RestControllerTest {
         mockingForLoginUserAnnotation();
 
         String emptyContent = "";
+        Long scheduleId = 1L;
 
-        mockMvc.perform(patch("/api/schedules/1")
+        mockMvc.perform(put(ENDPOINT_URL_TEMPLATE, scheduleId)
                         .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
                         .content(emptyContent)
                         .characterEncoding(StandardCharsets.UTF_8)
@@ -128,6 +132,8 @@ public class ScheduleMoveControllerTest extends RestControllerTest {
     @DisplayName("형식이 올바르지 않은 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
     public void moveSchedule_with_invalidContent() throws Exception {
         mockingForLoginUserAnnotation();
+
+        Long scheduleId = 1L;
         String invalidContent = """
                 {
                     "targetDayId": 따옴표로 감싸지 않은 값,
@@ -135,7 +141,7 @@ public class ScheduleMoveControllerTest extends RestControllerTest {
                 }
                 """;
 
-        mockMvc.perform(patch("/api/schedules/1")
+        mockMvc.perform(put(ENDPOINT_URL_TEMPLATE, scheduleId)
                         .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
                         .content(invalidContent)
                         .characterEncoding(StandardCharsets.UTF_8)
@@ -152,6 +158,7 @@ public class ScheduleMoveControllerTest extends RestControllerTest {
     @DisplayName("타입이 올바르지 않은 요청 데이터 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
     public void moveSchedule_with_invalidType() throws Exception {
         mockingForLoginUserAnnotation();
+        Long scheduleId = 1L;
         String invalidTypeContent = """
                 {
                     "targetDayId": 1,
@@ -159,7 +166,7 @@ public class ScheduleMoveControllerTest extends RestControllerTest {
                 }
                 """;
 
-        mockMvc.perform(patch("/api/schedules/1")
+        mockMvc.perform(put(ENDPOINT_URL_TEMPLATE, scheduleId)
                         .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
                         .content(invalidTypeContent)
                         .characterEncoding(StandardCharsets.UTF_8)

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/docs/ScheduleMoveControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/docs/ScheduleMoveControllerDocsTest.java
@@ -22,7 +22,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
@@ -43,7 +43,8 @@ public class ScheduleMoveControllerDocsTest extends RestDocsTestSupport {
     @MockBean
     private ScheduleMoveCommandFactory scheduleMoveCommandFactory;
 
-    private final String ACCESS_TOKEN = "Bearer accessToken";
+    private static final String ACCESS_TOKEN = "Bearer accessToken";
+    private static final String ENDPOINT_URL_TEMPLATE = "/api/schedules/{scheduleId}/position";
 
     @Test
     @DisplayName("인증된 사용자의 일정 이동 요청 -> 성공")
@@ -70,7 +71,7 @@ public class ScheduleMoveControllerDocsTest extends RestDocsTestSupport {
                 .willReturn(moveResult);
 
         // when & then
-        mockMvc.perform(patch("/api/schedules/{scheduleId}", scheduleId)
+        mockMvc.perform(put(ENDPOINT_URL_TEMPLATE, scheduleId)
                         .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
                         .content(createJson(request))
                         .characterEncoding(StandardCharsets.UTF_8)


### PR DESCRIPTION

# JIRA 티켓
- [TRL-349]

---

# 작업 내역
- [x] 일정 이동 API의 엔드포인트 수정 및 테스트코드, 문서 반영

---

# 설명
- 기존 : PATCH, `/api/schedules/{scheduleId}`
- 변경 : PUT, `/api/schedules/{scheduleId}/position`

[TRL-349]: https://cosain.atlassian.net/browse/TRL-349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ