### PR TITLE
[TRL-352] fix: 전체 Day 목록 조회시 Day에 대한 일정이 존재하지 않는 경우에도 모든 인자가 null 인 ScheduleSummary 를 반환하는 문제 해결

### DIFF
--- a/src/main/java/com/cosain/trilo/trip/infra/repository/day/DayQueryRepository.java
+++ b/src/main/java/com/cosain/trilo/trip/infra/repository/day/DayQueryRepository.java
@@ -66,7 +66,7 @@ public class DayQueryRepository {
                                         schedule.place.placeId,
                                         schedule.place.coordinate.latitude,
                                         schedule.place.coordinate.longitude
-                                ))
+                                ).skipNulls())
                         ))
                 );
     }

--- a/src/test/java/com/cosain/trilo/unit/trip/infra/repository/DayQueryRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/infra/repository/DayQueryRepositoryTest.java
@@ -121,6 +121,27 @@ public class DayQueryRepositoryTest {
         }
 
         @Test
+        void Day에_해당하는_Schedule이_하나도_존재하지_않는_경우_ScheduleSummary_리스트의_크기는_0_이된다() {
+            // given
+            Trip trip = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023,5,10), LocalDate.of(2023,5,11));
+
+            Day day1 = trip.getDays().get(0);
+            Day day2 = trip.getDays().get(1);
+            em.persist(trip);
+            em.persist(day1);
+            em.persist(day2);
+
+            // when
+            List<DayScheduleDetail> dayScheduleDetails = dayQueryRepository.findDayScheduleListByTripId(trip.getId());
+            List<ScheduleSummary> findSchedules = dayScheduleDetails.get(0).getSchedules();
+
+            assertThat(findSchedules).isEmpty();
+            assertThat(findSchedules.size()).isEqualTo(0);
+        }
+
+
+
+        @Test
         @DisplayName("여행 날짜 기준 오름차순, 일정 순서값 기준 오름 차순으로 조회된다.")
         void sortTest(){
 


### PR DESCRIPTION
# JIRA 티켓
[TRL-352]

# 작업 내역

전체 Day 목록 조회시 Day에 대한 일정이 존재하지 않는 경우에도 모든 인자가 null 인 ScheduleSummary 를 반환하는 문제 해결했습니다.

한방 쿼리 작성 및 가독성 향상, 컴파일 타임 체크 등을 위해서 조회용 QueryRespository 의 데이터 접근 기술은 QueryDSL 을 사용하고 있습니다. Day 목록 조회 시 작성한 쿼리 결과에 대해서 DTO 로 매핑해주기 위해 GroupBy(), list() 와 같은 QueryDSL 에서 지원해주는 Result Aggregation 함수들을 사용했는데 결과를 매핑한 DTO 의 모든 필드들이 Null 이 되는 경우에도 DTO 를 생성해서 반환을 해주어 실제 일정이 존재하지 않음에도 모든 필드가 Null 인 일정이 다음과 같이 Day 목록 조회시 포함되어 전달되는 문제가 있었습니다.

## 문제 상황

![image](https://github.com/teamCoSaIn/trilo-be/assets/53935439/b9a1f9dc-3b1d-4b61-bf32-80e0e37db226)

## 해결

![image](https://github.com/teamCoSaIn/trilo-be/assets/53935439/f54c7398-0dbe-4ead-9915-9b3298ece69a)

모든 인자가 null 인 Wrapping Expression 이 instance 로 반환될 때 null 값을 건너뛰는 새 `FactoryExpression` 을 만드는 데 사용되는 함수인 `skipNulls()` 를 활용하여 문제를 해결했습니다. 

반환타입이 `FactoryExpression<?>` 인데 해당 타입이 `Expression` 을 상속하는 타입이라 `GroupBy()`의 전달 인자 타입과 일치하여 적용을 해봤는데 해결이 됐네요. 일단 문제는 해결됐지만 정확한 내부 동작을 알지는 못해서 학습이 필요해보입니다. 우선 현재 프로젝트에 적용해서 문제를 해결하는게 더 우선이기에 `SkipNulls()` 를 적용해서 해결을 하고, 추후 관련 내용을 학습 후 공유해보겠습니다.

![image](https://github.com/teamCoSaIn/trilo-be/assets/53935439/92a44e5f-738b-4f3f-9e1a-80276841fa52)


# 참고 자료
https://stackoverflow.com/questions/33959641/querydsl-null-entity-from-onetomany-association-with-projection-bean
https://github.com/querydsl/querydsl/issues/1677

[TRL-352]: https://cosain.atlassian.net/browse/TRL-352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ