### PR TITLE
[TRL-359] chore: 여행 이미지 파라미터명 수정 (imagePath -> imageURL)

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -284,7 +284,7 @@ include::{snippets}/trip-period-update-controller-docs-test/update-trip-period_w
 - 인증방식 : 액세스 토큰
 
 요청한 여행의 이미지를 수정합니다.
-수정이 성공됐을 경우, 다시 여행의 식별자와 여행 이미지의 URL을 응답합니다.
+수정이 성공됐을 경우, 다시 여행의 식별자와 여행 이미지의 URL(경로)을 응답합니다.
 
 
 ==== 요청
@@ -326,7 +326,7 @@ Content-Type: image/jpeg
 ===== 응답
 include::{snippets}/trip-image-update-controller-docs-test/trip-image-update-api-docs-test/http-response.adoc[]
 
-서버는 요청 사항에 맞게 여행의 이미지을 수정하고, 수정된 여행의 식별자 및 저장 경로 URL을 반환합니다.
+서버는 요청 사항에 맞게 여행의 이미지을 수정하고, 수정된 여행의 식별자 및 저장 URL(경로)를 반환합니다.
 
 '''
 

--- a/src/main/java/com/cosain/trilo/trip/application/trip/command/service/TripImageUpdateService.java
+++ b/src/main/java/com/cosain/trilo/trip/application/trip/command/service/TripImageUpdateService.java
@@ -29,7 +29,7 @@ public class TripImageUpdateService implements TripImageUpdateUseCase {
      * @param tripId : 여행의 식별자
      * @param tripperId : 사용자(여행자)의 식별자
      * @param file : 이미지 파일
-     * @return 교체된 이미지의 전체 경로 URL
+     * @return 교체된 이미지의 전체 URL(경로)
      * @throws TripNotFoundException : 일치하는 식별자의 여행을 찾을 수 없을 경우 발생
      * @throws NoTripUpdateAuthorityException : 여행을 수정할 권한이 없을 때 발생
      * @throws TripImageUploadFailedException : 여행의 이미지를 이미지 저장소에 올리는데 실패했을 때 발생
@@ -47,7 +47,7 @@ public class TripImageUpdateService implements TripImageUpdateUseCase {
         tripImageOutputAdapter.uploadImage(file, uploadName); // 이미지 저장소에 업로드 후, 전체 이미지 경로(fullPath)를 구성
 
         trip.changeImage(TripImage.of(uploadName)); // 여행이미지 도메인의 실제 이미지 변경
-        return tripImageOutputAdapter.getTripImageFullPath(uploadName); // 이미지 전체 경로를 반환
+        return tripImageOutputAdapter.getFullTripImageURL(uploadName); // 이미지 전체 경로를 반환
     }
 
     /**

--- a/src/main/java/com/cosain/trilo/trip/application/trip/command/usecase/TripImageUpdateUseCase.java
+++ b/src/main/java/com/cosain/trilo/trip/application/trip/command/usecase/TripImageUpdateUseCase.java
@@ -12,7 +12,7 @@ public interface TripImageUpdateUseCase {
      * @param tripId : 여행의 식별자
      * @param tripperId : 사용자(여행자)의 식별자
      * @param file : 이미지 파일
-     * @return 교체된 이미지의 전체 경로 URL
+     * @return 교체된 이미지의 전체 URL(경로)
      * @throws TripNotFoundException : 일치하는 식별자의 여행을 찾을 수 없을 경우 발생
      * @throws NoTripUpdateAuthorityException : 여행을 수정할 권한이 없을 때 발생
      * @throws TripImageUploadFailedException : 여행의 이미지를 이미지 저장소에 올리는데 실패했을 때 발생

--- a/src/main/java/com/cosain/trilo/trip/application/trip/query/service/TripListSearchService.java
+++ b/src/main/java/com/cosain/trilo/trip/application/trip/query/service/TripListSearchService.java
@@ -26,24 +26,24 @@ public class TripListSearchService implements TripListSearchUseCase {
 
     @Override
     public Slice<TripSummary> searchTripSummaries(TripPageCondition tripPageCondition, Pageable pageable) {
-
         verifyTripperExists(tripPageCondition.getTripperId());
         Slice<TripSummary> tripSummaries = findTripSummaries(tripPageCondition, pageable);
-        updateImagePath(tripSummaries);
+        tripSummaries.forEach(this::updateImageURL);
         return tripSummaries;
     }
 
-    private void updateImagePath(Slice<TripSummary> tripSummaries) {
-        tripSummaries.stream().forEach(tripSummary ->
-                tripSummary.updateImagePath(tripImageOutputAdapter.getTripImageFullPath(tripSummary.getImagePath())));
+    private void verifyTripperExists(Long tripperId) {
+        userRepository.findById(tripperId)
+                .orElseThrow(() -> new TripperNotFoundException("해당 식별자의 사용자(여행자)를 찾지 못 함"));
     }
 
-    private void verifyTripperExists(Long tripperId){
-        userRepository.findById(tripperId).orElseThrow(TripperNotFoundException::new);
-    }
-
-    private Slice<TripSummary> findTripSummaries(TripPageCondition tripPageCondition, Pageable pageable){
+    private Slice<TripSummary> findTripSummaries(TripPageCondition tripPageCondition, Pageable pageable) {
         return tripQueryRepository.findTripSummariesByTripperId(tripPageCondition, pageable);
     }
 
+    private void updateImageURL(TripSummary tripSummary) {
+        String imageName = tripSummary.getImageURL(); // 실제 DB에 저장된 이미지 이름
+        String fullImageURL = tripImageOutputAdapter.getFullTripImageURL(imageName);
+        tripSummary.updateImageURL(fullImageURL);
+    }
 }

--- a/src/main/java/com/cosain/trilo/trip/infra/adapter/TripImageOutputAdapter.java
+++ b/src/main/java/com/cosain/trilo/trip/infra/adapter/TripImageOutputAdapter.java
@@ -37,11 +37,11 @@ public class TripImageOutputAdapter {
     }
 
     /**
-     * 여행 이미지의 전체 경로(URL)을 얻어옵니다.
+     * 여행 이미지의 전체 URL(경로)을 얻어옵니다.
      * @param uploadedFileName
      * @return
      */
-    public String getTripImageFullPath(String uploadedFileName) {
+    public String getFullTripImageURL(String uploadedFileName) {
         return bucketPath.concat(uploadedFileName);
     }
 

--- a/src/main/java/com/cosain/trilo/trip/infra/dto/TripSummary.java
+++ b/src/main/java/com/cosain/trilo/trip/infra/dto/TripSummary.java
@@ -14,7 +14,7 @@ public class TripSummary {
     private String status;
     private LocalDate startDate;
     private LocalDate endDate;
-    private String imagePath;
+    private String imageURL;
 
     @QueryProjection
     public TripSummary(long tripId, long tripperId, String title, Enum status, LocalDate startDate, LocalDate endDate, String imageName) {
@@ -24,10 +24,10 @@ public class TripSummary {
         this.status = status.name();
         this.startDate = startDate;
         this.endDate = endDate;
-        this.imagePath = imageName;
+        this.imageURL = imageName;
     }
 
-    public void updateImagePath(String imagePath){
-        this.imagePath = imagePath;
+    public void updateImageURL(String imageURL){
+        this.imageURL = imageURL;
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/presentation/trip/command/TripImageUpdateController.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/trip/command/TripImageUpdateController.java
@@ -35,8 +35,8 @@ public class TripImageUpdateController {
         Long tripperId = user.getId();
         ImageFile imageFile = ImageFile.from(multipartFile);
 
-        String imagePath = tripImageUpdateUseCase.updateTripImage(tripId, tripperId, imageFile);
-        return new TripImageUpdateResponse(tripId, imagePath);
+        String imageURL = tripImageUpdateUseCase.updateTripImage(tripId, tripperId, imageFile);
+        return new TripImageUpdateResponse(tripId, imageURL);
     }
 
 }

--- a/src/main/java/com/cosain/trilo/trip/presentation/trip/command/dto/response/TripImageUpdateResponse.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/trip/command/dto/response/TripImageUpdateResponse.java
@@ -6,10 +6,10 @@ import lombok.Getter;
 public class TripImageUpdateResponse {
 
     private Long tripId;
-    private String imagePath;
+    private String imageURL;
 
-    public TripImageUpdateResponse(Long tripId, String imagePath) {
+    public TripImageUpdateResponse(Long tripId, String imageURL) {
         this.tripId = tripId;
-        this.imagePath = imagePath;
+        this.imageURL = imageURL;
     }
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/application/trip/command/service/TripImageUpdateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/trip/command/service/TripImageUpdateServiceTest.java
@@ -62,7 +62,7 @@ public class TripImageUpdateServiceTest {
 
 
         String fullPath = String.format("https://{여행 이미지 저장소}/trips/%d/{uuid 파일명}.jpeg", tripId);
-        given(tripImageOutputAdapter.getTripImageFullPath(anyString())).willReturn(fullPath);
+        given(tripImageOutputAdapter.getFullTripImageURL(anyString())).willReturn(fullPath);
 
         // when
         String returnFullPath = tripImageUpdateService.updateTripImage(tripId, tripperId, imageFile);
@@ -72,7 +72,7 @@ public class TripImageUpdateServiceTest {
         assertThat(returnFullPath).isEqualTo(fullPath);
         verify(tripRepository, times(1)).findById(eq(tripId));
         verify(tripImageOutputAdapter, times(1)).uploadImage(any(ImageFile.class), anyString());
-        verify(tripImageOutputAdapter, times(1)).getTripImageFullPath(anyString());
+        verify(tripImageOutputAdapter, times(1)).getFullTripImageURL(anyString());
     }
 
     @DisplayName("일치하는 식별자의 여행이 없으면 -> TripNotFoundException")

--- a/src/test/java/com/cosain/trilo/unit/trip/infra/adapter/TripImageOutputAdapterTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/infra/adapter/TripImageOutputAdapterTest.java
@@ -30,7 +30,7 @@ public class TripImageOutputAdapterTest {
     private TripImageOutputAdapter tripImageOutputAdapter;
 
     private AmazonS3 amazonS3;
-     private String bucketName;
+    private String bucketName;
     private String bucketPath;
 
     @BeforeEach
@@ -71,16 +71,16 @@ public class TripImageOutputAdapterTest {
     }
 
     @Test
-    @DisplayName("getTripImageFullPath -> 여행 이미지의 전체 경로를 얻어온다.")
-    void testGetTripImageFullPath() {
+    @DisplayName("getFullTripImageURL -> 여행 이미지의 전체 경로를 얻어온다.")
+    void testGetFUllTripImageURL() {
         // given
         String fileName = "trips/1/12760-fa712554-123.jpeg";
 
         // when
-        String fullImagePath = tripImageOutputAdapter.getTripImageFullPath(fileName);
+        String fullImageURL = tripImageOutputAdapter.getFullTripImageURL(fileName);
 
         // then
-        assertThat(fullImagePath).isEqualTo(bucketPath.concat(fileName));
+        assertThat(fullImageURL).isEqualTo(bucketPath.concat(fileName));
     }
 
     private ImageFile imageFileFixture(String testImageResourceFileName) throws IOException {

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/TripImageUpdateControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/TripImageUpdateControllerTest.java
@@ -21,8 +21,8 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.http.HttpMethod.POST;
-import static org.springframework.http.HttpMethod.PUT;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -51,9 +51,9 @@ public class TripImageUpdateControllerTest extends RestControllerTest {
 
         MockMultipartFile multipartFile = new MockMultipartFile(name, fileName, contentType, fileInputStream);
 
-        String imagePath = String.format("https://{이미지 파일 저장소 주소}/trips/%s/{이미지 파일명}.jpeg", tripId);
+        String imageURL = String.format("https://{이미지 파일 저장소 주소}/trips/%s/{이미지 파일명}.jpeg", tripId);
         given(tripImageUpdateUseCase.updateTripImage(eq(tripId), any(), any(ImageFile.class)))
-                .willReturn(imagePath);
+                .willReturn(imageURL);
 
         mockMvc.perform(multipart(POST, "/api/trips/{tripId}/image/update", tripId)
                         .file(multipartFile)
@@ -64,7 +64,7 @@ public class TripImageUpdateControllerTest extends RestControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.tripId").value(tripId))
-                .andExpect(jsonPath("$.imagePath").value(imagePath));
+                .andExpect(jsonPath("$.imageURL").value(imageURL));
 
         verify(tripImageUpdateUseCase, times(1)).updateTripImage(eq(tripId), any(), any(ImageFile.class));
     }
@@ -84,9 +84,9 @@ public class TripImageUpdateControllerTest extends RestControllerTest {
 
         MockMultipartFile multipartFile = new MockMultipartFile(name, fileName, contentType, fileInputStream);
 
-        String imagePath = String.format("https://{이미지 파일 저장소 주소}/trips/%s/{이미지 파일명}.gif", tripId);
+        String imageURL = String.format("https://{이미지 파일 저장소 주소}/trips/%s/{이미지 파일명}.gif", tripId);
         given(tripImageUpdateUseCase.updateTripImage(eq(tripId), any(), any(ImageFile.class)))
-                .willReturn(imagePath);
+                .willReturn(imageURL);
 
         mockMvc.perform(multipart(POST, "/api/trips/{tripId}/image/update", tripId)
                         .file(multipartFile)
@@ -97,7 +97,7 @@ public class TripImageUpdateControllerTest extends RestControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.tripId").value(tripId))
-                .andExpect(jsonPath("$.imagePath").value(imagePath));
+                .andExpect(jsonPath("$.imageURL").value(imageURL));
 
         verify(tripImageUpdateUseCase, times(1)).updateTripImage(eq(tripId), any(), any(ImageFile.class));
     }
@@ -116,9 +116,9 @@ public class TripImageUpdateControllerTest extends RestControllerTest {
 
         MockMultipartFile multipartFile = new MockMultipartFile(name, fileName, contentType, fileInputStream);
 
-        String imagePath = String.format("https://{이미지 파일 저장소 주소}/trips/%s/{이미지 파일명}.png", tripId);
+        String imageURL = String.format("https://{이미지 파일 저장소 주소}/trips/%s/{이미지 파일명}.png", tripId);
         given(tripImageUpdateUseCase.updateTripImage(eq(tripId), any(), any(ImageFile.class)))
-                .willReturn(imagePath);
+                .willReturn(imageURL);
 
         mockMvc.perform(multipart(POST, "/api/trips/{tripId}/image/update", tripId)
                         .file(multipartFile)
@@ -129,7 +129,7 @@ public class TripImageUpdateControllerTest extends RestControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.tripId").value(tripId))
-                .andExpect(jsonPath("$.imagePath").value(imagePath));
+                .andExpect(jsonPath("$.imageURL").value(imageURL));
 
         verify(tripImageUpdateUseCase, times(1)).updateTripImage(eq(tripId), any(), any(ImageFile.class));
     }
@@ -147,9 +147,9 @@ public class TripImageUpdateControllerTest extends RestControllerTest {
         String contentType = "image/webp";
 
         MockMultipartFile multipartFile = new MockMultipartFile(name, fileName, contentType, fileInputStream);
-        String imagePath = String.format("https://{이미지 파일 저장소 주소}/trips/%s/{이미지 파일명}.webp", tripId);
+        String imageURL = String.format("https://{이미지 파일 저장소 주소}/trips/%s/{이미지 파일명}.webp", tripId);
         given(tripImageUpdateUseCase.updateTripImage(eq(tripId), any(), any(ImageFile.class)))
-                .willReturn(imagePath);
+                .willReturn(imageURL);
 
         mockMvc.perform(multipart(POST, "/api/trips/{tripId}/image/update", tripId)
                         .file(multipartFile)
@@ -160,7 +160,7 @@ public class TripImageUpdateControllerTest extends RestControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.tripId").value(tripId))
-                .andExpect(jsonPath("$.imagePath").value(imagePath));
+                .andExpect(jsonPath("$.imageURL").value(imageURL));
 
         verify(tripImageUpdateUseCase, times(1)).updateTripImage(eq(tripId), any(), any(ImageFile.class));
     }

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/docs/TripImageUpdateControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/command/docs/TripImageUpdateControllerDocsTest.java
@@ -56,9 +56,9 @@ public class TripImageUpdateControllerDocsTest extends RestDocsTestSupport {
 
         MockMultipartFile multipartFile = new MockMultipartFile(name, fileName, contentType, fileInputStream);
 
-        String imagePath = String.format("https://{이미지 파일 저장소 주소}/trips/%s/{이미지 파일명}.jpeg", tripId);
+        String imageURL = String.format("https://{이미지 파일 저장소 주소}/trips/%s/{이미지 파일명}.jpeg", tripId);
         given(tripImageUpdateUseCase.updateTripImage(eq(tripId), any(), any(ImageFile.class)))
-                .willReturn(imagePath);
+                .willReturn(imageURL);
 
         mockMvc.perform(multipart("/api/trips/{tripId}/image/update", tripId)
                         .file(multipartFile)
@@ -69,7 +69,7 @@ public class TripImageUpdateControllerDocsTest extends RestDocsTestSupport {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.tripId").value(tripId))
-                .andExpect(jsonPath("$.imagePath").value(imagePath))
+                .andExpect(jsonPath("$.imageURL").value(imageURL))
                 .andDo(restDocs.document(
                         requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION)
                                         .description("Bearer 타입 AccessToken")
@@ -86,9 +86,9 @@ public class TripImageUpdateControllerDocsTest extends RestDocsTestSupport {
                                 fieldWithPath("tripId")
                                         .type(NUMBER)
                                         .description("수정된 여행(trip) 식별자(id)"),
-                                fieldWithPath("imagePath")
+                                fieldWithPath("imageURL")
                                         .type(STRING)
-                                        .description("이미지가 저장된 경로 URL")
+                                        .description("이미지가 저장된 URL(경로)")
                         )
                 ));
 

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/query/docs/TripperTripListQueryControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/query/docs/TripperTripListQueryControllerDocsTest.java
@@ -6,6 +6,7 @@ import com.cosain.trilo.trip.domain.vo.TripStatus;
 import com.cosain.trilo.trip.infra.dto.TripSummary;
 import com.cosain.trilo.trip.presentation.trip.query.TripperTripListQueryController;
 import com.cosain.trilo.trip.presentation.trip.query.dto.request.TripPageCondition;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -29,6 +30,7 @@ import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(TripperTripListQueryController.class)
@@ -40,7 +42,8 @@ public class TripperTripListQueryControllerDocsTest extends RestDocsTestSupport 
     private final String ACCESS_TOKEN = "Bearer accessToken";
 
     @Test
-    void 사용자_여행_목록_조회() throws Exception{
+    @DisplayName("여행자(사용자)의 여행 목록 조회 문서화 테스트")
+    void tripperTripListQueryDocsTest() throws Exception{
         mockingForLoginUserAnnotation();
 
         Long tripperId = 1L;
@@ -62,7 +65,16 @@ public class TripperTripListQueryControllerDocsTest extends RestDocsTestSupport 
                         .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
                         .characterEncoding(StandardCharsets.UTF_8)
                         .contentType(MediaType.APPLICATION_JSON))
-                .andExpectAll(status().isOk())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.hasNext").value(true))
+                .andExpect(jsonPath("$.trips").isNotEmpty())
+                .andExpect(jsonPath("$.trips.[*].tripId").exists())
+                .andExpect(jsonPath("$.trips.[*].tripperId").exists())
+                .andExpect(jsonPath("$.trips.[*].title").exists())
+                .andExpect(jsonPath("$.trips.[*].status").exists())
+                .andExpect(jsonPath("$.trips.[*].startDate").exists())
+                .andExpect(jsonPath("$.trips.[*].endDate").exists())
+                .andExpect(jsonPath("$.trips.[*].imageURL").exists())
                 .andDo(restDocs.document(
                         requestHeaders(
                                 headerWithName(HttpHeaders.AUTHORIZATION)
@@ -85,7 +97,7 @@ public class TripperTripListQueryControllerDocsTest extends RestDocsTestSupport 
                                 fieldWithPath("status").type(STRING).description("여행 상태"),
                                 fieldWithPath("startDate").type(STRING).description("여행 시작 날짜"),
                                 fieldWithPath("endDate").type(STRING).description("여행 끝 날짜"),
-                                fieldWithPath("imagePath").type(STRING).description("이미지 파일 위치")
+                                fieldWithPath("imageURL").type(STRING).description("이미지가 저장된 URL(경로)")
                         )
                 ));
     }


### PR DESCRIPTION
# JIRA 티켓
- [TRL-359]

# 작업 내역
- [x] imagePath -> imageURL 파라미터명 변경
- [x] 테스트 코드에서 일부 부적절한 코드 수정(테스트 코드에 `LocalDate.now()` 가 삽입된 부분, ...)

# 설명
- 프론트엔드 분들이 API를 읽으실 때, imagePath 라는 명칭보다는 imageURL이 더 직관적이라는 의견이 나왔고, 이에 맞게 수정함.
- 문서에서 imagePath의 설명이 일관적이지 않음. 동일하게 수정

# 참고자료


[TRL-359]: https://cosain.atlassian.net/browse/TRL-359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ