### PR TITLE
[TRL-362] fix: 여행 기간 변경 시 서버측 MySQL 문법 예외 발생 오류 수정

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -9,10 +9,23 @@ on:
 jobs:
   Build-Test:
     runs-on: ubuntu-latest
+    env:
+      DB_DATABASE: trilo_db
+      DB_ROOT_PASSWORD: root
+      DB_USER: test
+      DB_USER_PASSWORD: db1004
 
     steps:
       - name: Check Out (체크 아웃)
         uses: actions/checkout@v3
+
+      - name: Set up MySQL (MySQL 설정)
+        run: |
+          sudo /etc/init.d/mysql start
+          mysql -e "CREATE DATABASE ${{ env.DB_DATABASE }};" -uroot -p${{ env.DB_ROOT_PASSWORD }}
+          mysql -e "CREATE user '${{ env.DB_USER }}'@'%' IDENTIFIED BY '${{ env.DB_USER_PASSWORD }}';" -uroot -p${{ env.DB_ROOT_PASSWORD }}
+          mysql -e "GRANT ALL ON *.* TO 'test'@'%';" -uroot -p${{ env.DB_ROOT_PASSWORD }}
+          mysql -e "FLUSH PRIVILEGES;" -uroot -p${{ env.DB_ROOT_PASSWORD }}
 
       - name: Start Redis (레디스 시작)
         uses: supercharge/redis-github-action@1.5.0

--- a/.github/workflows/deploy-ec2.yml
+++ b/.github/workflows/deploy-ec2.yml
@@ -13,6 +13,11 @@ env:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      DB_DATABASE: trilo_db
+      DB_ROOT_PASSWORD: root
+      DB_USER: test
+      DB_USER_PASSWORD: db1004
 
     steps:
       - name: Check Out (체크 아웃)
@@ -22,6 +27,14 @@ jobs:
         uses: supercharge/redis-github-action@1.5.0
         with:
           redis-version: 7.0.7
+
+      - name: Set up MySQL (MySQL 설정)
+        run: |
+          sudo /etc/init.d/mysql start
+          mysql -e "CREATE DATABASE ${{ env.DB_DATABASE }};" -uroot -p${{ env.DB_ROOT_PASSWORD }}
+          mysql -e "CREATE user '${{ env.DB_USER }}'@'%' IDENTIFIED BY '${{ env.DB_USER_PASSWORD }}';" -uroot -p${{ env.DB_ROOT_PASSWORD }}
+          mysql -e "GRANT ALL ON *.* TO 'test'@'%';" -uroot -p${{ env.DB_ROOT_PASSWORD }}
+          mysql -e "FLUSH PRIVILEGES;" -uroot -p${{ env.DB_ROOT_PASSWORD }}
 
       - name: Set up JDK 17 (JDK 17 설치)
         uses: actions/setup-java@v3

--- a/src/main/java/com/cosain/trilo/trip/domain/repository/ScheduleRepository.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/repository/ScheduleRepository.java
@@ -21,44 +21,50 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     void deleteAllByTripId(@Param("tripId") Long tripId);
 
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE Schedule s " +
-            "SET s.scheduleIndex.value = (" +
-            "  SELECT COUNT(s2) " +
-            "  FROM Schedule s2 " +
-            "  WHERE (:dayId is not null AND s2.day.id = :dayId AND s2.scheduleIndex.value < s.scheduleIndex.value) " +
-            "        OR (:dayId is null AND s2.day is null AND s2.trip.id = :tripId AND s2.scheduleIndex.value < s.scheduleIndex.value) " +
-            ") * 10000000 " +
-            "WHERE s.trip.id = :tripId " +
-            "  AND ((:dayId is not null AND s.day.id = :dayId) OR (:dayId is null AND s.day is null))")
+    @Query(value = """
+            UPDATE schedules s
+            SET s.schedule_index = (
+              SELECT subQuery.countValue * 10000000
+              FROM (
+                SELECT COUNT(s2.schedule_id) AS countValue
+                FROM schedules s2
+                WHERE (:dayId IS NOT NULL AND s2.day_id = :dayId AND s2.schedule_index < s.schedule_index)
+                      OR (:dayId IS NULL AND s2.day_id IS NULL AND s2.trip_id = :tripId AND s2.schedule_index < s.schedule_index)
+              ) AS subQuery
+            )
+            WHERE s.trip_id = :tripId
+              AND ((:dayId IS NOT NULL AND s.day_id = :dayId) OR (:dayId IS NULL AND s.day_id IS NULL))
+           """, nativeQuery = true
+    )
     int relocateDaySchedules(@Param("tripId") Long tripId, @Param("dayId") Long dayId);
 
     @Modifying(clearAutomatically = true)
     @Query(value = "WITH subquery1 AS (" + // 날짜 순 오름차순(같으면 schedule_index 오름차순) 가져오고, 각 행에 순서 번호 부여
-                    "   SELECT " +
-                    "       s2.schedule_id, " +
-                    "       ROW_NUMBER() OVER (ORDER BY d.trip_date ASC, s2.schedule_index ASC) AS row_num " +
-                    "   FROM " +
-                    "       schedules s2 " +
-                    "       JOIN days d ON s2.day_id = d.day_id " +
-                    "   WHERE " +
-                    "       s2.day_id IN :dayIds" +
-                    "), " +
-                    "subquery2 AS (" +
-                    "   SELECT " +
-                    "       MAX(s3.schedule_index) AS max_temporary_storage_schedule_index " + // 임시보관함의 최대 인덱스값 구하기
-                    "   FROM " +
-                    "       schedules s3 " +
-                    "   WHERE " +
-                    "       s3.trip_id = :tripId AND s3.day_id IS NULL" +
-                    ") " +
-                    "UPDATE " +
-                    "   schedules s1 " +
-                    "SET " + // 임시보관함의 제일 뒤로 옮기기
-                    "   s1.day_id = NULL, " +
-                    "   s1.schedule_index = COALESCE((SELECT max_temporary_storage_schedule_index FROM subquery2), -10000000) + " +
-                    "       (SELECT row_num * 10000000 FROM subquery1 WHERE subquery1.schedule_id = s1.schedule_id) " +
-                    "WHERE " +
-                    "   s1.day_id IN :dayIds", nativeQuery = true)
+            "   SELECT " +
+            "       s2.schedule_id, " +
+            "       ROW_NUMBER() OVER (ORDER BY d.trip_date ASC, s2.schedule_index ASC) AS row_num " +
+            "   FROM " +
+            "       schedules s2 " +
+            "       JOIN days d ON s2.day_id = d.day_id " +
+            "   WHERE " +
+            "       s2.day_id IN :dayIds" +
+            "), " +
+            "subquery2 AS (" +
+            "   SELECT " +
+            "       MAX(s3.schedule_index) AS max_temporary_storage_schedule_index " + // 임시보관함의 최대 인덱스값 구하기
+            "   FROM " +
+            "       schedules s3 " +
+            "   WHERE " +
+            "       s3.trip_id = :tripId AND s3.day_id IS NULL" +
+            ") " +
+            "UPDATE " +
+            "   schedules s1 " +
+            "SET " + // 임시보관함의 제일 뒤로 옮기기
+            "   s1.day_id = NULL, " +
+            "   s1.schedule_index = COALESCE((SELECT max_temporary_storage_schedule_index FROM subquery2), -10000000) + " +
+            "       (SELECT row_num * 10000000 FROM subquery1 WHERE subquery1.schedule_id = s1.schedule_id) " +
+            "WHERE " +
+            "   s1.day_id IN :dayIds", nativeQuery = true)
     int moveSchedulesToTemporaryStorage(@Param("tripId") Long tripId, @Param("dayIds") List<Long> dayIds);
 
     @Query("""

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -2,10 +2,10 @@ spring:
   profiles:
     active: test
   datasource:
-    url: jdbc:h2:mem:test;MODE=MYSQL
-    username: sa
-    password:
-    driver-class-name: org.h2.Driver
+    url: jdbc:mysql://localhost:3306/trilo_db
+    username: test
+    password: db1004
+    driver-class-name: com.mysql.cj.jdbc.Driver
 
   data:
     redis:
@@ -71,7 +71,6 @@ spring:
       hibernate:
         # show_sql: true # sout으로 하이버네이트 실행 SQL을 남기는데 이는 아래의 spring.logging.level.org.hibernate.SQL 옵션에서 log로 대체
         format_sql: true # sql을 로깅할 때 예쁘게 보여줌
-        dialect: org.hibernate.dialect.MySQL8Dialect
         create_empty_composites.enabled: true
 
 logging:


### PR DESCRIPTION
# JIRA 티켓
- [TRL-362]

# 작업 내역
- [x] ScheduleRepository.relocateDaySchedule 메서드 쿼리 MySQL native 쿼리로 수정
- [x] 빌드테스트 설정을 MySQL 설정으로 변경
- [x] 빌드 스크립트 - MySQL 셋업 설정

# 설명
- 로컬, 테스트 환경에서는 H2 데이터베이스를 사용하면서 MySQL 방언을 적용하여 테스트를 수행했습니다. 이것을 기준으로 테스트를 했을 때는 문제가 없는 것 처럼 보였습니다.
- 하지만, 서버환경에서는 실제 MySQL을 사용하고 있고, 문법 예외가 발생했습니다. 우리가 JPQL로 작성한 쿼리로 실행했을 때와 실사용 DB의 환경 불일치로 인한 문제라고 생각됩니다.
- MySQL에서 작동하도록 쿼리를 작성하였을 경우 MySQL 기반으로 테스트를 한 결과 테스트 코드는 정상 동작하며, 로컬에서 실제 실행 테스트를 했을 경우, 정상 동작합니다. 하지만 H2로 의존 데이터베이스를 변경하면 제대로 동작하지 않습니다.
- 실사용 DB에서 제대로 동작되지 않는 다면 테스트코드의 신뢰성이 떨어질 수 밖에 없다는 결론에 이르렀고, 저는 실사용 DB에 맞춰서 빌드 테스트에서도 MySQL 기반 테스트가 진행되도록 하였습니다. 실제로 애플리케이션이 Cloud 환경에서 올바르게 게 동작하기 위해서 지켜야 하는 12가지 규칙을 제시한 [12 factors](https://12factor.net/) 의 10번 원칙에서는 개발/프로덕션 환경의 일치를 원칙으로 내세운 바가 있기도 합니다.
- [생각] nativer Query는 나쁜가?
  - 추후 사용 데이터베이스 변경 시 nativer Query가 많을 경우 이 부분에 대해서 수정이 필요한 것은 사실입니다.
  - 하지만 ORM에만 의존하여 기능을 개발할 경우 ORM이 가진 기능적/문법적 제약 때문에 성능 최적화, 혹은 복잡한 쿼리를 작성해야하는 경우 이 부분에서 ORM 문법이 허용한 내에서 쿼리를 작성함으로서 기능 구현의 자유도를 해치는 경우도 발생합니다. 복잡한 대형 쿼리의 경우 성능 튜닝 관점에서 결국 native query가 필요할 가능성이 큽니다.
  - 또, 예를 들어 JPA의 saveAll() 과 같은 기능을 놓고보면 일괄적으로 엔티티를 영속화 시켜야하는데, 결국 엔티티 갯수만큼 쿼리가 날아갑니다. 이러한 기능은 JdbcTemplate, MyBatis 등을 통해 native Query를 통해 bulk insert를 통해 최적화 시킬 수 있습니다.
  - 우리의 기능에서 복잡한 대형 벌크성 쿼리가 필요한 부분 은 임시보관함으로 기존 일정들 일괄 이동, 특정 day/임시보관함 전체 재배치, Day 일괄 삽입, 등이 있는데 이러한 부분에 대해서는 저는 native Query를 써도 된다고 생각합니다.
  - 물론 ORM으로 해결할 수 있는 간단한 문제에 대해서는 저는 ORM을 씀으로서 추후 데이터베이스 구현체 교체 시 영향을 최소화 시킬 수 있는 관점에서 좋다고 봅니다.

# 참고자료
- [12factors](https://12factor.net/)


[TRL-362]: https://cosain.atlassian.net/browse/TRL-362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ