### PR TITLE
[TRL-367] fix: 회원 프로필 조회 API 문서 잘못된 파라미터 전달 수정

### DIFF
--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/query/docs/TripperTripListQueryControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/query/docs/TripperTripListQueryControllerDocsTest.java
@@ -42,8 +42,7 @@ public class TripperTripListQueryControllerDocsTest extends RestDocsTestSupport 
     private final String ACCESS_TOKEN = "Bearer accessToken";
 
     @Test
-    @DisplayName("여행자(사용자)의 여행 목록 조회 문서화 테스트")
-    void tripperTripListQueryDocsTest() throws Exception{
+    void 사용자_여행_목록_조회() throws Exception{
         mockingForLoginUserAnnotation();
 
         Long tripperId = 1L;

--- a/src/test/java/com/cosain/trilo/unit/user/presentation/UserRestControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/user/presentation/UserRestControllerDocsTest.java
@@ -32,7 +32,7 @@ public class UserRestControllerDocsTest extends RestDocsTestSupport {
     @Test
     public void 사용자_프로필_조회() throws Exception{
         // given
-        Long userId = 2L;
+        Long userId = 1L;
         mockingForLoginUserAnnotation();
         given(userService.getUserProfile(userId, 1L)).willReturn(UserProfileResponse.from(KAKAO_MEMBER.create()));
 

--- a/src/test/java/com/cosain/trilo/unit/user/presentation/UserRestControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/user/presentation/UserRestControllerDocsTest.java
@@ -2,6 +2,7 @@ package com.cosain.trilo.unit.user.presentation;
 
 import com.cosain.trilo.support.RestDocsTestSupport;
 import com.cosain.trilo.user.application.UserService;
+import com.cosain.trilo.user.domain.User;
 import com.cosain.trilo.user.presentation.UserRestController;
 import com.cosain.trilo.user.presentation.dto.UserProfileResponse;
 import org.apache.http.HttpHeaders;
@@ -34,9 +35,9 @@ public class UserRestControllerDocsTest extends RestDocsTestSupport {
         // given
         Long userId = 1L;
         mockingForLoginUserAnnotation();
-        given(userService.getUserProfile(userId, 1L)).willReturn(UserProfileResponse.from(KAKAO_MEMBER.create()));
+        User requestUser = KAKAO_MEMBER.create();
+        given(userService.getUserProfile(userId, requestUser.getId())).willReturn(UserProfileResponse.from(requestUser));
 
-        mockingForLoginUserAnnotation();
         // when & then
         mockMvc.perform(RestDocumentationRequestBuilders.get(BASE_URL + "/{userId}/profile", userId)
                         .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN))


### PR DESCRIPTION
# JIRA 티켓
[TRL-367]

# 작업 내역

- [x] 회원 프로필 조회 API 문서에서 잘못된 파라미터를 전달하고 있는 부분 수정


[TRL-367]: https://cosain.atlassian.net/browse/TRL-367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ