### PR TITLE
[TRL-368] chore: 회원 프로필 조회 기능 명확한 변수명으로 수정 및 예외 코드 수정

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -822,7 +822,7 @@ include::{snippets}/trip-day-list-query-controller-docs-test/day_목록_조회/h
 ==== 기본 정보
 
 - 메서드 : GET
-- URL : `/api/users/profile`
+- URL : `/api/users/{userId}/profile`
 - 인증 방식 : 엑세스 토큰
 
 ==== 요청

--- a/src/main/java/com/cosain/trilo/user/application/UserService.java
+++ b/src/main/java/com/cosain/trilo/user/application/UserService.java
@@ -1,7 +1,7 @@
 package com.cosain.trilo.user.application;
 
-import com.cosain.trilo.common.exception.UserNotFoundException;
 import com.cosain.trilo.user.application.exception.NoUserProfileSearchAuthorityException;
+import com.cosain.trilo.user.application.exception.UserNotFoundException;
 import com.cosain.trilo.user.domain.User;
 import com.cosain.trilo.user.domain.UserRepository;
 import com.cosain.trilo.user.presentation.dto.UserProfileResponse;

--- a/src/main/java/com/cosain/trilo/user/application/exception/UserNotFoundException.java
+++ b/src/main/java/com/cosain/trilo/user/application/exception/UserNotFoundException.java
@@ -1,0 +1,35 @@
+package com.cosain.trilo.user.application.exception;
+
+import com.cosain.trilo.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class UserNotFoundException extends CustomException {
+
+    private static final String ERROR_CODE = "user-0003";
+    private static final HttpStatus HTTP_STATUS = HttpStatus.NOT_FOUND;
+
+    public UserNotFoundException() {
+    }
+
+    public UserNotFoundException(String debugMessage) {
+        super(debugMessage);
+    }
+
+    public UserNotFoundException(Throwable cause) {
+        super(cause);
+    }
+
+    public UserNotFoundException(String debugMessage, Throwable cause) {
+        super(debugMessage, cause);
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HTTP_STATUS;
+    }
+}

--- a/src/main/java/com/cosain/trilo/user/presentation/UserRestController.java
+++ b/src/main/java/com/cosain/trilo/user/presentation/UserRestController.java
@@ -18,8 +18,8 @@ public class UserRestController {
 
     @GetMapping("/{userId}/profile")
     @ResponseStatus(HttpStatus.OK)
-    public UserProfileResponse getUserProfile(@PathVariable Long userId, @LoginUser User user){
-        UserProfileResponse userProfileResponse = userService.getUserProfile(userId, user.getId());
+    public UserProfileResponse getUserProfile(@PathVariable("userId") Long targetUserId, @LoginUser User user){
+        UserProfileResponse userProfileResponse = userService.getUserProfile(targetUserId, user.getId());
         return userProfileResponse;
     }
 

--- a/src/main/resources/exceptions/exception.yml
+++ b/src/main/resources/exceptions/exception.yml
@@ -72,6 +72,10 @@ user-0002:
   message: No UserProfile Search Authority
   detail: 해당 사용자 프로필을 조회할 권한이 없습니다.
 
+user-0003:
+  message: UserNotFound
+  detail: 해당 사용자가 존재하지 않습니다.
+
 
 # 여행 관련
 trip-0001:

--- a/src/main/resources/exceptions/exception_en.yml
+++ b/src/main/resources/exceptions/exception_en.yml
@@ -69,6 +69,13 @@ user-0001:
   message: TripperNotFound
   detail: The traveler with the matching identifier could not be found.
 
+user-0002:
+  message: No UserProfile Search Authority
+  detail: You do not have any authority to search the user profile
+
+user-0003:
+  message: UserNotFound
+  detail: The User with the matching identifier could not be found.
 
 # 여행 관련
 trip-0001:

--- a/src/test/java/com/cosain/trilo/unit/user/application/UserServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/user/application/UserServiceTest.java
@@ -1,13 +1,12 @@
 package com.cosain.trilo.unit.user.application;
 
-import com.cosain.trilo.common.exception.UserNotFoundException;
 import com.cosain.trilo.user.application.UserService;
 import com.cosain.trilo.user.application.exception.NoUserProfileSearchAuthorityException;
+import com.cosain.trilo.user.application.exception.UserNotFoundException;
 import com.cosain.trilo.user.domain.AuthProvider;
 import com.cosain.trilo.user.domain.Role;
 import com.cosain.trilo.user.domain.User;
 import com.cosain.trilo.user.domain.UserRepository;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;


### PR DESCRIPTION
# JIRA 티켓
[TRL-368]

# 작업 내역
- [x] 회원 프로필 조회 기능에서 경로 변수 바인딩 -> `targetUserId` 으로 변경
- [x] 검색하려는 회원이 존재하지 않을 때 발생하는 별도의 404 예외 코드 생성 `user-0003`


[TRL-368]: https://cosain.atlassian.net/browse/TRL-368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ