### PR TITLE
[TRL-378] fix: 일정 본문 크기로 인한 데이터베이스 오류 발생 -> 본문 바이트 제한 수정

### DIFF
--- a/src/main/java/com/cosain/trilo/trip/domain/vo/ScheduleContent.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/vo/ScheduleContent.java
@@ -5,6 +5,9 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.*;
 
+import java.nio.charset.StandardCharsets;
+
+
 @Getter
 @EqualsAndHashCode(of = {"value"})
 @ToString(of = {"value"})
@@ -13,15 +16,24 @@ import lombok.*;
 public class ScheduleContent {
 
     private static final ScheduleContent DEFAULT_CONTENT = ScheduleContent.of("");
+    private static final int MAX_BYTE = 65535;
 
-    @Column(name = "content")
+    @Column(name = "content", length = MAX_BYTE)
     private String value;
 
     public static ScheduleContent of(String rawContent) {
+        validateContent(rawContent);
+        return new ScheduleContent(rawContent);
+    }
+
+    private static void validateContent(String rawContent) {
         if (rawContent == null) {
             throw new InvalidScheduleContentException("일정의 본문이 null");
         }
-        return new ScheduleContent(rawContent);
+        int textSize = rawContent.getBytes(StandardCharsets.UTF_8).length;
+        if (textSize > MAX_BYTE) {
+            throw new InvalidScheduleContentException("일정의 본문 크기가 제한보다 큼");
+        }
     }
 
     public static ScheduleContent defaultContent() {

--- a/src/main/resources/exceptions/exception.yml
+++ b/src/main/resources/exceptions/exception.yml
@@ -178,7 +178,7 @@ schedule-0011:
 
 schedule-0012:
   message: Invalid Schedule Content
-  detail: 일정의 본문은 null일 수 없습니다.
+  detail: 일정의 본문은 null일 수 없으며, 크기는 65535 byte를 초과할 수 없습니다.
 
 # 장소 관련
 place-0001:

--- a/src/main/resources/exceptions/exception_en.yml
+++ b/src/main/resources/exceptions/exception_en.yml
@@ -179,7 +179,7 @@ schedule-0011:
 
 schedule-0012:
   message: Invalid Schedule Content
-  detail: The schedule content cannot be null;
+  detail: The content of the schedule cannot be null and its size cannot exceed 65535 bytes.
 
 # 장소 관련
 place-0001:

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/vo/ScheduleContentTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/vo/ScheduleContentTest.java
@@ -7,13 +7,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("ScheduleContent(일정 본문) 테스트")
 public class ScheduleContentTest {
 
-    @DisplayName("일정 본문이 null 이 아닌 문자열(공백 허용) -> 정상 생성")
+    @DisplayName("일정 본문이 null 이 아닌 적정 길이의 문자열(공백 허용) -> 정상 생성")
     @ValueSource(strings = {"일정 본문", "", "     "})
     @ParameterizedTest
     void successCreateTest(String rawContent) {
@@ -37,8 +40,37 @@ public class ScheduleContentTest {
                 .isInstanceOf(InvalidScheduleContentException.class);
     }
 
+    @DisplayName("일정 본문 바이트 크기 65535 -> 정상 생성")
     @Test
-    @DisplayName("디폴트 ScheduleContents는 빈 문자열이다.")
+    public void maxContentTest() {
+        // given
+        byte[] bytes = new byte[65535];
+        Arrays.fill(bytes, (byte) 'A');
+        String rawContent = new String(bytes, StandardCharsets.UTF_8);
+
+        // when
+        ScheduleContent scheduleContent = ScheduleContent.of(rawContent);
+
+        // then
+        assertThat(scheduleContent.getValue()).isEqualTo(rawContent);
+    }
+
+    @DisplayName("일정 본문 바이트 크기 65535 초과 -> InvalidScheduleContentException")
+    @ParameterizedTest
+    @ValueSource(ints = {65536, 65537, 12345678})
+    public void largeContentText(int size) {
+        // given
+        byte[] bytes = new byte[size];
+        Arrays.fill(bytes, (byte) 'A');
+        String rawContent = new String(bytes, StandardCharsets.UTF_8);
+
+        // when && then
+        assertThatThrownBy(()-> ScheduleContent.of(rawContent))
+                .isInstanceOf(InvalidScheduleContentException.class);
+    }
+
+    @Test
+    @DisplayName("디폴트 ScheduleContent는 빈 문자열이다.")
     void testDefault() {
         // when
         ScheduleContent scheduleContent = ScheduleContent.defaultContent();

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/docs/ScheduleUpdateControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/command/docs/ScheduleUpdateControllerDocsTest.java
@@ -95,7 +95,7 @@ public class ScheduleUpdateControllerDocsTest extends RestDocsTestSupport {
                                 fieldWithPath("content")
                                         .type(STRING)
                                         .description("일정의 본문")
-                                        .attributes(key("constraints").value("null을 허용하지 않습니다. (공백, 빈문자열 허용)")),
+                                        .attributes(key("constraints").value("null을 허용하지 않으며 최대 65535 바이트까지 허용합니다. (공백, 빈문자열 허용)")),
                                 fieldWithPath("startTime")
                                         .type(STRING)
                                         .description("일정의 시작시간. 필수."),


### PR DESCRIPTION
# JIRA 티켓
- [TRL-378]

# 작업 내역
- [x] ScheduleContent 데이터베이스 바이트 제약 추가(65535 바이트까지)
- [x] ScheduleContent 도메인 제약 추가(65535 바이트까지)
- [x] ScheduleUpdateCommandFactory 검증 로직 테스트코드 추가 작성
- [x] 일정 수정 API 문서 수정 반영

# 설명
- 도메인 상에서 일정 본문의 크기 제한을 걸어두지 않았음
- 하지만 ddl-auto로 생성된 일정 본문의 데이터베이스 타입은 varchar(255)임
- 데이터베이스 상에서의 일정 본문의 크기 제약을 65535 byte로 함
- 또, ScheduleContent 생성 시점에서 바이트 크기 검증을 수행하여 사전에 도메인적으로 예외를 발생시키게 함

# 참고자료


[TRL-378]: https://cosain.atlassian.net/browse/TRL-378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ