### PR TITLE
[TRL-380] feat: 회원 탈퇴 API 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -833,6 +833,8 @@ include::{snippets}/trip-day-list-query-controller-docs-test/day_목록_조회/h
 ==== 요청
 ===== 헤더
 include::{snippets}/user-rest-controller-docs-test/사용자_프로필_조회/request-headers.adoc[]
+===== 경로 변수
+include::{snippets}/user-rest-controller-docs-test/사용자_프로필_조회/path-parameters.adoc[]
 ==== 응답
 ===== 본문
 include::{snippets}/user-rest-controller-docs-test/사용자_프로필_조회/response-fields.adoc[]
@@ -841,3 +843,24 @@ include::{snippets}/user-rest-controller-docs-test/사용자_프로필_조회/re
 include::{snippets}/user-rest-controller-docs-test/사용자_프로필_조회/http-request.adoc[]
 ===== 응답
 include::{snippets}/user-rest-controller-docs-test/사용자_프로필_조회/http-response.adoc[]
+
+=== 회원 탈퇴
+
+==== 기본 정보
+
+- 메서드 : DELETE
+- URL : `/api/users/{userId}`
+- 인증 방식 : 엑세스 토큰
+
+회원 탈퇴 시 회원의 개인정보를 비롯하여 해당 회원이 작성했던 모든 회원 관련 여행 정보들이 함께 삭제됩니다.
+
+==== 요청
+===== 헤더
+include::{snippets}/user-rest-controller-docs-test/회원_탈퇴/request-headers.adoc[]
+===== 경로 변수
+include::{snippets}/user-rest-controller-docs-test/회원_탈퇴/path-parameters.adoc[]
+==== 예제
+===== 요청
+include::{snippets}/user-rest-controller-docs-test/회원_탈퇴/http-request.adoc[]
+===== 응답
+include::{snippets}/user-rest-controller-docs-test/회원_탈퇴/http-response.adoc[]

--- a/src/main/java/com/cosain/trilo/config/AsyncConfig.java
+++ b/src/main/java/com/cosain/trilo/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package com.cosain.trilo.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/com/cosain/trilo/trip/application/event/TripEventListener.java
+++ b/src/main/java/com/cosain/trilo/trip/application/event/TripEventListener.java
@@ -1,0 +1,22 @@
+package com.cosain.trilo.trip.application.event;
+
+import com.cosain.trilo.trip.application.trip.command.service.TripAllDeleteService;
+import com.cosain.trilo.user.application.event.UserDeleteEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class TripEventListener {
+
+    private final TripAllDeleteService tripAllDeleteService;
+
+    @Async
+    @TransactionalEventListener
+    public void handle(UserDeleteEvent event){
+        Long tripperId = event.getUserId();
+        tripAllDeleteService.deleteAllByTripperId(tripperId);
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/application/trip/command/service/TripAllDeleteService.java
+++ b/src/main/java/com/cosain/trilo/trip/application/trip/command/service/TripAllDeleteService.java
@@ -1,0 +1,30 @@
+package com.cosain.trilo.trip.application.trip.command.service;
+
+import com.cosain.trilo.trip.domain.entity.Trip;
+import com.cosain.trilo.trip.domain.repository.DayRepository;
+import com.cosain.trilo.trip.domain.repository.ScheduleRepository;
+import com.cosain.trilo.trip.domain.repository.TripRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TripAllDeleteService {
+
+    private final TripRepository tripRepository;
+    private final DayRepository dayRepository;
+    private final ScheduleRepository scheduleRepository;
+
+    public void deleteAllByTripperId(Long tripperId){
+        List<Trip> trips = tripRepository.findAllByTripperId(tripperId);
+        List<Long> tripIdsForDelete = trips.stream().map(Trip::getId).collect(Collectors.toList());
+        scheduleRepository.deleteAllByTripIds(tripIdsForDelete);
+        dayRepository.deleteAllByTripIds(tripIdsForDelete);
+        tripRepository.deleteAllByTripperId(tripperId);
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/domain/repository/DayRepository.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/repository/DayRepository.java
@@ -23,4 +23,8 @@ public interface DayRepository extends JpaRepository<Day, Long> {
     @Modifying
     @Query("DELETE FROM Day as d WHERE d.trip.id = :tripId")
     void deleteAllByTripId(@Param("tripId") Long tripId);
+
+    @Modifying
+    @Query("DELETE FROM Day as d WHERE d.trip.id in :tripIds")
+    void deleteAllByTripIds(@Param("tripIds") List<Long> tripIds);
 }

--- a/src/main/java/com/cosain/trilo/trip/domain/repository/ScheduleRepository.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/repository/ScheduleRepository.java
@@ -80,4 +80,8 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             WHERE s.day.id = :dayId
             """)
     int findDayScheduleCount(@Param("dayId") Long dayId);
+
+    @Modifying
+    @Query("DELETE FROM Schedule s WHERE s.trip.id in :tripIdsForDelete")
+    void deleteAllByTripIds(@Param("tripIdsForDelete") List<Long> tripIdsForDelete);
 }

--- a/src/main/java/com/cosain/trilo/trip/domain/repository/TripRepository.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/repository/TripRepository.java
@@ -2,9 +2,11 @@ package com.cosain.trilo.trip.domain.repository;
 
 import com.cosain.trilo.trip.domain.entity.Trip;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TripRepository extends JpaRepository<Trip, Long> {
@@ -13,4 +15,12 @@ public interface TripRepository extends JpaRepository<Trip, Long> {
             " FROM Trip as t LEFT JOIN FETCH t.days" +
             " WHERE t.id = :id")
     Optional<Trip> findByIdWithDays(@Param("id") Long tripId);
+
+    @Query("SELECT t FROM Trip as t WHERE t.tripperId = :tripperId")
+    List<Trip> findAllByTripperId(@Param("tripperId") Long tripperId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Trip t WHERE t.tripperId = :tripperId")
+    void deleteAllByTripperId(@Param("tripperId") Long tripperId);
+
 }

--- a/src/main/java/com/cosain/trilo/user/application/UserService.java
+++ b/src/main/java/com/cosain/trilo/user/application/UserService.java
@@ -1,19 +1,24 @@
 package com.cosain.trilo.user.application;
 
+import com.cosain.trilo.user.application.event.UserDeleteEvent;
+import com.cosain.trilo.user.application.exception.NoUserDeleteAuthorityException;
 import com.cosain.trilo.user.application.exception.NoUserProfileSearchAuthorityException;
 import com.cosain.trilo.user.application.exception.UserNotFoundException;
 import com.cosain.trilo.user.domain.User;
 import com.cosain.trilo.user.domain.UserRepository;
 import com.cosain.trilo.user.presentation.dto.UserProfileResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class UserService {
 
     private final UserRepository userRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional(readOnly = true)
     public UserProfileResponse getUserProfile(Long targetUserId, Long requestUserId){
@@ -31,5 +36,21 @@ public class UserService {
 
     private User findUserOrThrows(Long userId) {
         return userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+    }
+
+    public void delete(Long targetUserId, Long requestUserId){
+
+        validateUserDeleteAuthority(targetUserId, requestUserId);
+        User findUser = userRepository.findById(targetUserId)
+                .orElseThrow(UserNotFoundException::new);
+
+        eventPublisher.publishEvent(new UserDeleteEvent(findUser.getId())); // 비동기적으로 사용자 관련된 여행 정보 삭제
+        userRepository.deleteById(targetUserId);
+    }
+
+    private void validateUserDeleteAuthority(Long targetUserId, Long requestUserId){
+        if(!targetUserId.equals(requestUserId)){
+            throw new NoUserDeleteAuthorityException();
+        }
     }
 }

--- a/src/main/java/com/cosain/trilo/user/application/event/UserDeleteEvent.java
+++ b/src/main/java/com/cosain/trilo/user/application/event/UserDeleteEvent.java
@@ -1,0 +1,13 @@
+package com.cosain.trilo.user.application.event;
+
+import lombok.Getter;
+
+@Getter
+public class UserDeleteEvent {
+
+    private final Long userId;
+    public UserDeleteEvent(Long userId) {
+        this.userId = userId;
+    }
+
+}

--- a/src/main/java/com/cosain/trilo/user/application/exception/NoUserDeleteAuthorityException.java
+++ b/src/main/java/com/cosain/trilo/user/application/exception/NoUserDeleteAuthorityException.java
@@ -1,0 +1,35 @@
+package com.cosain.trilo.user.application.exception;
+
+import com.cosain.trilo.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class NoUserDeleteAuthorityException extends CustomException {
+
+    private static final String ERROR_CODE = "user-0004";
+    private static final HttpStatus HTTP_STATUS = HttpStatus.FORBIDDEN;
+
+    public NoUserDeleteAuthorityException() {
+    }
+
+    public NoUserDeleteAuthorityException(String debugMessage) {
+        super(debugMessage);
+    }
+
+    public NoUserDeleteAuthorityException(Throwable cause) {
+        super(cause);
+    }
+
+    public NoUserDeleteAuthorityException(String debugMessage, Throwable cause) {
+        super(debugMessage, cause);
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HTTP_STATUS;
+    }
+}

--- a/src/main/java/com/cosain/trilo/user/presentation/UserRestController.java
+++ b/src/main/java/com/cosain/trilo/user/presentation/UserRestController.java
@@ -4,7 +4,6 @@ import com.cosain.trilo.common.LoginUser;
 import com.cosain.trilo.user.application.UserService;
 import com.cosain.trilo.user.domain.User;
 import com.cosain.trilo.user.presentation.dto.UserProfileResponse;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -21,6 +20,12 @@ public class UserRestController {
     public UserProfileResponse getUserProfile(@PathVariable("userId") Long targetUserId, @LoginUser User user){
         UserProfileResponse userProfileResponse = userService.getUserProfile(targetUserId, user.getId());
         return userProfileResponse;
+    }
+
+    @DeleteMapping("/{userId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteUser(@PathVariable("userId") Long targetUserId, @LoginUser User user){
+        userService.delete(targetUserId, user.getId());
     }
 
 }

--- a/src/main/resources/exceptions/exception.yml
+++ b/src/main/resources/exceptions/exception.yml
@@ -76,6 +76,10 @@ user-0003:
   message: UserNotFound
   detail: 해당 사용자가 존재하지 않습니다.
 
+user-004:
+  message: No User Delete Authority
+  detail: 해당 사용자를 삭제할 권한이 없습니다.
+
 
 # 여행 관련
 trip-0001:

--- a/src/main/resources/exceptions/exception_en.yml
+++ b/src/main/resources/exceptions/exception_en.yml
@@ -77,6 +77,10 @@ user-0003:
   message: UserNotFound
   detail: The User with the matching identifier could not be found.
 
+user-004:
+  message: No User Delete Authority
+  detail: You do not have any authority to delete the user
+
 # 여행 관련
 trip-0001:
   message: Trip Not Found

--- a/src/test/java/com/cosain/trilo/integration/user/UserIntegrationTest.java
+++ b/src/test/java/com/cosain/trilo/integration/user/UserIntegrationTest.java
@@ -3,14 +3,14 @@ package com.cosain.trilo.integration.user;
 import com.cosain.trilo.support.IntegrationTest;
 import com.cosain.trilo.user.domain.User;
 import com.cosain.trilo.user.domain.UserRepository;
+import jakarta.persistence.EntityManager;
 import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 
-import static com.cosain.trilo.fixture.UserFixture.GOOGLE_MEMBER;
-import static com.cosain.trilo.fixture.UserFixture.KAKAO_MEMBER;
+import static com.cosain.trilo.fixture.UserFixture.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -20,6 +20,9 @@ public class UserIntegrationTest extends IntegrationTest {
 
     @Autowired
     UserRepository userRepository;
+
+    @Autowired
+    EntityManager entityManager;
 
     @Nested
     class 회원_프로필_조회{
@@ -41,7 +44,7 @@ public class UserIntegrationTest extends IntegrationTest {
         }
 
         @Test
-        void 회원_프로필_조회_시_다른_회원의_프로필을_조회할_경우_403_에러를_발생시킨다() throws Exception{
+        void 회원_프로필_조회_시_다른_회원의_프로필을_조회할_경우_403_응답() throws Exception{
             // given
             User user = userRepository.save(KAKAO_MEMBER.create());
             User anotherUser = userRepository.save(GOOGLE_MEMBER.create());
@@ -57,7 +60,38 @@ public class UserIntegrationTest extends IntegrationTest {
         }
     }
 
+    @Nested
+    class 회원_탈퇴{
+        @Test
+        void 회원_탈퇴_성공() throws Exception{
+            // given
+            User user = userRepository.save(KAKAO_MEMBER.create());
+            String accessToken = createAccessToken(user.getId());
 
+            // when & then
+            mockMvc.perform(RestDocumentationRequestBuilders.delete(BASE_URL + "/{userId}", user.getId())
+                    .header(HttpHeaders.AUTHORIZATION, TOKEN_TYPE + accessToken))
+                    .andExpect(status().isNoContent());
+
+        }
+
+        @Test
+        void 회원_탈퇴_시_본인이_아닌_회원의_탈퇴_요청을_하는_경우_403_응답() throws Exception{
+            // given
+            User user = userRepository.save(KAKAO_MEMBER.create());
+            User anotherUser  = userRepository.save(NAVER_MEMBER.create());
+            String accessToken = createAccessToken(user.getId());
+            System.out.println(user.getId() +" "+ anotherUser.getId());
+
+            // when & then
+            mockMvc.perform(RestDocumentationRequestBuilders.delete(BASE_URL + "/{userId}", anotherUser.getId())
+                            .header(HttpHeaders.AUTHORIZATION, TOKEN_TYPE + accessToken))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.errorCode").value("user-0004"))
+                    .andExpect(jsonPath("$.errorMessage").exists())
+                    .andExpect(jsonPath("$.errorDetail").exists());
+        }
+    }
 
 
 }

--- a/src/test/java/com/cosain/trilo/support/IntegrationTest.java
+++ b/src/test/java/com/cosain/trilo/support/IntegrationTest.java
@@ -7,12 +7,14 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@Transactional
 public class IntegrationTest {
 
     @Autowired

--- a/src/test/java/com/cosain/trilo/unit/trip/application/trip/command/service/TripAllDeleteServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/trip/command/service/TripAllDeleteServiceTest.java
@@ -1,0 +1,43 @@
+package com.cosain.trilo.unit.trip.application.trip.command.service;
+
+import com.cosain.trilo.trip.application.trip.command.service.TripAllDeleteService;
+import com.cosain.trilo.trip.domain.repository.DayRepository;
+import com.cosain.trilo.trip.domain.repository.ScheduleRepository;
+import com.cosain.trilo.trip.domain.repository.TripRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class TripAllDeleteServiceTest {
+
+    @InjectMocks
+    private TripAllDeleteService tripAllDeleteService;
+
+    @Mock
+    private TripRepository tripRepository;
+    @Mock
+    private ScheduleRepository scheduleRepository;
+    @Mock
+    private DayRepository dayRepository;
+
+    @Test
+    void 메서드_호출_테스트(){
+        // given
+        Long tripperId = 1L;
+
+        // when
+        tripAllDeleteService.deleteAllByTripperId(tripperId);
+
+        // then
+        verify(tripRepository).findAllByTripperId(any());
+        verify(tripRepository).deleteAllByTripperId(any());
+        verify(dayRepository).deleteAllByTripIds(any());
+        verify(scheduleRepository).deleteAllByTripIds(any());
+    }
+}

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/repository/DayRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/repository/DayRepositoryTest.java
@@ -5,12 +5,10 @@ import com.cosain.trilo.support.RepositoryTest;
 import com.cosain.trilo.trip.domain.entity.Day;
 import com.cosain.trilo.trip.domain.entity.Trip;
 import com.cosain.trilo.trip.domain.repository.DayRepository;
-import com.cosain.trilo.trip.domain.vo.TripPeriod;
-import com.cosain.trilo.trip.domain.vo.TripStatus;
-import com.cosain.trilo.trip.domain.vo.TripTitle;
 import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
@@ -106,4 +104,38 @@ public class DayRepositoryTest {
         List<Day> findDays = dayRepository.findAllById(List.of(day1.getId(), day2.getId(), day3.getId()));
         assertThat(findDays).isEmpty();
     }
+
+    @Nested
+    class deleteAllByTripIdsTest{
+
+        @Test
+        void 전달받은_여행_ID_목록에_해당하는_모든_Day가_제거된다(){
+            // given
+            Trip trip1 = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023,3,1), LocalDate.of(2023,3,3));
+            Trip trip2 = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023,3,1), LocalDate.of(2023,3,3));
+            Trip trip3 = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023,3,1), LocalDate.of(2023,3,3));
+
+            em.persist(trip1);
+            em.persist(trip2);
+            em.persist(trip3);
+
+            Day day1 = trip1.getDays().get(0);
+            Day day2 = trip2.getDays().get(0);
+            Day day3 = trip3.getDays().get(0);
+
+            em.persist(day1);
+            em.persist(day2);
+            em.persist(day3);
+
+            // when
+            dayRepository.deleteAllByTripIds(List.of(trip1.getId(), trip2.getId(), trip3.getId()));
+
+            // then
+            List<Day> days = dayRepository.findAllById(List.of(day1.getId(), day2.getId(), day3.getId()));
+            assertThat(days).isEmpty();
+
+        }
+    }
+
+
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/repository/ScheduleRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/repository/ScheduleRepositoryTest.java
@@ -545,4 +545,38 @@ public class ScheduleRepositoryTest {
         }
     }
 
+    @Nested
+    class deleteAllByTripIdsTest{
+        @Test
+        void 전달받은_여행_ID_목록에_해당하는_모든_일정이_삭제된다(){
+
+            // given
+            Trip trip = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023,3,1), LocalDate.of(2023,3,2));
+            em.persist(trip);
+
+            Day day1 = trip.getDays().get(0);
+            Day day2 = trip.getDays().get(1);
+            em.persist(day1);
+            em.persist(day2);
+
+            Schedule schedule1 = trip.createSchedule(day1, ScheduleTitle.of("일정제목1"), Place.of("장소식별자1", "장소명1", Coordinate.of(34.127, 124.7771)));
+            Schedule schedule2 = trip.createSchedule(day1, ScheduleTitle.of("일정제목2"), Place.of("장소식별자2", "장소명2", Coordinate.of(34.127, 124.7771)));
+            Schedule schedule3 = trip.createSchedule(null, ScheduleTitle.of("일정제목3"), Place.of("장소식별자3", "장소명3", Coordinate.of(34.127, 124.7771)));
+            Schedule schedule4 = trip.createSchedule(null, ScheduleTitle.of("일정제목4"), Place.of("장소식별자4", "장소명4", Coordinate.of(34.127, 124.7771)));
+            Schedule schedule5 = trip.createSchedule(day2, ScheduleTitle.of("일정제목5"), Place.of("장소식별자5", "장소명5", Coordinate.of(34.127, 124.7771)));
+            em.persist(schedule1);
+            em.persist(schedule2);
+            em.persist(schedule3);
+            em.persist(schedule4);
+            em.persist(schedule5);
+
+            // when
+            scheduleRepository.deleteAllByTripIds(List.of(trip.getId()));
+
+            // then
+            List<Schedule> findSchedules = scheduleRepository.findAllById(List.of(schedule1.getId(), schedule2.getId(), schedule3.getId(), schedule4.getId(), schedule5.getId()));
+            assertThat(findSchedules).isEmpty();
+        }
+    }
+
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/repository/TripRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/repository/TripRepositoryTest.java
@@ -169,4 +169,33 @@ public class TripRepositoryTest {
         Trip findTrip = tripRepository.findById(trip.getId()).orElse(null);
         assertThat(findTrip).isNull();
     }
+
+    @Nested
+    class deleteAllByTripperIdTest{
+        @Test
+        void tripperId_에_해당하는_모든_trip이_제거된다(){
+            // given
+            Long tripperId = 1L;
+            Trip trip1 = Trip.create(TripTitle.of("여행 제목1"), tripperId);
+            Trip trip2 = Trip.create(TripTitle.of("여행 제목2"), tripperId);
+            Trip trip3 = Trip.create(TripTitle.of("여행 제목3"), tripperId);
+            Trip trip4 = Trip.create(TripTitle.of("여행 제목4"), tripperId);
+            em.persist(trip1);
+            em.persist(trip2);
+            em.persist(trip3);
+            em.persist(trip4);
+
+            em.flush();
+            em.clear();
+
+            // when
+            tripRepository.deleteAllByTripperId(tripperId);
+
+            // then
+            assertThat(tripRepository.existsById(trip1.getId())).isFalse();
+            assertThat(tripRepository.existsById(trip2.getId())).isFalse();
+            assertThat(tripRepository.existsById(trip3.getId())).isFalse();
+            assertThat(tripRepository.existsById(trip4.getId())).isFalse();
+        }
+    }
 }

--- a/src/test/java/com/cosain/trilo/unit/user/presentation/UserRestControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/user/presentation/UserRestControllerDocsTest.java
@@ -59,4 +59,24 @@ public class UserRestControllerDocsTest extends RestDocsTestSupport {
                         )
                 ));
     }
+
+    @Test
+    public void 회원_탈퇴() throws Exception{
+        // given
+        Long userId = 1L;
+        mockingForLoginUserAnnotation();
+
+        // when & then
+        mockMvc.perform(RestDocumentationRequestBuilders.delete(BASE_URL + "/{userId}", userId)
+                .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN))
+                .andExpect(MockMvcResultMatchers.status().isNoContent())
+                .andDo(restDocs.document(
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer 타입 AccessToken")
+                        ),
+                        pathParameters(
+                                parameterWithName("userId").description("탈퇴할 회원 ID")
+                        )
+                ));
+    }
 }

--- a/src/test/java/com/cosain/trilo/unit/user/presentation/UserRestControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/user/presentation/UserRestControllerTest.java
@@ -6,6 +6,7 @@ import com.cosain.trilo.user.application.UserService;
 import com.cosain.trilo.user.presentation.UserRestController;
 import com.cosain.trilo.user.presentation.dto.UserProfileResponse;
 import org.apache.http.HttpHeaders;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -13,7 +14,10 @@ import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import static com.cosain.trilo.fixture.UserFixture.KAKAO_MEMBER;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 @WebMvcTest(UserRestController.class)
@@ -25,27 +29,64 @@ public class UserRestControllerTest extends RestControllerTest {
     private final String BASE_URL = "/api/users";
     private final String ACCESS_TOKEN = "Bearer accessToken";
 
-    @Test
-    public void 인증된_사용자_프로필_조회시_200() throws Exception{
-        // given
-        Long userId = 2L;
-        mockingForLoginUserAnnotation();
-        given(userService.getUserProfile(userId, 1L)).willReturn(UserProfileResponse.from(KAKAO_MEMBER.create()));
-        // when & then
-        mockMvc.perform(RestDocumentationRequestBuilders.get(BASE_URL + "/{userId}/profile", userId)
-                .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN))
-                .andExpect(MockMvcResultMatchers.status().isOk());
-    }
+    @Nested
+    class 회원_프로필_조회{
+        @Test
+        public void 인증된_사용자_요청_200() throws Exception{
+            // given
+            Long userId = 2L;
+            mockingForLoginUserAnnotation();
+            given(userService.getUserProfile(userId, 1L)).willReturn(UserProfileResponse.from(KAKAO_MEMBER.create()));
+
+            // when & then
+            mockMvc.perform(RestDocumentationRequestBuilders.get(BASE_URL + "/{userId}/profile", userId)
+                            .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN))
+                    .andExpect(MockMvcResultMatchers.status().isOk());
+        }
 
 
-    @Test
-    public void 미인증된_사용자_프로필_조회시_401() throws Exception{
-        Long userId = 1L;
-        mockMvc.perform(RestDocumentationRequestBuilders.get(BASE_URL + "/{userId}/profile", userId)
-                .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN))
-                .andExpect(MockMvcResultMatchers.status().isUnauthorized())
-                .andExpect(jsonPath("$.errorCode").value("auth-0001"))
-                .andExpect(jsonPath("$.errorMessage").exists())
-                .andExpect(jsonPath("$.errorDetail").exists());
+        @Test
+        public void 미인증된_사용자_요청_401() throws Exception{
+            // given
+            Long userId = 1L;
+
+            // when & then
+            mockMvc.perform(RestDocumentationRequestBuilders.get(BASE_URL + "/{userId}/profile", userId)
+                            .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN))
+                    .andExpect(MockMvcResultMatchers.status().isUnauthorized())
+                    .andExpect(jsonPath("$.errorCode").value("auth-0001"))
+                    .andExpect(jsonPath("$.errorMessage").exists())
+                    .andExpect(jsonPath("$.errorDetail").exists());
+        }
     }
+
+    @Nested
+    class 회원_탈퇴{
+        @Test
+        void 인증된_사용자_요청_204() throws Exception{
+            // given
+            Long userId = 1L;
+            mockingForLoginUserAnnotation();
+
+            // when & then
+            mockMvc.perform(RestDocumentationRequestBuilders.delete(BASE_URL + "/{userId}", userId)
+                            .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN))
+                    .andExpect(MockMvcResultMatchers.status().isNoContent());
+        }
+
+        @Test
+        void 미인증된_사용자_요청_401() throws Exception{
+            // given
+            Long userId = 1L;
+
+            // when & then
+            mockMvc.perform(RestDocumentationRequestBuilders.delete(BASE_URL + "/{userId}", userId)
+                            .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN))
+                    .andExpect(MockMvcResultMatchers.status().isUnauthorized())
+                    .andExpect(jsonPath("$.errorCode").value("auth-0001"))
+                    .andExpect(jsonPath("$.errorMessage").exists())
+                    .andExpect(jsonPath("$.errorDetail").exists());
+        }
+    }
+
 }


### PR DESCRIPTION
# JIRA 티켓
[TRL-380]

# 작업 내역

- [x] 비동기 설정 추가
- [x] 회원과 관련된 모든 여행 정보 삭제 기능 구현
- [x] 회원 정보 삭제 기능 구현
- [x] 회원 탈퇴 API EndPoint 추가 ( 회원 탈퇴 RestController 구현 ) 
- [x] 통합 테스트 작성
- [x] 회원 탈퇴 API 문서화


# 설명

## 이벤트를 사용하여 바운디드 컨택스트 사이에 발생할 수 있는 불필요한 의존성 제거

![image](https://github.com/teamCoSaIn/trilo-be/assets/53935439/f3cff92d-2afc-4047-9db5-bb104a9f8187)

스프링 이벤트를 통해 관심사를 분리하여 회원 bounded context 내에서는 회원 정보를 삭제하고, 이벤트를 발행하여 이를 구독하는 여행 bounded context 에서 회원과 관련된 여행 정보들을 삭제합니다. 이를 통해 불필요한 의존성을 제거하여 side-effect 및 복잡도를 줄이고 관심사를 하나로 모아 응집도를 높입니다. 또한 향후 별개의 서비스로 분리가 될 때 좀 더 용이하게 전환이 가능합니다. 

여기서 스프링 이벤트에는 두 가지 종류가 있으며 차이점은 다음과 같습니다.

- `@TransationalEventListener` (선택)  
- `@EventListener`

`@TransactionalEventListener`은 트랜잭션 컨텍스트 내에서 이벤트를 처리하고, 트랜잭션의 커밋 여부와 순서를 보장합니다. 반면, `@EventListener`은 트랜잭션과 독립적으로 이벤트를 처리하며, 실행 순서를 보장하지 않습니다. 

똑같이 비동기로 이벤트를 발행하더라도 `@EventListener` 를 사용할 경우, 코드를 통해 이벤트를 호출하는 시점에 바로 발행을 해버리기 때문에 회원 정보 삭제 라는 하나의 트랜잭션으로 묶여있는 기능에서 rollback 이 일어나도 회원 여행 정보 삭제 기능에 문제가 없다면 그대로 실행이 되버리게 됩니다. 즉, 회원 정보는 삭제가 안됐는데 여행 정보가 삭제되어 버리는 문제가 발생할 수 있습니다.

이를 해결하기 위해 `@TransactionalEventListener` 를 사용했습니다. 일단 기본적으로 phase 를 통해 다양한 옵션을 줄 수 있지만 default인 `AFTER_COMMIT` 옵션을 사용하여 트랜잭션 커밋 시점에 이벤트를 발행하도록 했습니다. 즉 순서를 보장하여 회원 정보 삭제 작업이 완전히 끝난 뒤( commit 이후 )에 이벤트를 발행하게 됩니다. 

![image](https://github.com/teamCoSaIn/trilo-be/assets/53935439/5ef555e0-af75-4319-a36c-1a09aa52788e)


## 이벤트 발행 후 비동기적으로 실행

비동기적으로 실행한 이유는 다음과 같습니다. WAS에서 엔드포인트로 요청을 받으면 한정된 스레드 풀에서 스레드 자원을 얻어서 실행이 됩니다. 그리고 이 스레드는 다음과 같이 커넥션 풀에서 자원을 얻어 DB 와 통신할 수 있는 connection 를 얻게 됩니다.

![image](https://github.com/teamCoSaIn/trilo-be/assets/53935439/c79bc528-7744-4d9a-887b-30ea9c16a74d)

만약 하나의 트랜잭션으로 묶인 작업이 이 Connection 을 오래 소유하면 소유할 수록 다른 요청 스레드가 기다리는 병목 현상이 발생할 수 있습니다. 회원 탈퇴는 다음과 같은 작업을 진행하게 됩니다.

1. 회원 정보 삭제
2. 회원과 관련된 Trip 벌크 삭제
3. 회원과 관련된 Day 벌크 삭제 
4. 회원 Schedule Schedule 벌크 삭제

만약 이 4개의 작업이(정확히 4개는 아닙니다.) 하나의 트랜잭션으로 묶일 경우 그 만큼 Connection 을 오래 소유하게 됩니다. 이를 쪼갤 필요가 있다고 생각해서 비동기로 처리하게 되었습니다.

![image](https://github.com/teamCoSaIn/trilo-be/assets/53935439/25e09259-3481-409c-b1c7-04391665f71a)

위와 같이 비동기로 실행된 작업은 별개의 Connection 을 얻어와 실행되게 되므로 어느정도 병목현상을 제거할 수 있습니다.

## 회원과 관련된 여행 정보에 대한 벌크 삭제

회원 관련 여행 정보에 대한 일괄 삭제가 필요했고, 여러가지 방법을 시도해보았습니다. 시행착오는 과정이 조금 길어 요약해놓은 자료를 [블로그](https://castle-of-gyu.tistory.com/88)에 게시했습니다.

![image](https://github.com/teamCoSaIn/trilo-be/assets/53935439/cf4c495e-dd80-47bc-9d17-5edc42240ff8)

외래키 제약 조건을 위반하지 않기 위해 총 3개의 벌크성 삭제 쿼리를 발행합니다.

# 참고 자료

https://tecoble.techcourse.co.kr/post/2022-09-20-external-in-transaction/
https://sabarada.tistory.com/188


[TRL-380]: https://cosain.atlassian.net/browse/TRL-380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ