### PR TITLE
[TRL-379] test: IntegrationTest - 회원 Setup 메서드 작성

### DIFF
--- a/src/main/java/com/cosain/trilo/user/domain/User.java
+++ b/src/main/java/com/cosain/trilo/user/domain/User.java
@@ -2,14 +2,12 @@ package com.cosain.trilo.user.domain;
 
 import com.cosain.trilo.auth.infra.OAuthProfileDto;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @Entity
 @Table(name = "users")
+@ToString(of = {"id", "name", "email", "profileImageURL", "authProvider", "role"})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
 

--- a/src/main/resources/exceptions/exception.yml
+++ b/src/main/resources/exceptions/exception.yml
@@ -76,7 +76,7 @@ user-0003:
   message: UserNotFound
   detail: 해당 사용자가 존재하지 않습니다.
 
-user-004:
+user-0004:
   message: No User Delete Authority
   detail: 해당 사용자를 삭제할 권한이 없습니다.
 

--- a/src/main/resources/exceptions/exception_en.yml
+++ b/src/main/resources/exceptions/exception_en.yml
@@ -77,7 +77,7 @@ user-0003:
   message: UserNotFound
   detail: The User with the matching identifier could not be found.
 
-user-004:
+user-0004:
   message: No User Delete Authority
   detail: You do not have any authority to delete the user
 

--- a/src/test/java/com/cosain/trilo/integration/user/UserIntegrationTest.java
+++ b/src/test/java/com/cosain/trilo/integration/user/UserIntegrationTest.java
@@ -3,17 +3,20 @@ package com.cosain.trilo.integration.user;
 import com.cosain.trilo.support.IntegrationTest;
 import com.cosain.trilo.user.domain.User;
 import com.cosain.trilo.user.domain.UserRepository;
-import jakarta.persistence.EntityManager;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpHeaders;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 
-import static com.cosain.trilo.fixture.UserFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@Slf4j
+@DisplayName("사용자 관련 기능 통합 테스트")
 public class UserIntegrationTest extends IntegrationTest {
     private final String BASE_URL = "/api/users";
     private final String TOKEN_TYPE = "Bearer ";
@@ -21,16 +24,15 @@ public class UserIntegrationTest extends IntegrationTest {
     @Autowired
     UserRepository userRepository;
 
-    @Autowired
-    EntityManager entityManager;
-
     @Nested
     class 회원_프로필_조회{
         @Test
         void 회원_프로필_조회_성공() throws Exception{
             // given
-            User user = userRepository.save(KAKAO_MEMBER.create());
-            String accessToken = createAccessToken(user.getId());
+            User user = setupMockKakaoUser();
+            String accessToken = createAccessToken(user);
+
+            log.info("user = {}", user);
 
             // when & then
             mockMvc.perform(RestDocumentationRequestBuilders.get(BASE_URL + "/{userId}/profile", user.getId())
@@ -46,12 +48,15 @@ public class UserIntegrationTest extends IntegrationTest {
         @Test
         void 회원_프로필_조회_시_다른_회원의_프로필을_조회할_경우_403_응답() throws Exception{
             // given
-            User user = userRepository.save(KAKAO_MEMBER.create());
-            User anotherUser = userRepository.save(GOOGLE_MEMBER.create());
-            String accessToken = createAccessToken(user.getId());
+            User requestUser = setupMockGoogleUser();
+            User targetUser = setupMockKakaoUser();
+            String accessToken = createAccessToken(requestUser);
+
+            log.info("requestUser = {}", requestUser);
+            log.info("targetUser = {}", targetUser);
 
             // when & then
-            mockMvc.perform(RestDocumentationRequestBuilders.get(BASE_URL + "/{userId}/profile", anotherUser.getId())
+            mockMvc.perform(RestDocumentationRequestBuilders.get(BASE_URL + "/{userId}/profile", targetUser.getId())
                             .header(HttpHeaders.AUTHORIZATION, TOKEN_TYPE + accessToken))
                     .andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.errorCode").value("user-0002"))
@@ -65,26 +70,32 @@ public class UserIntegrationTest extends IntegrationTest {
         @Test
         void 회원_탈퇴_성공() throws Exception{
             // given
-            User user = userRepository.save(KAKAO_MEMBER.create());
-            String accessToken = createAccessToken(user.getId());
+            User user = setupMockKakaoUser();
+            String accessToken = createAccessToken(user);
+
+            log.info("User = {}", user);
 
             // when & then
             mockMvc.perform(RestDocumentationRequestBuilders.delete(BASE_URL + "/{userId}", user.getId())
                     .header(HttpHeaders.AUTHORIZATION, TOKEN_TYPE + accessToken))
                     .andExpect(status().isNoContent());
 
+            User findUser = userRepository.findById(user.getId()).orElse(null);
+            assertThat(findUser).isNull();
         }
 
         @Test
         void 회원_탈퇴_시_본인이_아닌_회원의_탈퇴_요청을_하는_경우_403_응답() throws Exception{
             // given
-            User user = userRepository.save(KAKAO_MEMBER.create());
-            User anotherUser  = userRepository.save(NAVER_MEMBER.create());
-            String accessToken = createAccessToken(user.getId());
-            System.out.println(user.getId() +" "+ anotherUser.getId());
+            User requestUser = setupMockKakaoUser();
+            User targetUser = setupMockGoogleUser();
+            String accessToken = createAccessToken(requestUser);
+
+            log.info("requestUser = {}", requestUser);
+            log.info("targetUser = {}", targetUser);
 
             // when & then
-            mockMvc.perform(RestDocumentationRequestBuilders.delete(BASE_URL + "/{userId}", anotherUser.getId())
+            mockMvc.perform(RestDocumentationRequestBuilders.delete(BASE_URL + "/{userId}", targetUser.getId())
                             .header(HttpHeaders.AUTHORIZATION, TOKEN_TYPE + accessToken))
                     .andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.errorCode").value("user-0004"))
@@ -92,6 +103,5 @@ public class UserIntegrationTest extends IntegrationTest {
                     .andExpect(jsonPath("$.errorDetail").exists());
         }
     }
-
 
 }

--- a/src/test/java/com/cosain/trilo/support/IntegrationTest.java
+++ b/src/test/java/com/cosain/trilo/support/IntegrationTest.java
@@ -1,6 +1,10 @@
 package com.cosain.trilo.support;
 
 import com.cosain.trilo.auth.infra.TokenProvider;
+import com.cosain.trilo.user.domain.AuthProvider;
+import com.cosain.trilo.user.domain.Role;
+import com.cosain.trilo.user.domain.User;
+import com.cosain.trilo.user.domain.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -26,6 +30,9 @@ public class IntegrationTest {
     @Autowired
     private TokenProvider tokenProvider;
 
+    @Autowired
+    private UserRepository userRepository;
+
     @BeforeEach
     void setUp(){
         mockMvc = MockMvcBuilders
@@ -34,8 +41,33 @@ public class IntegrationTest {
                 .build();
     }
 
-    protected String createAccessToken(Long userId){
-        String accessToken = tokenProvider.createAccessTokenById(userId);
-        return accessToken;
+    protected User setupMockNaverUser() {
+        return createMockUser("naver-user@naver.com", AuthProvider.NAVER);
+    }
+
+    protected User setupMockKakaoUser() {
+        return createMockUser("kakao-user@kakao.com", AuthProvider.KAKAO);
+    }
+
+    protected User setupMockGoogleUser() {
+        return createMockUser("google-user@google.com", AuthProvider.GOOGLE);
+    }
+
+    protected String createAccessToken(User user){
+        Long userId = user.getId();
+        return tokenProvider.createAccessTokenById(userId);
+    }
+
+    private User createMockUser(String email, AuthProvider authProvider) {
+        User mockUser = User.builder()
+                .name("사용자")
+                .email(email)
+                .profileImageUrl("https://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg")
+                .authProvider(authProvider)
+                .role(Role.MEMBER)
+                .build();
+
+        userRepository.save(mockUser);
+        return mockUser;
     }
 }


### PR DESCRIPTION
# JIRA 티켓
- [TRL-379]

# 작업 내역
- [x] IntegrationTest  - 회원 setUp 기능 작성
- [x] IntegrationTest  - createAccessToken 인자로 User클래스 받도록 변경

# 설명
- 통합테스트에서 Mock 회원을 등록하는 과정에서, 매 순간마다 리포지토리를 호출하고 회원을 가입시키는 작업을 수행해야하는데,
실제 통합클래스 코드에서 이들을 매번 하기에는 중복 로직이 너무 많습니다.
- IntegrationTest에 회원 생성을 하는 기능을 두고 재사용 가능하게 하였습니다.

# 참고자료


[TRL-379]: https://cosain.atlassian.net/browse/TRL-379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ