### PR TITLE
[TRL-386] test: 여행 생성 API 통합 테스트

### DIFF
--- a/src/main/java/com/cosain/trilo/trip/domain/entity/Trip.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/entity/Trip.java
@@ -8,10 +8,7 @@ import com.cosain.trilo.trip.domain.exception.InvalidTripDayException;
 import com.cosain.trilo.trip.domain.exception.MidScheduleIndexConflictException;
 import com.cosain.trilo.trip.domain.vo.*;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.Where;
 
@@ -21,10 +18,11 @@ import java.util.List;
 import java.util.Random;
 
 @Getter
-@Entity
 @Slf4j
-@Table(name = "trip")
+@ToString(of = {"id", "tripperId", "tripTitle", "status", "tripPeriod", "tripImage"})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "trip")
+@Entity
 public class Trip {
 
     public static final int MAX_TRIP_SCHEDULE_COUNT = 110;

--- a/src/main/java/com/cosain/trilo/trip/presentation/trip/command/dto/response/TripCreateResponse.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/trip/command/dto/response/TripCreateResponse.java
@@ -1,8 +1,11 @@
 package com.cosain.trilo.trip.presentation.trip.command.dto.response;
 
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TripCreateResponse {
 
     private Long tripId;

--- a/src/test/java/com/cosain/trilo/integration/trip/TripCreateIntegrationTest.java
+++ b/src/test/java/com/cosain/trilo/integration/trip/TripCreateIntegrationTest.java
@@ -1,0 +1,72 @@
+package com.cosain.trilo.integration.trip;
+
+import com.cosain.trilo.support.IntegrationTest;
+import com.cosain.trilo.trip.domain.entity.Trip;
+import com.cosain.trilo.trip.domain.repository.TripRepository;
+import com.cosain.trilo.trip.domain.vo.TripImage;
+import com.cosain.trilo.trip.domain.vo.TripPeriod;
+import com.cosain.trilo.trip.domain.vo.TripStatus;
+import com.cosain.trilo.trip.domain.vo.TripTitle;
+import com.cosain.trilo.trip.presentation.trip.command.dto.request.TripCreateRequest;
+import com.cosain.trilo.trip.presentation.trip.command.dto.response.TripCreateResponse;
+import com.cosain.trilo.user.domain.User;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Slf4j
+@DisplayName("[통합] 여행 생성 API 테스트")
+public class TripCreateIntegrationTest extends IntegrationTest {
+
+    @Autowired
+    TripRepository tripRepository;
+
+    @DisplayName("여행 생성 -> 여행 생성 됨")
+    @Test
+    void createTest() throws Exception {
+        // given
+        User user = setupMockKakaoUser();
+        String title = "여행 제목";
+        TripCreateRequest createRequest = new TripCreateRequest(title);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(post("/api/trips")
+                .header(HttpHeaders.AUTHORIZATION, authorizationHeader(user))
+                .content(createRequestJson(createRequest))
+                .characterEncoding(StandardCharsets.UTF_8)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        TripCreateResponse response = createResponseObject(resultActions, TripCreateResponse.class);
+        Trip createdTrip = tripRepository.findById(response.getTripId()).orElse(null);
+
+        // then 1 - 응답 메시지 검증
+        resultActions
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.tripId").isNotEmpty());
+
+        // then - 2 생성된 Trip의 필드 검증
+        assertThat(createdTrip).isNotNull();
+        assertThat(createdTrip.getTripperId()).isEqualTo(user.getId());
+        assertThat(createdTrip.getTripTitle()).isEqualTo(TripTitle.of(title));
+        assertThat(createdTrip.getTripPeriod()).isEqualTo(TripPeriod.empty());
+        assertThat(createdTrip.getTripImage()).isEqualTo(TripImage.defaultImage());
+        assertThat(createdTrip.getStatus()).isSameAs(TripStatus.UNDECIDED);
+        assertThat(createdTrip.getDays()).isEmpty();
+        assertThat(createdTrip.getTemporaryStorage()).isEmpty();
+    }
+
+}

--- a/src/test/java/com/cosain/trilo/integration/user/UserIntegrationTest.java
+++ b/src/test/java/com/cosain/trilo/integration/user/UserIntegrationTest.java
@@ -19,7 +19,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DisplayName("사용자 관련 기능 통합 테스트")
 public class UserIntegrationTest extends IntegrationTest {
     private final String BASE_URL = "/api/users";
-    private final String TOKEN_TYPE = "Bearer ";
 
     @Autowired
     UserRepository userRepository;
@@ -30,13 +29,12 @@ public class UserIntegrationTest extends IntegrationTest {
         void 회원_프로필_조회_성공() throws Exception{
             // given
             User user = setupMockKakaoUser();
-            String accessToken = createAccessToken(user);
 
             log.info("user = {}", user);
 
             // when & then
             mockMvc.perform(RestDocumentationRequestBuilders.get(BASE_URL + "/{userId}/profile", user.getId())
-                            .header(HttpHeaders.AUTHORIZATION, TOKEN_TYPE + accessToken))
+                            .header(HttpHeaders.AUTHORIZATION, authorizationHeader(user)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.id").value(user.getId()))
                     .andExpect(jsonPath("$.name").value(user.getName()))
@@ -50,14 +48,13 @@ public class UserIntegrationTest extends IntegrationTest {
             // given
             User requestUser = setupMockGoogleUser();
             User targetUser = setupMockKakaoUser();
-            String accessToken = createAccessToken(requestUser);
 
             log.info("requestUser = {}", requestUser);
             log.info("targetUser = {}", targetUser);
 
             // when & then
             mockMvc.perform(RestDocumentationRequestBuilders.get(BASE_URL + "/{userId}/profile", targetUser.getId())
-                            .header(HttpHeaders.AUTHORIZATION, TOKEN_TYPE + accessToken))
+                            .header(HttpHeaders.AUTHORIZATION, authorizationHeader(requestUser)))
                     .andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.errorCode").value("user-0002"))
                     .andExpect(jsonPath("$.errorMessage").exists())
@@ -71,13 +68,11 @@ public class UserIntegrationTest extends IntegrationTest {
         void 회원_탈퇴_성공() throws Exception{
             // given
             User user = setupMockKakaoUser();
-            String accessToken = createAccessToken(user);
-
             log.info("User = {}", user);
 
             // when & then
             mockMvc.perform(RestDocumentationRequestBuilders.delete(BASE_URL + "/{userId}", user.getId())
-                    .header(HttpHeaders.AUTHORIZATION, TOKEN_TYPE + accessToken))
+                    .header(HttpHeaders.AUTHORIZATION, authorizationHeader(user)))
                     .andExpect(status().isNoContent());
 
             User findUser = userRepository.findById(user.getId()).orElse(null);
@@ -89,14 +84,12 @@ public class UserIntegrationTest extends IntegrationTest {
             // given
             User requestUser = setupMockKakaoUser();
             User targetUser = setupMockGoogleUser();
-            String accessToken = createAccessToken(requestUser);
-
             log.info("requestUser = {}", requestUser);
             log.info("targetUser = {}", targetUser);
 
             // when & then
             mockMvc.perform(RestDocumentationRequestBuilders.delete(BASE_URL + "/{userId}", targetUser.getId())
-                            .header(HttpHeaders.AUTHORIZATION, TOKEN_TYPE + accessToken))
+                            .header(HttpHeaders.AUTHORIZATION, authorizationHeader(requestUser)))
                     .andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.errorCode").value("user-0004"))
                     .andExpect(jsonPath("$.errorMessage").exists())


### PR DESCRIPTION
# JIRA 티켓
- [TRL-386]

# 작업 내역
- [x] IntegrationTest - 편의 메서드 추가
- [x] 여행 생성 API - 통합 테스트 작성

# 설명
- accessToken을 생성하고, 이것을 기반으로 인증 헤더를 만드는 작업을 컨트롤러에서 수행하고 있는데, user 갖다가 인증 헤더를 만드는쪽이 더 간단할  것이라는 판단하에, 인증헤더 생성 메서드를 IntegrationTest쪽에 둠
- createRequestJson : 전달받은 객체를 Json 문자열화
- createResponseObject : ResultActions로부터 응답 객체를 가져옴
- 여행 생성의 성공을 중점적으로 검증. 자잘자잘한 입력값 검증 등은 이미 단위 테스트에서 충분히 이루어지고 있어서 해당 부분까지는 검증하지 않음

# 참고자료


[TRL-386]: https://cosain.atlassian.net/browse/TRL-386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ