### PR TITLE
[TRL-399] test: TripFixture 리팩터링

### DIFF
--- a/src/test/java/com/cosain/trilo/fixture/TripFixture.java
+++ b/src/test/java/com/cosain/trilo/fixture/TripFixture.java
@@ -9,62 +9,136 @@ import com.cosain.trilo.trip.domain.vo.TripTitle;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.IntStream;
 
-public enum TripFixture {
+public class TripFixture {
 
-    UNDECIDED_TRIP(TripStatus.UNDECIDED),
-    DECIDED_TRIP(TripStatus.DECIDED),
-    ;
-
-    private final TripStatus status;
-    TripFixture(TripStatus status){
-        this.status = status;
+    /**
+     * 식별자가 있는 Undecided 상태의 여행을 생성합니다. 여행의 제목은 디폴트 값이 지정됩니다.
+     *
+     * @param tripId    : 여행 식별자
+     * @param tripperId : 소유 여행자(사용자)의 식별자
+     * @return 여행
+     */
+    public static Trip undecided_Id(Long tripId, Long tripperId) {
+        return undecided_Id_Title(tripId, tripperId, "여행 제목");
     }
 
-    public Trip createUndecided(Long id, Long tripperId, String rawTitle){
-        if(this.status.equals(TripStatus.DECIDED)) throw new IllegalArgumentException("status 가 DECIDED 일 경우 startDate와 endDate를 지정해주어야 합니다.");
-        return Trip.builder()
-                .id(id)
-                .tripperId(tripperId)
-                .tripTitle(TripTitle.of(rawTitle))
-                .status(this.status)
-                .tripPeriod(TripPeriod.empty())
-                .build();
+    /**
+     * 식별자가 있는 Undecided 상태의 여행을 생성합니다.
+     *
+     * @param tripId    : 여행 식별자
+     * @param tripperId : 소유 여행자(사용자)의 식별자
+     * @param rawTitle  : 제목(일반 문자열)
+     * @return 여행
+     */
+    public static Trip undecided_Id_Title(Long tripId, Long tripperId, String rawTitle) {
+        return createMockTrip(tripId, tripperId, rawTitle, TripStatus.UNDECIDED, TripPeriod.empty());
     }
 
-    public Trip createDecided(Long id, Long tripperId, String rawTitle, LocalDate startDate, LocalDate endDate) {
-        if (this.status.equals(TripStatus.UNDECIDED))
-            throw new IllegalArgumentException("status 가 UNDECIDED 일 경우 startDate와 endDate를 지정해 줄 수 없습니다.");
+    /**
+     * 식별자가 없는 Undecided 상태의 여행을 생성합니다. 이 때 여행 제목은 디폴트로 지정됩니다.
+     *
+     * @param tripperId : 소유 여행자(사용자)의 식별자
+     * @return 여행
+     */
+    public static Trip undecided_nullId(Long tripperId) {
+        return undecided_nullId_Title(tripperId, "여행 제목");
+    }
 
+    /**
+     * 식별자가 없는 Undecided 상태의 여행을 생성합니다.
+     *
+     * @param tripperId : 소유 여행자(사용자)의 식별자
+     * @param rawTitle  : 제목(일반 문자열)
+     * @return 여행
+     */
+    public static Trip undecided_nullId_Title(Long tripperId, String rawTitle) {
+        return createMockTrip(null, tripperId, rawTitle, TripStatus.UNDECIDED, TripPeriod.empty());
+    }
+
+    /**
+     * 식별자가 있는 Decided 상태의 여행을 생성합니다. 기간에 속한 Day들의 Color들은 디폴트 색상이 적용됩니다.
+     * @param tripId : 여행 식별자
+     * @param tripperId : 여행자(사용자) 식별자
+     * @param startDate : 여행 시작일
+     * @param endDate : 여행 종료일
+     * @param startDayId : 생성되는 Day들의 시작 id
+     * @return 여행(+ 기간에 속하는 Day들을 포함시킴)
+     */
+    public static Trip decided_Id(Long tripId, Long tripperId, LocalDate startDate, LocalDate endDate, Long startDayId) {
+        return decided_Id_Color(tripId, tripperId, startDate, endDate, startDayId, DayColor.BLACK);
+    }
+
+    /**
+     * 식별자가 있는 Decided 상태의 여행을 생성합니다.
+     * @param tripId : 여행 식별자
+     * @param tripperId : 여행자(사용자) 식별자
+     * @param startDate : 여행 시작일
+     * @param endDate : 여행 종료일
+     * @param startDayId : 생성되는 Day들의 시작 id
+     * @param dayColor : 소속된 Day들 전체의 색상
+     * @return 여행(+ 기간에 속하는 Day들을 포함시킴)
+     */
+    public static Trip decided_Id_Color(Long tripId, Long tripperId, LocalDate startDate, LocalDate endDate, Long startDayId, DayColor dayColor) {
         TripPeriod tripPeriod = TripPeriod.of(startDate, endDate);
+        Trip trip = createMockTrip(tripId, tripperId, "여행 제목", TripStatus.DECIDED, tripPeriod);
 
-        Trip trip = Trip.builder()
-                .id(id)
-                .tripperId(tripperId)
-                .tripTitle(TripTitle.of(rawTitle))
-                .tripPeriod(tripPeriod)
-                .status(this.status)
-                .build();
+        List<LocalDate> dates = tripPeriod.dateStream().toList();
 
-        List<Day> days = createDays(trip, tripPeriod);
-        trip.getDays().addAll(days);
-
+        List<Day> tripDays = IntStream.range(0, dates.size())
+                .mapToObj(i -> createMockDay(startDayId + i, dates.get(i), trip, dayColor))
+                .toList();
+        trip.getDays().addAll(tripDays);
         return trip;
     }
 
-    private List<Day> createDays(Trip trip, TripPeriod tripPeriod) {
-        return tripPeriod.dateStream()
-                .map(date -> this.createDay(date, trip))
-                .toList();
+    /**
+     * 식별자가 없는 Decided 상태의 여행을 생성합니다. 기간에 속한 Day들의 Color들은 디폴트 색상이 적용됩니다.
+     * @param tripperId : 여행자(사용자) 식별자
+     * @param startDate : 여행 시작일
+     * @param endDate : 여행 종료일
+     * @return 여행(+ 기간에 속하는 Day들을 포함시킴)
+     */
+    public static Trip decided_nullId(Long tripperId, LocalDate startDate, LocalDate endDate) {
+        return decided_nullId_Color(tripperId, startDate, endDate, DayColor.BLACK);
     }
 
-    private Day createDay(LocalDate date, Trip trip) {
-        DayColor dummyDayColor = DayColor.BLACK;
+    /**
+     * 식별자가 없는 Decided 상태의 여행을 생성합니다.
+     * @param tripperId : 여행자(사용자) 식별자
+     * @param startDate : 여행 시작일
+     * @param endDate : 여행 종료일
+     * @param dayColor : 소속된 Day들 전체의 색상
+     * @return 여행(+ 기간에 속하는 Day들을 포함시킴)
+     */
+    public static Trip decided_nullId_Color(Long tripperId, LocalDate startDate, LocalDate endDate, DayColor dayColor) {
+        TripPeriod tripPeriod = TripPeriod.of(startDate, endDate);
+        Trip trip = createMockTrip(null, tripperId, "여행 제목", TripStatus.DECIDED, tripPeriod);
 
+        List<Day> tripDays = tripPeriod.dateStream()
+                .map(date -> createMockDay(null, date, trip, dayColor))
+                .toList();
+        trip.getDays().addAll(tripDays);
+        return trip;
+    }
+
+    private static Trip createMockTrip(Long tripId, Long tripperId, String rawTitle, TripStatus tripStatus, TripPeriod tripPeriod) {
+        return Trip.builder()
+                .id(tripId)
+                .tripperId(tripperId)
+                .tripTitle(TripTitle.of(rawTitle))
+                .status(tripStatus)
+                .tripPeriod(tripPeriod)
+                .build();
+    }
+
+    private static Day createMockDay(Long dayId, LocalDate tripDate, Trip trip, DayColor dayColor) {
         return Day.builder()
+                .id(dayId)
+                .tripDate(tripDate)
                 .trip(trip)
-                .tripDate(date)
-                .dayColor(dummyDayColor)
+                .dayColor(dayColor)
                 .build();
     }
 

--- a/src/test/java/com/cosain/trilo/integration/trip/TripTitleUpdateIntegrationTest.java
+++ b/src/test/java/com/cosain/trilo/integration/trip/TripTitleUpdateIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.cosain.trilo.integration.trip;
 
+import com.cosain.trilo.fixture.TripFixture;
 import com.cosain.trilo.support.IntegrationTest;
 import com.cosain.trilo.trip.domain.entity.Trip;
 import com.cosain.trilo.trip.domain.repository.TripRepository;
@@ -68,7 +69,7 @@ public class TripTitleUpdateIntegrationTest extends IntegrationTest {
     }
 
     private Trip setupMockTrip(String rawTitle, Long tripperId) {
-        Trip trip = Trip.create(TripTitle.of(rawTitle), tripperId);
+        Trip trip = TripFixture.undecided_nullId_Title(tripperId, rawTitle);
         tripRepository.save(trip);
         return trip;
     }

--- a/src/test/java/com/cosain/trilo/unit/trip/application/day/command/service/DayColorUpdateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/day/command/service/DayColorUpdateServiceTest.java
@@ -1,5 +1,6 @@
 package com.cosain.trilo.unit.trip.application.day.command.service;
 
+import com.cosain.trilo.fixture.TripFixture;
 import com.cosain.trilo.trip.application.day.command.dto.DayColorUpdateCommand;
 import com.cosain.trilo.trip.application.day.command.service.DayColorUpdateService;
 import com.cosain.trilo.trip.application.exception.DayNotFoundException;
@@ -8,9 +9,6 @@ import com.cosain.trilo.trip.domain.entity.Day;
 import com.cosain.trilo.trip.domain.entity.Trip;
 import com.cosain.trilo.trip.domain.repository.DayRepository;
 import com.cosain.trilo.trip.domain.vo.DayColor;
-import com.cosain.trilo.trip.domain.vo.TripPeriod;
-import com.cosain.trilo.trip.domain.vo.TripStatus;
-import com.cosain.trilo.trip.domain.vo.TripTitle;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -69,8 +67,7 @@ public class DayColorUpdateServiceTest {
 
         DayColor beforeDayColor = DayColor.BLACK;
         DayColor requestDayColor = DayColor.RED;
-
-        Day day = mockDay(tripId, tripOwnerId, beforeDayColor);
+        Day day = fixtureDay(tripId, tripOwnerId, beforeDayColor);
         DayColorUpdateCommand updateCommand = new DayColorUpdateCommand(requestDayColor);
 
         given(dayRepository.findByIdWithTrip(eq(dayId))).willReturn(Optional.of(day));
@@ -92,7 +89,7 @@ public class DayColorUpdateServiceTest {
         DayColor beforeDayColor = DayColor.BLACK;
         DayColor requestDayColor = DayColor.RED;
 
-        Day day = mockDay(tripId, tripOwnerId, beforeDayColor);
+        Day day = fixtureDay(tripId, tripOwnerId, beforeDayColor);
         DayColorUpdateCommand updateCommand = new DayColorUpdateCommand(requestDayColor);
 
         given(dayRepository.findByIdWithTrip(eq(dayId))).willReturn(Optional.of(day));
@@ -105,22 +102,11 @@ public class DayColorUpdateServiceTest {
         assertThat(day.getDayColor()).isSameAs(requestDayColor);
     }
 
-
-    private Day mockDay(Long tripId, Long tripperId, DayColor dayColor) {
-        Trip trip = Trip.builder()
-                .id(tripId)
-                .tripperId(tripperId)
-                .tripTitle(TripTitle.of("여행 제목"))
-                .tripPeriod(TripPeriod.of(LocalDate.of(2023,3,1), LocalDate.of(2023,3,1)))
-                .status(TripStatus.DECIDED)
-                .build();
-        Day day = Day.builder()
-                .trip(trip)
-                .dayColor(dayColor)
-                .tripDate(LocalDate.of(2023,3,1))
-                .build();
-        trip.getDays().add(day);
-        return day;
+    private Day fixtureDay(Long tripId, Long tripperId, DayColor dayColor) {
+        LocalDate startDate = LocalDate.of(2023,3,1);
+        LocalDate endDate = LocalDate.of(2023,3,1);
+        Trip trip = TripFixture.decided_Id_Color(tripId, tripperId, startDate, endDate, 1L, dayColor);
+        return trip.getDays().get(0);
     }
 
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleCreateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleCreateServiceTest.java
@@ -1,18 +1,21 @@
 package com.cosain.trilo.unit.trip.application.schedule.command.service;
 
 import com.cosain.trilo.fixture.TripFixture;
+import com.cosain.trilo.trip.application.exception.NoScheduleCreateAuthorityException;
 import com.cosain.trilo.trip.application.exception.TooManyDayScheduleException;
 import com.cosain.trilo.trip.application.exception.TooManyTripScheduleException;
-import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleCreateCommand;
-import com.cosain.trilo.trip.application.exception.NoScheduleCreateAuthorityException;
 import com.cosain.trilo.trip.application.schedule.command.service.ScheduleCreateService;
+import com.cosain.trilo.trip.application.schedule.command.usecase.dto.ScheduleCreateCommand;
 import com.cosain.trilo.trip.domain.entity.Day;
 import com.cosain.trilo.trip.domain.entity.Schedule;
 import com.cosain.trilo.trip.domain.entity.Trip;
 import com.cosain.trilo.trip.domain.repository.DayRepository;
 import com.cosain.trilo.trip.domain.repository.ScheduleRepository;
 import com.cosain.trilo.trip.domain.repository.TripRepository;
-import com.cosain.trilo.trip.domain.vo.*;
+import com.cosain.trilo.trip.domain.vo.Coordinate;
+import com.cosain.trilo.trip.domain.vo.Place;
+import com.cosain.trilo.trip.domain.vo.ScheduleIndex;
+import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -55,22 +58,11 @@ public class ScheduleCreateServiceTest {
             Long tripperId = 1L;
             Long tripId = 2L;
             Long dayId = 3L;
+            LocalDate startDate = LocalDate.of(2023,3,1);
+            LocalDate endDate = LocalDate.of(2023,3,1);
 
-            Trip trip = Trip.builder()
-                    .id(tripId)
-                    .tripperId(tripperId)
-                    .tripTitle(TripTitle.of("여행 제목"))
-                    .status(TripStatus.DECIDED)
-                    .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
-                    .build();
-
-            Day day = Day.builder()
-                    .id(dayId)
-                    .tripDate(LocalDate.of(2023, 3, 1))
-                    .trip(trip)
-                    .build();
-
-            trip.getDays().add(day);
+            Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, dayId);
+            Day day = trip.getDays().get(0);
 
             ScheduleCreateCommand scheduleCreateCommand = ScheduleCreateCommand.builder()
                     .dayId(dayId)
@@ -113,21 +105,11 @@ public class ScheduleCreateServiceTest {
             Long tripperId = 1L;
             Long tripId = 2L;
             Long dayId = 3L;
+            LocalDate startDate = LocalDate.of(2023,3,1);
+            LocalDate endDate = LocalDate.of(2023,3,1);
 
-            Trip beforeTrip = Trip.builder()
-                    .id(tripId)
-                    .tripperId(tripperId)
-                    .tripTitle(TripTitle.of("여행 제목"))
-                    .status(TripStatus.DECIDED)
-                    .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
-                    .build();
-
-            Day beforeDay = Day.builder()
-                    .id(dayId)
-                    .tripDate(LocalDate.of(2023, 3, 1))
-                    .trip(beforeTrip)
-                    .build();
-
+            Trip beforeTrip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, dayId);
+            Day beforeDay = beforeTrip.getDays().get(0);
 
             Schedule beforeSchedule = Schedule.builder()
                     .id(1L)
@@ -147,20 +129,8 @@ public class ScheduleCreateServiceTest {
                     .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
                     .build();
 
-
-            Trip rediscoveredTrip = Trip.builder()
-                    .id(tripId)
-                    .tripperId(tripperId)
-                    .tripTitle(TripTitle.of("여행 제목"))
-                    .status(TripStatus.DECIDED)
-                    .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
-                    .build();
-
-            Day rediscoveredDay = Day.builder()
-                    .id(dayId)
-                    .tripDate(LocalDate.of(2023, 3, 1))
-                    .trip(rediscoveredTrip)
-                    .build();
+            Trip rediscoveredTrip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, dayId);
+            Day rediscoveredDay = rediscoveredTrip.getDays().get(0);
 
             Schedule rediscoveredBeforeSchedule = Schedule.builder()
                     .id(1L)
@@ -221,13 +191,7 @@ public class ScheduleCreateServiceTest {
             Long tripId = 2L;
             Long dayId = null;
 
-            Trip trip = Trip.builder()
-                    .id(tripId)
-                    .tripperId(tripperId)
-                    .tripTitle(TripTitle.of("여행 제목"))
-                    .status(TripStatus.DECIDED)
-                    .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
-                    .build();
+            Trip trip = TripFixture.undecided_Id(tripId, tripperId);
 
             ScheduleCreateCommand scheduleCreateCommand = ScheduleCreateCommand.builder()
                     .dayId(dayId)
@@ -365,13 +329,7 @@ public class ScheduleCreateServiceTest {
         Long tripperId = 1L;
         Long tripId = 2L;
 
-        Trip trip = Trip.builder()
-                .id(tripId)
-                .tripperId(tripperId)
-                .tripTitle(TripTitle.of("여행 제목"))
-                .status(TripStatus.DECIDED)
-                .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
-                .build();
+        Trip trip = TripFixture.undecided_Id(tripId, tripperId);
 
         ScheduleCreateCommand scheduleCreateCommand = ScheduleCreateCommand.builder()
                 .dayId(null)
@@ -403,21 +361,11 @@ public class ScheduleCreateServiceTest {
         Long tripperId = 1L;
         Long tripId = 2L;
         Long dayId = 3L;
+        LocalDate startDate = LocalDate.of(2023,3,1);
+        LocalDate endDate = LocalDate.of(2023,3,1);
 
-        Trip trip = Trip.builder()
-                .id(tripId)
-                .tripperId(tripperId)
-                .tripTitle(TripTitle.of("여행 제목"))
-                .status(TripStatus.DECIDED)
-                .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)))
-                .build();
-
-        Day day = Day.builder()
-                .id(dayId)
-                .tripDate(LocalDate.of(2023,3,1))
-                .trip(trip)
-                .build();
-
+        Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, dayId);
+        Day day = trip.getDays().get(0);
 
         ScheduleCreateCommand scheduleCreateCommand = ScheduleCreateCommand.builder()
                 .dayId(dayId)

--- a/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleCreateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleCreateServiceTest.java
@@ -265,9 +265,9 @@ public class ScheduleCreateServiceTest {
         @DisplayName("임시보관함에서 일정의 순서가 하한선을 벗어날 경우 재배치 기능이 호출되는 지 여부 테스트")
         public void when_temporaryStorage_Schedule_is_under_limit_then_relocate_called() {
             // given
-            Long tripperId = 1L;
             Long tripId = 1L;
-            Trip trip = TripFixture.UNDECIDED_TRIP.createUndecided(tripId, tripperId, "제목");
+            Long tripperId = 2L;
+            Trip trip = TripFixture.undecided_Id(tripId, tripperId);
 
             Schedule beforeSchedule = Schedule.builder()
                     .id(1L)
@@ -279,7 +279,7 @@ public class ScheduleCreateServiceTest {
                     .build();
             trip.getTemporaryStorage().add(beforeSchedule);
 
-            Trip rediscoveredTrip = TripFixture.UNDECIDED_TRIP.createUndecided(tripId, tripperId, "제목");
+            Trip rediscoveredTrip = TripFixture.undecided_Id(tripId, tripperId);
             Schedule relocatedSchedule = Schedule.builder()
                     .id(1L)
                     .day(null)
@@ -328,20 +328,18 @@ public class ScheduleCreateServiceTest {
     }
 
     @Test
-    @DisplayName("권한 없는 사람이 Schedule을 생성하면, NoScheduleCreateAuthortyException이 발생한다.")
+    @DisplayName("권한 없는 사람이 Schedule을 생성하면, NoScheduleCreateAuthorityException이 발생한다.")
     public void when_no_authority_tripper_create_schedule_it_throws_NoScheduleCreateAuthorityException() {
         // given
         Long tripOwnerId = 1L;
         Long noAuthorityTripperId = 2L;
         Long tripId = 3L;
         Long dayId = 4L;
+        LocalDate startDate = LocalDate.of(2023,4,1);
+        LocalDate endDate = LocalDate.of(2023,4,1);
 
-        Trip trip = TripFixture.DECIDED_TRIP.createDecided(tripId, tripOwnerId, "제목", LocalDate.of(2023,4,1), LocalDate.of(2023,4,1));
-        Day day = Day.builder()
-                .id(dayId)
-                .tripDate(LocalDate.of(2023,4,1))
-                .dayColor(DayColor.BLACK)
-                .build();
+        Trip trip = TripFixture.decided_Id(tripId, tripOwnerId, startDate, endDate, 1L);
+        Day day = trip.getDays().get(0);
 
         ScheduleCreateCommand scheduleCreateCommand = ScheduleCreateCommand.builder()
                 .dayId(dayId)

--- a/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleDeleteServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleDeleteServiceTest.java
@@ -1,5 +1,6 @@
 package com.cosain.trilo.unit.trip.application.schedule.command.service;
 
+import com.cosain.trilo.fixture.TripFixture;
 import com.cosain.trilo.trip.application.exception.NoScheduleDeleteAuthorityException;
 import com.cosain.trilo.trip.application.exception.ScheduleNotFoundException;
 import com.cosain.trilo.trip.application.schedule.command.service.ScheduleDeleteService;
@@ -22,7 +23,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDate;
 import java.util.Optional;
 
-import static com.cosain.trilo.fixture.TripFixture.DECIDED_TRIP;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -68,7 +68,9 @@ public class ScheduleDeleteServiceTest {
             Long invalidTripperId = 3L;
             Long scheduleId = 4L;
 
-            Trip trip = DECIDED_TRIP.createDecided(tripId, tripOwnerId, "여행 제목", LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1));
+            LocalDate startDate = LocalDate.of(2023,3,1);
+            LocalDate endDate = LocalDate.of(2023,3,1);
+            Trip trip = TripFixture.decided_Id(tripId, tripOwnerId, startDate, endDate, 1L);
             Day day = trip.getDays().get(0);
 
             Schedule schedule = Schedule.builder()
@@ -97,8 +99,10 @@ public class ScheduleDeleteServiceTest {
         Long tripOwnerId = 2L;
         Long deleteTripperId = 2L;
         Long scheduleId = 3L;
+        LocalDate startDate = LocalDate.of(2023,3,1);
+        LocalDate endDate = LocalDate.of(2023,3,1);
 
-        Trip trip = DECIDED_TRIP.createDecided(tripId, tripOwnerId, "여행 제목", LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1));
+        Trip trip = TripFixture.decided_Id(tripId, tripOwnerId, startDate, endDate, 1L);
         Day day = trip.getDays().get(0);
 
         Schedule schedule = Schedule.builder()

--- a/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleUpdateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleUpdateServiceTest.java
@@ -1,5 +1,6 @@
 package com.cosain.trilo.unit.trip.application.schedule.command.service;
 
+import com.cosain.trilo.fixture.TripFixture;
 import com.cosain.trilo.trip.application.exception.NoScheduleUpdateAuthorityException;
 import com.cosain.trilo.trip.application.exception.ScheduleNotFoundException;
 import com.cosain.trilo.trip.application.schedule.command.service.ScheduleUpdateService;
@@ -8,10 +9,9 @@ import com.cosain.trilo.trip.domain.entity.Schedule;
 import com.cosain.trilo.trip.domain.entity.Trip;
 import com.cosain.trilo.trip.domain.repository.ScheduleRepository;
 import com.cosain.trilo.trip.domain.vo.ScheduleContent;
+import com.cosain.trilo.trip.domain.vo.ScheduleIndex;
 import com.cosain.trilo.trip.domain.vo.ScheduleTime;
 import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
-import com.cosain.trilo.trip.domain.vo.TripTitle;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,7 +22,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalTime;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -39,60 +42,81 @@ public class ScheduleUpdateServiceTest {
     @DisplayName("호출이 제대로 이루어 지는지 테스트")
     public void update_schedule_test(){
         // given
+        Long tripId = 1L;
+        Long tripperId = 2L;
+        Long scheduleId = 3L;
+
         ScheduleTitle newTitle = ScheduleTitle.of("변경할 제목");
         ScheduleContent newContent = ScheduleContent.of("변경할 내용");
         ScheduleTime newScheduleTime = ScheduleTime.of(LocalTime.of(13,0), LocalTime.of(13,5));
         ScheduleUpdateCommand command = new ScheduleUpdateCommand(newTitle, newContent, newScheduleTime);
 
+        Trip trip = TripFixture.undecided_Id(tripId, tripperId);
         Schedule schedule = Schedule.builder()
-                .trip(Trip.create(TripTitle.of("여행 제목"), 1L))
-                .scheduleTitle(ScheduleTitle.of("원래 제목"))
-                .scheduleContent(ScheduleContent.of("원래 내용"))
+                .id(scheduleId)
+                .trip(trip)
+                .day(null)
+                .scheduleTitle(ScheduleTitle.of("기존 제목"))
+                .scheduleContent(ScheduleContent.of("기존 본문"))
+                .scheduleIndex(ScheduleIndex.ZERO_INDEX)
                 .build();
 
         given(scheduleRepository.findByIdWithTrip(anyLong())).willReturn(Optional.of(schedule));
         // when
-        scheduleUpdateService.updateSchedule(1L, 1L, command);
+        scheduleUpdateService.updateSchedule(scheduleId, tripperId, command);
 
         // then
-        verify(scheduleRepository).findByIdWithTrip(anyLong());
+        verify(scheduleRepository).findByIdWithTrip(eq(scheduleId));
+        assertThat(schedule.getScheduleTitle()).isEqualTo(newTitle);
+        assertThat(schedule.getScheduleContent()).isEqualTo(newContent);
+        assertThat(schedule.getScheduleTime()).isEqualTo(newScheduleTime);
+    }
+
+    @Test
+    @DisplayName("요청한 일정이 존재하지 않는다면, ScheduleNotFoundException 이 발생한다")
+    public void when_no_schedule_test(){
+        // given
+        Long scheduleId = 1L;
+        Long tripperId = 2L;
+
+        ScheduleTitle newTitle = ScheduleTitle.of("변경할 제목");
+        ScheduleContent newContent = ScheduleContent.of("변경할 내용");
+        ScheduleTime newScheduleTime = ScheduleTime.of(LocalTime.of(13,0), LocalTime.of(13,5));
+        ScheduleUpdateCommand command = new ScheduleUpdateCommand(newTitle, newContent, newScheduleTime);
+
+        given(scheduleRepository.findByIdWithTrip(eq(scheduleId))).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> scheduleUpdateService.updateSchedule(scheduleId, tripperId, command))
+                .isInstanceOf(ScheduleNotFoundException.class);
     }
 
     @Test
     @DisplayName("권한이 없는 사람이 Schedule 을 변경하려고 하면, NoScheduleUpdateAuthorityException 이 발생한다")
     public void when_no_authority_user_try_update_test(){
         // given
+        Long tripId = 1L;
+        Long tripperId = 2L;
+        Long scheduleId = 3L;
+        Long noAuthorityTripperId = 4L;
+
         ScheduleTitle newTitle = ScheduleTitle.of("변경할 제목");
         ScheduleContent newContent = ScheduleContent.of("변경할 내용");
         ScheduleTime newScheduleTime = ScheduleTime.of(LocalTime.of(13,0), LocalTime.of(13,5));
         ScheduleUpdateCommand command = new ScheduleUpdateCommand(newTitle, newContent, newScheduleTime);
 
+        Trip trip = TripFixture.undecided_Id(tripId, tripperId);
         Schedule schedule = Schedule.builder()
-                .trip(Trip.create(TripTitle.of("여행 제목"), 2L))
+                .id(scheduleId)
+                .day(null)
+                .trip(trip)
                 .scheduleTitle(ScheduleTitle.of("원래 제목"))
                 .scheduleContent(ScheduleContent.of("원래 내용"))
                 .build();
 
-        given(scheduleRepository.findByIdWithTrip(anyLong())).willReturn(Optional.of(schedule));
+        given(scheduleRepository.findByIdWithTrip(eq(scheduleId))).willReturn(Optional.of(schedule));
         // when & then
-        Assertions.assertThatThrownBy(() -> scheduleUpdateService.updateSchedule(1L, 1L, command))
+        assertThatThrownBy(() -> scheduleUpdateService.updateSchedule(scheduleId, noAuthorityTripperId, command))
                 .isInstanceOf(NoScheduleUpdateAuthorityException.class);
-    }
-
-    @Test
-    @DisplayName("일정이 존재하지 않는다면, ScheduleNotFoundException 이 발생한다")
-    public void when_no_schedule_test(){
-        // given
-        // given
-        ScheduleTitle newTitle = ScheduleTitle.of("변경할 제목");
-        ScheduleContent newContent = ScheduleContent.of("변경할 내용");
-        ScheduleTime newScheduleTime = ScheduleTime.of(LocalTime.of(13,0), LocalTime.of(13,5));
-        ScheduleUpdateCommand command = new ScheduleUpdateCommand(newTitle, newContent, newScheduleTime);
-
-        given(scheduleRepository.findByIdWithTrip(anyLong())).willReturn(Optional.empty());
-
-        // when & then
-        Assertions.assertThatThrownBy(() -> scheduleUpdateService.updateSchedule(1L, 1L, command))
-                .isInstanceOf(ScheduleNotFoundException.class);
     }
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/application/trip/command/service/TripAllDeleteServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/trip/command/service/TripAllDeleteServiceTest.java
@@ -10,7 +10,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -35,9 +35,9 @@ public class TripAllDeleteServiceTest {
         tripAllDeleteService.deleteAllByTripperId(tripperId);
 
         // then
-        verify(tripRepository).findAllByTripperId(any());
-        verify(tripRepository).deleteAllByTripperId(any());
-        verify(dayRepository).deleteAllByTripIds(any());
-        verify(scheduleRepository).deleteAllByTripIds(any());
+        verify(tripRepository).findAllByTripperId(eq(tripperId));
+        verify(tripRepository).deleteAllByTripperId(eq(tripperId));
+        verify(dayRepository).deleteAllByTripIds(anyList());
+        verify(scheduleRepository).deleteAllByTripIds(anyList());
     }
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/application/trip/command/service/TripCreateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/trip/command/service/TripCreateServiceTest.java
@@ -1,7 +1,8 @@
 package com.cosain.trilo.unit.trip.application.trip.command.service;
 
-import com.cosain.trilo.trip.application.trip.command.usecase.dto.TripCreateCommand;
+import com.cosain.trilo.fixture.TripFixture;
 import com.cosain.trilo.trip.application.trip.command.service.TripCreateService;
+import com.cosain.trilo.trip.application.trip.command.usecase.dto.TripCreateCommand;
 import com.cosain.trilo.trip.domain.entity.Trip;
 import com.cosain.trilo.trip.domain.repository.TripRepository;
 import com.cosain.trilo.trip.domain.vo.TripTitle;
@@ -12,10 +13,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.util.ReflectionUtils;
 
-import java.lang.reflect.Field;
-
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -33,28 +32,23 @@ public class TripCreateServiceTest {
 
     @Test
     @DisplayName("create 하면, 내부적으로 repository가 호출된다.")
-    public void create_and_repository_called() throws Exception {
+    public void create_and_repository_called() {
         // given
+        Long tripId = 1L;
+        Long tripperId = 2L;
+
         TripCreateCommand createCommand = new TripCreateCommand(TripTitle.of("제목"));
-        Long tripperId = 1L;
 
         // mocking
-        Trip trip = Trip.create(TripTitle.of("제목"), tripperId);
-        injectFakeTripId(trip, 1L);
-
+        Trip trip = TripFixture.undecided_Id(tripId, tripperId);
         given(tripRepository.save(any(Trip.class))).willReturn(trip);
 
         // when
-        tripCreateService.createTrip(tripperId, createCommand);
+        Long returnTripId = tripCreateService.createTrip(tripperId, createCommand);
 
         // then
         verify(tripRepository).save(any(Trip.class));
-    }
-
-    private void injectFakeTripId(Trip trip, Long fakeTripId) {
-        Field field = ReflectionUtils.findField(Trip.class, "id");
-        ReflectionUtils.makeAccessible(field);
-        ReflectionUtils.setField(field, trip, fakeTripId);
+        assertThat(returnTripId).isEqualTo(tripId);
     }
 
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/application/trip/command/service/TripDeleteServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/trip/command/service/TripDeleteServiceTest.java
@@ -1,5 +1,6 @@
 package com.cosain.trilo.unit.trip.application.trip.command.service;
 
+import com.cosain.trilo.fixture.TripFixture;
 import com.cosain.trilo.trip.application.exception.NoTripDeleteAuthorityException;
 import com.cosain.trilo.trip.application.exception.TripNotFoundException;
 import com.cosain.trilo.trip.application.trip.command.service.TripDeleteService;
@@ -17,7 +18,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
-import static com.cosain.trilo.fixture.TripFixture.UNDECIDED_TRIP;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -67,7 +67,7 @@ public class TripDeleteServiceTest {
             Long tripOwnerId = 1L;
             Long invalidTripperId = 2L;
 
-            Trip trip = UNDECIDED_TRIP.createUndecided(tripId, tripOwnerId, "여행 제목");
+            Trip trip = TripFixture.undecided_Id(tripId, tripOwnerId);
             given(tripRepository.findById(eq(tripId))).willReturn(Optional.of(trip));
 
             // when & then
@@ -86,7 +86,7 @@ public class TripDeleteServiceTest {
         Long tripOwnerId = 2L;
         Long deleteTripperId = 2L;
 
-        Trip trip = UNDECIDED_TRIP.createUndecided(tripId, tripOwnerId, "여행 제목");
+        Trip trip = TripFixture.undecided_Id(tripId, tripOwnerId);
 
         given(tripRepository.findById(eq(tripId))).willReturn(Optional.of(trip));
         willDoNothing().given(scheduleRepository).deleteAllByTripId(eq(tripId));

--- a/src/test/java/com/cosain/trilo/unit/trip/application/trip/command/service/TripPeriodUpdateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/trip/command/service/TripPeriodUpdateServiceTest.java
@@ -1,18 +1,15 @@
 package com.cosain.trilo.unit.trip.application.trip.command.service;
 
+import com.cosain.trilo.fixture.TripFixture;
 import com.cosain.trilo.trip.application.exception.NoTripUpdateAuthorityException;
 import com.cosain.trilo.trip.application.exception.TripNotFoundException;
 import com.cosain.trilo.trip.application.trip.command.service.TripPeriodUpdateService;
 import com.cosain.trilo.trip.application.trip.command.usecase.dto.TripPeriodUpdateCommand;
-import com.cosain.trilo.trip.domain.entity.Day;
 import com.cosain.trilo.trip.domain.entity.Trip;
 import com.cosain.trilo.trip.domain.repository.DayRepository;
 import com.cosain.trilo.trip.domain.repository.ScheduleRepository;
 import com.cosain.trilo.trip.domain.repository.TripRepository;
-import com.cosain.trilo.trip.domain.vo.DayColor;
 import com.cosain.trilo.trip.domain.vo.TripPeriod;
-import com.cosain.trilo.trip.domain.vo.TripStatus;
-import com.cosain.trilo.trip.domain.vo.TripTitle;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -22,9 +19,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
@@ -78,7 +73,7 @@ public class TripPeriodUpdateServiceTest {
 
         TripPeriodUpdateCommand updateCommand = createCommand(startDate, endDate);
 
-        Trip trip = mockUnDecidedTrip(tripId, tripperId);
+        Trip trip = TripFixture.undecided_Id(tripId, tripperId);
         given(tripRepository.findByIdWithDays(eq(tripId))).willReturn(Optional.of(trip));
 
         // when
@@ -99,7 +94,7 @@ public class TripPeriodUpdateServiceTest {
         Long tripperId = 2L;
 
         TripPeriodUpdateCommand updateCommand = createCommand(LocalDate.of(2023, 3, 2), LocalDate.of(2023,3,5));
-        Trip trip = mockDecidedTrip(tripId, tripperId, LocalDate.of(2023,3,1), LocalDate.of(2023,3,4), 1L);
+        Trip trip = TripFixture.decided_Id(tripId, tripperId, LocalDate.of(2023,3,1), LocalDate.of(2023,3,4), 1L);
 
         given(tripRepository.findByIdWithDays(eq(tripId))).willReturn(Optional.of(trip)); // trip 조회 일어남.
 
@@ -132,7 +127,7 @@ public class TripPeriodUpdateServiceTest {
 
             TripPeriodUpdateCommand updateCommand = createCommand(LocalDate.of(2023,3,1), LocalDate.of(2023,3,3));
 
-            Trip trip = mockUnDecidedTrip(tripId, tripperId);
+            Trip trip = TripFixture.undecided_Id(tripId, tripperId);
             given(tripRepository.findByIdWithDays(eq(tripId))).willReturn(Optional.of(trip));
 
             // when & then
@@ -146,47 +141,6 @@ public class TripPeriodUpdateServiceTest {
 
     private TripPeriodUpdateCommand createCommand(LocalDate startDate, LocalDate endDate) {
         return new TripPeriodUpdateCommand(TripPeriod.of(startDate, endDate));
-    }
-
-    private Trip mockUnDecidedTrip(Long id, Long tripperId) {
-        return Trip.builder()
-                .id(id)
-                .tripperId(tripperId)
-                .tripTitle(TripTitle.of("여행 제목"))
-                .tripPeriod(TripPeriod.empty())
-                .status(TripStatus.UNDECIDED)
-                .build();
-    }
-
-    private Trip mockDecidedTrip(Long id, Long tripperId, LocalDate startDate, LocalDate endDate, Long startDayId) {
-        TripPeriod period = TripPeriod.of(startDate, endDate);
-        Trip trip = Trip.builder()
-                .id(id)
-                .tripperId(tripperId)
-                .tripTitle(TripTitle.of("여행 제목"))
-                .tripPeriod(TripPeriod.empty())
-                .status(TripStatus.UNDECIDED)
-                .build();
-
-        List<Day> days = mockDays(period, trip, startDayId);
-        trip.getDays().addAll(days);
-        return trip;
-    }
-
-    private List<Day> mockDays(TripPeriod period, Trip trip, Long startDayId) {
-        List<LocalDate> dates = period.dateStream().toList();
-        return IntStream.range(0, dates.size())
-                .mapToObj(idx -> createDay(trip, startDayId, dates, idx))
-                .toList();
-    }
-
-    private Day createDay(Trip trip, Long startDayId, List<LocalDate> dates, int idx) {
-        return Day.builder()
-                .id(startDayId + idx)
-                .tripDate(dates.get(idx))
-                .trip(trip)
-                .dayColor(DayColor.BLACK)
-                .build();
     }
 
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/application/trip/command/service/TripTitleUpdateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/trip/command/service/TripTitleUpdateServiceTest.java
@@ -45,7 +45,7 @@ public class TripTitleUpdateServiceTest {
         String requestTitle = "수정 여행 제목";
 
         TripTitleUpdateCommand updateCommand = createCommand(requestTitle);
-        Trip trip = mockTrip(tripId, tripperId, beforeTitle);
+        Trip trip = TripFixture.undecided_Id_Title(tripId, tripperId, beforeTitle);
 
         given(tripRepository.findById(eq(tripId))).willReturn(Optional.of(trip));
 
@@ -89,7 +89,7 @@ public class TripTitleUpdateServiceTest {
         String requestTitle = "수정 여행 제목";
 
         TripTitleUpdateCommand updateCommand = createCommand(requestTitle);
-        Trip trip = mockTrip(tripId, realTripOwnerId, beforeTitle);
+        Trip trip = TripFixture.undecided_Id_Title(tripId, realTripOwnerId, beforeTitle);
 
         given(tripRepository.findById(eq(tripId))).willReturn(Optional.of(trip));
 
@@ -102,10 +102,6 @@ public class TripTitleUpdateServiceTest {
 
     private TripTitleUpdateCommand createCommand(String rawTitle) {
         return new TripTitleUpdateCommand(TripTitle.of(rawTitle));
-    }
-
-    private Trip mockTrip(Long id, Long tripperId, String rawTitle) {
-        return TripFixture.UNDECIDED_TRIP.createUndecided(id, tripperId, rawTitle);
     }
 
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/entity/DayTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/entity/DayTest.java
@@ -24,7 +24,12 @@ public class DayTest {
     @ValueSource(strings = {"RED", "ORANGE", "PURPLE"})
     @DisplayName("Day의 색상 변경 테스트")
     public void changeColorTest(String colorName) {
-        Trip trip = TripFixture.DECIDED_TRIP.createDecided(1L, 1L, "제목", LocalDate.of(2023,5,1), LocalDate.of(2023,5,1));
+        Long tripperId = 1L;
+        LocalDate startDate = LocalDate.of(2023,5,1);
+        LocalDate endDate = LocalDate.of(2023,5,1);
+        DayColor beforeColor = DayColor.BLACK;
+        Trip trip = TripFixture.decided_nullId_Color(tripperId, startDate, endDate, beforeColor);
+
         Day day = trip.getDays().get(0);
 
         DayColor color = DayColor.of(colorName);
@@ -41,7 +46,10 @@ public class DayTest {
         @DisplayName("Day의 날짜가 Period에 포함되면 true를 반환한다.")
         public void when_period_contains_date_day_is_in_this_period() {
             // given
-            Trip trip = TripFixture.DECIDED_TRIP.createDecided(1L, 1L, "제목", LocalDate.of(2023,5,2), LocalDate.of(2023,5,2));
+            Long tripperId = 1L;
+            LocalDate startDate = LocalDate.of(2023,5,2);
+            LocalDate endDate = LocalDate.of(2023,5,2);
+            Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
             Day day = trip.getDays().get(0);
 
             TripPeriod period = TripPeriod.of(LocalDate.of(2023, 5, 1), LocalDate.of(2023, 5, 3));
@@ -54,7 +62,10 @@ public class DayTest {
         @DisplayName("Day의 날짜가 Period에 포함되지 않으면 false를 반환한다.")
         public void when_period_not_contains_date_day_is_not_in_this_period() {
             // given
-            Trip trip = TripFixture.DECIDED_TRIP.createDecided(1L, 1L, "제목", LocalDate.of(2023,5,4), LocalDate.of(2023,5,4));
+            Long tripperId = 1L;
+            LocalDate startDate = LocalDate.of(2023,5,4);
+            LocalDate endDate = LocalDate.of(2023,5,4);
+            Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
             Day day = trip.getDays().get(0);
 
             TripPeriod period = TripPeriod.of(LocalDate.of(2023, 5, 1), LocalDate.of(2023, 5, 3));
@@ -67,8 +78,12 @@ public class DayTest {
         @DisplayName("Period가 빈 기간이면 false를 반환한다.")
         public void when_period_is_empty_then_day_is_not_in_this_period() {
             // given
-            Trip trip = TripFixture.DECIDED_TRIP.createDecided(1L, 1L, "제목", LocalDate.of(2023,5,4), LocalDate.of(2023,5,4));
+            Long tripperId = 1L;
+            LocalDate startDate = LocalDate.of(2023,5,2);
+            LocalDate endDate = LocalDate.of(2023,5,2);
+            Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
             Day day = trip.getDays().get(0);
+
             TripPeriod period = TripPeriod.empty();
 
             // when & then

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/entity/TripTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/entity/TripTest.java
@@ -231,45 +231,12 @@ public class TripTest {
                 Long tripId = 1L;
                 Long tripperId = 2L;
 
-                decidedTrip = Trip.builder()
-                        .id(tripId)
-                        .tripperId(tripperId)
-                        .tripTitle(TripTitle.of("여행 제목"))
-                        .tripPeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 5)))
-                        .status(TripStatus.DECIDED)
-                        .build();
-
-                day1 = Day.builder()
-                        .id(1L)
-                        .trip(decidedTrip)
-                        .tripDate(LocalDate.of(2023, 3, 1))
-                        .build();
-
-                day2 = Day.builder()
-                        .id(2L)
-                        .trip(decidedTrip)
-                        .tripDate(LocalDate.of(2023, 3, 2))
-                        .build();
-
-                day3 = Day.builder()
-                        .id(3L)
-                        .trip(decidedTrip)
-                        .tripDate(LocalDate.of(2023, 3, 3))
-                        .build();
-
-                day4 = Day.builder()
-                        .id(4L)
-                        .trip(decidedTrip)
-                        .tripDate(LocalDate.of(2023, 3, 4))
-                        .build();
-
-                day5 = Day.builder()
-                        .id(5L)
-                        .trip(decidedTrip)
-                        .tripDate(LocalDate.of(2023, 3, 5))
-                        .build();
-
-                decidedTrip.getDays().addAll(List.of(day1, day2, day3, day4, day5));
+                decidedTrip = TripFixture.decided_Id(tripId, tripperId, LocalDate.of(2023,3,1), LocalDate.of(2023,3,5), 1L);
+                day1 = decidedTrip.getDays().get(0);
+                day2 = decidedTrip.getDays().get(1);
+                day3 = decidedTrip.getDays().get(2);
+                day4 = decidedTrip.getDays().get(3);
+                day5 = decidedTrip.getDays().get(4);
             }
 
             @Test
@@ -846,21 +813,25 @@ public class TripTest {
             @DisplayName("targetOrder가 임시보관함 크기를 넘어가는 경우 InvalidScheduleMoveTargetOrderException 발생")
             @Test
             public void when_targetOrder_is_over_temporary_storage_max_size_then_it_throws_InvalidScheduleMoveTargetOrderException() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
-                Day day = null;
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                Trip trip = TripFixture.undecided_Id(tripId,tripperId);
+                Day targetDay = null;
 
-                Schedule schedule1 = trip.createSchedule(day, ScheduleTitle.of("일정제목"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
-                Schedule schedule2 = trip.createSchedule(day, ScheduleTitle.of("일정제목"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule1 = trip.createSchedule(targetDay, ScheduleTitle.of("일정제목"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Schedule schedule2 = trip.createSchedule(targetDay, ScheduleTitle.of("일정제목"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when & then
-                assertThatThrownBy(() -> trip.moveSchedule(schedule1, day, 3))
+                assertThatThrownBy(() -> trip.moveSchedule(schedule1, targetDay, 3))
                         .isInstanceOf(InvalidScheduleMoveTargetOrderException.class);
             }
 
             @DisplayName("임시보관함 내에서, 자신의 기존 순서로 이동할 경우, 아무런 변화도 일어나지 않는다.")
             @Test
             public void when_move_to_same_position_then_nothing_changed() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                Trip trip = TripFixture.undecided_Id(tripId, tripperId);
 
                 Schedule schedule2 = trip.createSchedule(null, ScheduleTitle.of("일정제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
                 Schedule schedule1 = trip.createSchedule(null, ScheduleTitle.of("일정제목1"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
@@ -886,7 +857,10 @@ public class TripTest {
             @DisplayName("임시보관함 내에 기존의 순서 다음으로 이동시키려 할 경우, 아무런 변화도 일어나지 않는다.")
             @Test
             public void when_move_to_after_currentOrder_then_nothing_changed() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                Trip trip = TripFixture.undecided_Id(tripId, tripperId);
+
                 Schedule schedule2 = trip.createSchedule(null, ScheduleTitle.of("일정제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
                 Schedule schedule1 = trip.createSchedule(null, ScheduleTitle.of("일정제목1"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
 
@@ -911,7 +885,9 @@ public class TripTest {
             @DisplayName("targetOrder가 임시보관함 크기와 똑같은 값이고, 끝 ScheduleIndex 범위가 안전하면 맨 뒤로 이동한다.")
             @Test
             public void when_targetOrder_isEqualTo_TemporaryStorageSize_and_tail_scheduleIndex_isSafe_schedule_move_to_Tail() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                Trip trip = TripFixture.undecided_Id(tripId, tripperId);
 
                 Schedule schedule2 = trip.createSchedule(null, ScheduleTitle.of("일정제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
                 Schedule schedule1 = trip.createSchedule(null, ScheduleTitle.of("일정제목1"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
@@ -934,7 +910,9 @@ public class TripTest {
             @DisplayName("targetOrder가 임시보관함 크기와 똑같은 값이고, 끝 ScheduleIndex 범위가 안전하지 않으면 ScheduleIndexRangeException 발생")
             @Test
             public void when_targetOrder_isEqualTo_TemporaryStorageSize_and_tail_scheduleIndex_is_unSafe_it_throws_ScheduleIndexRangeException() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                Trip trip = TripFixture.undecided_Id(tripId, tripperId);
                 Day day = null;
 
                 Schedule schedule1 = Schedule.builder()
@@ -965,7 +943,9 @@ public class TripTest {
             @DisplayName("targetOrder가 0이고, 맨 앞 ScheduleIndex 범위가 안전하면 맨 앞으로 이동한다.")
             @Test
             public void when_targetOrder_isEqualTo_Zero_and_head_scheduleIndex_is_Safe_then_schedule_move_to_Head() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                Trip trip = TripFixture.undecided_Id(tripId, tripperId);
 
                 Schedule schedule2 = trip.createSchedule(null, ScheduleTitle.of("일정제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
                 Schedule schedule1 = trip.createSchedule(null, ScheduleTitle.of("일정제목1"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
@@ -988,7 +968,9 @@ public class TripTest {
             @DisplayName("targetOrder가 0이고, 맨 앞 ScheduleIndex 범위가 안전하지 않으면 ScheduleIndexRangeException 발생")
             @Test
             public void when_targetOrder_isEqualTo_Zero_and_head_scheduleIndex_is_unSafe_it_throws_ScheduleIndexRangeException() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                Trip trip = TripFixture.undecided_Id(tripId, tripperId);
                 Day day = null;
 
                 Schedule schedule1 = Schedule.builder()
@@ -1019,7 +1001,9 @@ public class TripTest {
             @DisplayName("targetOrder가 유효한 순서이고, 해당 순서 앞과 간격이 충분하면 중간 인덱스가 부여된다.")
             @Test
             public void testMiddleInsert_Success() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                Trip trip = TripFixture.undecided_Id(tripId, tripperId);
 
                 Schedule schedule3 = trip.createSchedule(null, ScheduleTitle.of("일정제목3"), Place.of("place-id333", "place 이름333", Coordinate.of(37.72221, 137.86523)));
                 Schedule schedule2 = trip.createSchedule(null, ScheduleTitle.of("일정제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
@@ -1043,7 +1027,9 @@ public class TripTest {
             @DisplayName("targetOrder가 다른 일정의 순서이고, 해당 순서 앞과 간격이 충분하지 않으면 MidScheduleIndexConflictException 발생")
             @Test
             public void testMiddleInsert_Failure() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                Trip trip = TripFixture.undecided_Id(tripId, tripperId);
                 Day day = null;
 
                 Schedule schedule1 = Schedule.builder()
@@ -1089,7 +1075,9 @@ public class TripTest {
             @DisplayName("targetDay가 Trip의 Day가 아니면, InvalidTripDayException 발생")
             public void when_targetDay_is_not_in_trip_then_it_throws_InvalidTripDayException() {
                 // given
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                Trip trip = TripFixture.undecided_Id(tripId, tripperId);
 
                 Trip otherTrip = Trip.create(TripTitle.of("다른 여행 제목"), 1L);
                 otherTrip.changePeriod(TripPeriod.of(LocalDate.of(2023, 4, 1), LocalDate.of(2023, 4, 1)));
@@ -1109,12 +1097,17 @@ public class TripTest {
             @Test
             public void when_targetOrder_is_under_zero_then_it_throws_InvalidScheduleMoveTargetOrderException() {
                 // given
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                LocalDate startDate = LocalDate.of(2023,3,1);
+                LocalDate endDate = LocalDate.of(2023,3,1);
+
+                Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, 1L);
                 Day beforeDay = null;
+                Day targetDay = trip.getDays().get(0);
+
                 Schedule schedule = trip.createSchedule(beforeDay, ScheduleTitle.of("일정제목"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
 
-                Day targetDay = trip.getDays().get(0);
 
                 // when & then
                 assertThatThrownBy(() -> trip.moveSchedule(schedule, targetDay, -1))
@@ -1124,13 +1117,16 @@ public class TripTest {
             @DisplayName("targetOrder가 Schedules 크기를 넘어가는 경우 InvalidScheduleMoveTargetOrderException 발생")
             @Test
             public void when_targetOrder_is_over_day_schedules_max_size_then_it_throws_InvalidScheduleMoveTargetOrderException() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                LocalDate startDate = LocalDate.of(2023,3,1);
+                LocalDate endDate = LocalDate.of(2023,3,1);
 
+                Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, 1L);
                 Day beforeDay = null;
-                Schedule schedule1 = trip.createSchedule(beforeDay, ScheduleTitle.of("일정제목"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
-
                 Day targetDay = trip.getDays().get(0);
+
+                Schedule schedule1 = trip.createSchedule(beforeDay, ScheduleTitle.of("일정제목"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
                 Schedule schedule2 = trip.createSchedule(targetDay, ScheduleTitle.of("일정제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when & then
@@ -1142,9 +1138,13 @@ public class TripTest {
             @DisplayName("targetOrder가 Schedules 크기와 똑같은 값이고, 끝 ScheduleIndex 범위가 안전하면 맨 뒤로 이동한다.")
             @Test
             public void when_targetOrder_isEqualTo_SchedulesSize_and_tail_scheduleIndex_isSafe_schedule_move_to_Tail() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
+                // given
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                LocalDate startDate = LocalDate.of(2023,3,1);
+                LocalDate endDate = LocalDate.of(2023,3,1);
 
+                Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, 1L);
                 Day beforeDay = null;
                 Day targetDay = trip.getDays().get(0);
 
@@ -1171,9 +1171,13 @@ public class TripTest {
             @DisplayName("targetOrder가 Schedules 크기와 똑같은 값이고, 끝 ScheduleIndex 범위가 안전하지 않으면 ScheduleIndexRangeException 발생")
             @Test
             public void when_targetOrder_isEqualTo_SchedulesSize_and_tail_scheduleIndex_is_unSafe_it_throws_ScheduleIndexRangeException() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
+                // given
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                LocalDate startDate = LocalDate.of(2023,3,1);
+                LocalDate endDate = LocalDate.of(2023,3,1);
 
+                Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, 1L);
                 Day beforeDay = null;
                 Day targetDay = trip.getDays().get(0);
 
@@ -1205,9 +1209,13 @@ public class TripTest {
             @DisplayName("targetOrder가 0이고, 맨 앞 ScheduleIndex 범위가 안전하면 맨 앞로 이동한다.")
             @Test
             public void when_targetOrder_isEqualTo_Zero_and_head_scheduleIndex_isSafe_schedule_move_to_Head() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
+                // given
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                LocalDate startDate = LocalDate.of(2023,3,1);
+                LocalDate endDate = LocalDate.of(2023,3,1);
 
+                Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, 1L);
                 Day beforeDay = null;
                 Day targetDay = trip.getDays().get(0);
 
@@ -1234,8 +1242,13 @@ public class TripTest {
             @DisplayName("targetOrder가 0이고, 맨 앞 ScheduleIndex 범위가 안전하지 않으면 ScheduleIndexRangeException 발생")
             @Test
             public void when_targetOrder_isEqualTo_Zero_and_head_scheduleIndex_is_unSafe_it_throws_ScheduleIndexRangeException() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
+                // given
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                LocalDate startDate = LocalDate.of(2023,3,1);
+                LocalDate endDate = LocalDate.of(2023,3,1);
+
+                Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, 1L);
 
                 Day beforeDay = null;
                 Day targetDay = trip.getDays().get(0);
@@ -1268,9 +1281,13 @@ public class TripTest {
             @DisplayName("targetOrder가 다른 일정의 순서이고, 해당 순서 앞과 간격이 충분하면 중간 인덱스가 부여된다.")
             @Test
             public void testMiddleInsert_Success() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
+                // given
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                LocalDate startDate = LocalDate.of(2023,3,1);
+                LocalDate endDate = LocalDate.of(2023,3,1);
 
+                Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, 1L);
                 Day beforeDay = null;
                 Day targetDay = trip.getDays().get(0);
 
@@ -1299,9 +1316,13 @@ public class TripTest {
             @DisplayName("targetOrder가 다른 일정의 순서이고, 해당 순서 앞과 간격이 충분하지 않으면 MidScheduleIndexConflictException 발생")
             @Test
             public void testMiddleInsert_Failure() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
+                // given
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                LocalDate startDate = LocalDate.of(2023,3,1);
+                LocalDate endDate = LocalDate.of(2023,3,1);
 
+                Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, 1L);
                 Day beforeDay = null;
                 Day targetDay = trip.getDays().get(0);
 
@@ -1348,14 +1369,18 @@ public class TripTest {
             @DisplayName("targetDay가 Trip의 Day가 아니면, InvalidTripDayException 발생")
             public void when_targetDay_is_not_in_trip_then_it_throws_InvalidTripDayException() {
                 // given
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
+                Long tripId = 1L;
+                Long otherTripId = 2L;
+                Long tripperId = 3L;
+                LocalDate startDate = LocalDate.of(2023,3,1);
+                LocalDate endDate = LocalDate.of(2023,3,2);
+
+                Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, 1L);
                 Day beforeDay = trip.getDays().get(0);
                 Schedule schedule = trip.createSchedule(beforeDay, ScheduleTitle.of("여행 제목"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
 
-                Trip otherTrip = Trip.create(TripTitle.of("다른 여행 제목"), 1L);
-                otherTrip.changePeriod(TripPeriod.of(LocalDate.of(2023, 4, 1), LocalDate.of(2023, 4, 1)));
-                Day targetDay = otherTrip.getDays().get(0);
+                Trip otherTrip = TripFixture.decided_Id(otherTripId, tripperId, startDate, endDate, 3L);
+                Day targetDay = otherTrip.getDays().get(1);
 
                 // when & then
                 assertThatThrownBy(() -> trip.moveSchedule(schedule, targetDay, 0))
@@ -1366,12 +1391,16 @@ public class TripTest {
             @Test
             public void when_targetOrder_is_under_zero_then_it_throws_InvalidScheduleMoveTargetOrderException() {
                 // given
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
-                Day beforeDay = trip.getDays().get(0);
-                Schedule schedule = trip.createSchedule(beforeDay, ScheduleTitle.of("일정제목"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                LocalDate startDate = LocalDate.of(2023,3,1);
+                LocalDate endDate = LocalDate.of(2023,3,2);
 
+                Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, 1L);
+                Day beforeDay = trip.getDays().get(0);
                 Day targetDay = trip.getDays().get(1);
+
+                Schedule schedule = trip.createSchedule(beforeDay, ScheduleTitle.of("일정제목"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
 
                 // when & then
                 assertThatThrownBy(() -> trip.moveSchedule(schedule, targetDay, -1))
@@ -1381,14 +1410,16 @@ public class TripTest {
             @DisplayName("targetOrder가 Schedules 크기를 넘어가는 경우 InvalidScheduleMoveTargetOrderException 발생")
             @Test
             public void when_targetOrder_is_over_day_schedules_max_size_then_it_throws_InvalidScheduleMoveTargetOrderException() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                LocalDate startDate = LocalDate.of(2023,3,1);
+                LocalDate endDate = LocalDate.of(2023,3,2);
 
+                Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, 1L);
                 Day beforeDay = trip.getDays().get(0);
-                Schedule schedule1 = trip.createSchedule(beforeDay, ScheduleTitle.of("일정제목"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
-
-
                 Day targetDay = trip.getDays().get(1);
+
+                Schedule schedule1 = trip.createSchedule(beforeDay, ScheduleTitle.of("일정제목"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
                 Schedule schedule2 = trip.createSchedule(targetDay, ScheduleTitle.of("일정제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
                 // when & then
@@ -1399,8 +1430,12 @@ public class TripTest {
             @DisplayName("같은 Day의 기존의 순서로 이동할 경우, 아무런 변화도 일어나지 않는다.")
             @Test
             public void when_move_to_same_day_and_same_position_then_nothing_changed() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                LocalDate startDate = LocalDate.of(2023,3,1);
+                LocalDate endDate = LocalDate.of(2023,3,2);
+
+                Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, 1L);
                 Day day = trip.getDays().get(0);
 
                 Schedule schedule1 = trip.createSchedule(day, ScheduleTitle.of("일정제목1"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
@@ -1427,8 +1462,12 @@ public class TripTest {
             @DisplayName("같은 Day의 기존의 순서 다음으로 이동시키려 할 경우, 아무런 변화도 일어나지 않는다.")
             @Test
             public void when_move_to_same_day_and_after_currentOrder_then_nothing_changed() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                LocalDate startDate = LocalDate.of(2023,3,1);
+                LocalDate endDate = LocalDate.of(2023,3,1);
+
+                Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, 1L);
                 Day day = trip.getDays().get(0);
 
                 Schedule schedule1 = trip.createSchedule(day, ScheduleTitle.of("일정제목1"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
@@ -1456,9 +1495,12 @@ public class TripTest {
             @DisplayName("targetOrder가 Schedules 크기와 똑같은 값이고, 끝 ScheduleIndex 범위가 안전하면 맨 뒤로 이동한다.")
             @Test
             public void when_targetOrder_isEqualTo_SchedulesSize_and_tail_scheduleIndex_isSafe_schedule_move_to_Tail() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                LocalDate startDate = LocalDate.of(2023,3,1);
+                LocalDate endDate = LocalDate.of(2023,3,2);
 
+                Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, 1L);
                 Day beforeDay = trip.getDays().get(0);
                 Day targetDay = trip.getDays().get(1);
 
@@ -1485,9 +1527,12 @@ public class TripTest {
             @DisplayName("targetOrder가 Schedules 크기와 똑같은 값이고, 끝 ScheduleIndex 범위가 안전하지 않으면 ScheduleIndexRangeException 발생")
             @Test
             public void when_targetOrder_isEqualTo_SchedulesSize_and_tail_scheduleIndex_is_unSafe_it_throws_ScheduleIndexRangeException() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                LocalDate startDate = LocalDate.of(2023,3,1);
+                LocalDate endDate = LocalDate.of(2023,3,2);
 
+                Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, 1L);
                 Day beforeDay = trip.getDays().get(0);
                 Day targetDay = trip.getDays().get(1);
 
@@ -1510,7 +1555,6 @@ public class TripTest {
                 beforeDay.getSchedules().add(schedule1);
                 targetDay.getSchedules().add(schedule2);
 
-
                 // when & then
                 assertThatThrownBy(() -> trip.moveSchedule(schedule1, targetDay, 1))
                         .isInstanceOf(ScheduleIndexRangeException.class);
@@ -1519,9 +1563,12 @@ public class TripTest {
             @DisplayName("targetOrder가 0이고, 맨 앞 ScheduleIndex 범위가 안전하면 맨 앞으로 이동한다.")
             @Test
             public void when_targetOrder_isEqualTo_Zero_and_head_scheduleIndex_isSafe_schedule_move_to_Head() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                LocalDate startDate = LocalDate.of(2023,3,1);
+                LocalDate endDate = LocalDate.of(2023,3,2);
 
+                Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, 1L);
                 Day beforeDay = trip.getDays().get(0);
                 Day targetDay = trip.getDays().get(1);
 
@@ -1548,9 +1595,12 @@ public class TripTest {
             @DisplayName("targetOrder가 0이고, 맨 앞 ScheduleIndex 범위가 안전하지 않으면 ScheduleIndexRangeException 발생")
             @Test
             public void when_targetOrder_isEqualTo_Zero_and_head_scheduleIndex_is_unSafe_it_throws_ScheduleIndexRangeException() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                LocalDate startDate = LocalDate.of(2023,3,1);
+                LocalDate endDate = LocalDate.of(2023,3,2);
 
+                Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, 1L);
                 Day beforeDay = trip.getDays().get(0);
                 Day targetDay = trip.getDays().get(1);
 
@@ -1582,9 +1632,12 @@ public class TripTest {
             @DisplayName("targetOrder가 다른 일정의 순서이고, 해당 순서 앞과 간격이 충분하면 중간 인덱스가 부여된다.")
             @Test
             public void testMiddleInsert_Success() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                LocalDate startDate = LocalDate.of(2023,3,1);
+                LocalDate endDate = LocalDate.of(2023,3,2);
 
+                Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, 1L);
                 Day beforeDay = trip.getDays().get(0);
                 Day targetDay = trip.getDays().get(1);
 
@@ -1613,9 +1666,12 @@ public class TripTest {
             @DisplayName("targetOrder가 다른 일정의 순서이고, 해당 순서 앞과 간격이 충분하지 않으면 MidScheduleIndexConflictException 발생")
             @Test
             public void testMiddleInsert_Failure() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                LocalDate startDate = LocalDate.of(2023,3,1);
+                LocalDate endDate = LocalDate.of(2023,3,2);
 
+                Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, 1L);
                 Day beforeDay = trip.getDays().get(0);
                 Day targetDay = trip.getDays().get(1);
 
@@ -1662,12 +1718,16 @@ public class TripTest {
             @Test
             public void when_targetOrder_is_under_zero_then_it_throws_InvalidScheduleMoveTargetOrderException() {
                 // given
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
-                Day beforeDay = trip.getDays().get(0);
-                Schedule schedule = trip.createSchedule(beforeDay, ScheduleTitle.of("일정제목"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                LocalDate startDate = LocalDate.of(2023,3,1);
+                LocalDate endDate = LocalDate.of(2023,3,1);
 
+                Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, 1L);
+                Day beforeDay = trip.getDays().get(0);
                 Day targetDay = null;
+
+                Schedule schedule = trip.createSchedule(beforeDay, ScheduleTitle.of("일정제목"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
 
                 // when & then
                 assertThatThrownBy(() -> trip.moveSchedule(schedule, targetDay, -1))
@@ -1677,8 +1737,12 @@ public class TripTest {
             @DisplayName("targetOrder가 임시보관함 크기를 넘어가는 경우 InvalidScheduleMoveTargetOrderException 발생")
             @Test
             public void when_targetOrder_is_over_temporary_storage_max_size_then_it_throws_InvalidScheduleMoveTargetOrderException() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                LocalDate startDate = LocalDate.of(2023,3,1);
+                LocalDate endDate = LocalDate.of(2023,3,1);
+
+                Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, 1L);
                 Day beforeDay = trip.getDays().get(0);
                 Day targetDay = null;
 
@@ -1694,9 +1758,12 @@ public class TripTest {
             @DisplayName("targetOrder가 임시보관함 크기와 똑같은 값이고, 끝 ScheduleIndex 범위가 안전하면 맨 뒤로 이동한다.")
             @Test
             public void when_targetOrder_isEqualTo_temporaryStorageSize_and_tail_scheduleIndex_isSafe_schedule_move_to_Tail() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                LocalDate startDate = LocalDate.of(2023,3,1);
+                LocalDate endDate = LocalDate.of(2023,3,2);
 
+                Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, 1L);
                 Day beforeDay = trip.getDays().get(0);
                 Day targetDay = null;
 
@@ -1723,9 +1790,12 @@ public class TripTest {
             @DisplayName("targetOrder가 임시보관함 크기와 똑같은 값이고, 끝 ScheduleIndex 범위가 안전하지 않으면 ScheduleIndexRangeException 발생")
             @Test
             public void when_targetOrder_isEqualTo_temporaryStorageSize_and_tail_scheduleIndex_is_unSafe_it_throws_ScheduleIndexRangeException() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                LocalDate startDate = LocalDate.of(2023,3,1);
+                LocalDate endDate = LocalDate.of(2023,3,1);
 
+                Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, 1L);
                 Day beforeDay = trip.getDays().get(0);
                 Day targetDay = null;
 
@@ -1758,12 +1828,14 @@ public class TripTest {
             @DisplayName("targetOrder가 0이고, 맨 앞 ScheduleIndex 범위가 안전하면 맨 앞으로 이동한다.")
             @Test
             public void when_targetOrder_isEqualTo_Zero_and_Head_scheduleIndex_isSafe_schedule_move_to_Head() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 21L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                LocalDate startDate = LocalDate.of(2023,3,1);
+                LocalDate endDate = LocalDate.of(2023,3,1);
 
+                Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, 1L);
                 Day beforeDay = trip.getDays().get(0);
                 Day targetDay = null;
-
                 Schedule schedule1 = trip.createSchedule(beforeDay, ScheduleTitle.of("일정제목1"), Place.of("place-id111", "place 이름111", Coordinate.of(37.72221, 137.86523)));
                 Schedule schedule2 = trip.createSchedule(targetDay, ScheduleTitle.of("일정제목2"), Place.of("place-id222", "place 이름222", Coordinate.of(37.72221, 137.86523)));
 
@@ -1787,9 +1859,12 @@ public class TripTest {
             @DisplayName("targetOrder가 0이고, 끝 ScheduleIndex 범위가 안전하지 않으면 ScheduleIndexRangeException 발생")
             @Test
             public void when_targetOrder_isEqualTo_Zero_and_Head_scheduleIndex_is_unSafe_it_throws_ScheduleIndexRangeException() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2)));
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                LocalDate startDate = LocalDate.of(2023,3,1);
+                LocalDate endDate = LocalDate.of(2023,3,2);
 
+                Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, 1L);
                 Day beforeDay = trip.getDays().get(0);
                 Day targetDay = null;
 
@@ -1821,9 +1896,12 @@ public class TripTest {
             @DisplayName("targetOrder가 다른 일정의 순서이고, 해당 순서 앞과 간격이 충분하면 중간 인덱스가 부여된다.")
             @Test
             public void testMiddleInsert_Success() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                LocalDate startDate = LocalDate.of(2023,3,1);
+                LocalDate endDate = LocalDate.of(2023,3,2);
 
+                Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, 1L);
                 Day beforeDay = trip.getDays().get(0);
                 Day targetDay = null;
 
@@ -1852,9 +1930,12 @@ public class TripTest {
             @DisplayName("targetOrder가 다른 일정의 순서이고, 해당 순서 앞과 간격이 충분하지 않으면 MidScheduleIndexConflictException 발생")
             @Test
             public void testMiddleInsert_Failure() {
-                Trip trip = Trip.create(TripTitle.of("여행제목"), 1L);
-                trip.changePeriod(TripPeriod.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1)));
+                Long tripId = 1L;
+                Long tripperId = 2L;
+                LocalDate startDate = LocalDate.of(2023,3,1);
+                LocalDate endDate = LocalDate.of(2023,3,2);
 
+                Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, 1L);
                 Day beforeDay = trip.getDays().get(0);
                 Day targetDay = null;
 

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/entity/TripTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/entity/TripTest.java
@@ -1,5 +1,6 @@
 package com.cosain.trilo.unit.trip.domain.entity;
 
+import com.cosain.trilo.fixture.TripFixture;
 import com.cosain.trilo.trip.domain.dto.ScheduleMoveDto;
 import com.cosain.trilo.trip.domain.entity.Day;
 import com.cosain.trilo.trip.domain.entity.Schedule;
@@ -15,7 +16,6 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
 
-import static com.cosain.trilo.fixture.TripFixture.UNDECIDED_TRIP;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -82,7 +82,9 @@ public class TripTest {
         class Case_Change_UNDECIDED_Trip {
 
             // common given
-            private Trip undecidedTrip = UNDECIDED_TRIP.createUndecided(1L, 1L, "여행 제목");
+            private Long tripId = 1L;
+            private Long tripperId = 2L;
+            private Trip undecidedTrip = TripFixture.undecided_Id(tripId, tripperId);
 
             @Nested
             @DisplayName("비어있는 기간으로 변경하면")

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/repository/DayRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/repository/DayRepositoryTest.java
@@ -32,7 +32,10 @@ public class DayRepositoryTest {
     @DisplayName("findBYWithTripTest - 같이 가져온 Trip이 실제 Trip 클래스인지 함께 검증")
     public void findByIdWithTripTest() {
         // given
-        Trip trip = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023,3,1), LocalDate.of(2023,3,1));
+        Long tripperId = 1L;
+        LocalDate startDate = LocalDate.of(2023, 3, 1);
+        LocalDate endDate = LocalDate.of(2023, 3, 1);
+        Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
         em.persist(trip);
 
         Day day = trip.getDays().get(0);
@@ -57,7 +60,10 @@ public class DayRepositoryTest {
     @DisplayName("deleteAllByIds- 전달받은 Id 목록의 Day들을 삭제")
     void deleteAllByIdsTest() {
         // given
-        Trip trip = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023,5,1), LocalDate.of(2023,5,4));
+        Long tripperId = 1L;
+        LocalDate startDate = LocalDate.of(2023, 5, 1);
+        LocalDate endDate = LocalDate.of(2023, 5, 4);
+        Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
         em.persist(trip);
 
         Day day1 = trip.getDays().get(0);
@@ -84,7 +90,11 @@ public class DayRepositoryTest {
     @DisplayName("deleteAllByTripId로 Day를 삭제하면, 해당 여행의 모든 Day들이 삭제된다.")
     void deleteAllByTripIdTest() {
         // given
-        Trip trip = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023,3,1), LocalDate.of(2023,3,3));
+        Long tripperId = 1L;
+        LocalDate startDate = LocalDate.of(2023, 3, 1);
+        LocalDate endDate = LocalDate.of(2023, 3, 3);
+        Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
+        em.persist(trip);
 
         em.persist(trip);
 
@@ -106,15 +116,18 @@ public class DayRepositoryTest {
     }
 
     @Nested
-    class deleteAllByTripIdsTest{
+    class deleteAllByTripIdsTest {
 
         @Test
-        void 전달받은_여행_ID_목록에_해당하는_모든_Day가_제거된다(){
+        void 전달받은_여행_ID_목록에_해당하는_모든_Day가_제거된다() {
             // given
-            Trip trip1 = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023,3,1), LocalDate.of(2023,3,3));
-            Trip trip2 = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023,3,1), LocalDate.of(2023,3,3));
-            Trip trip3 = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023,3,1), LocalDate.of(2023,3,3));
+            Long tripperId = 1L;
+            LocalDate commonStartDate = LocalDate.of(2023,3,1);
+            LocalDate commonEndDate = LocalDate.of(2023,3,3);
 
+            Trip trip1 = TripFixture.decided_nullId(tripperId, commonStartDate, commonEndDate);
+            Trip trip2 = TripFixture.decided_nullId(tripperId, commonStartDate, commonEndDate);
+            Trip trip3 = TripFixture.decided_nullId(tripperId, commonStartDate, commonEndDate);
             em.persist(trip1);
             em.persist(trip2);
             em.persist(trip3);

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/repository/ScheduleRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/repository/ScheduleRepositoryTest.java
@@ -38,7 +38,10 @@ public class ScheduleRepositoryTest {
     @DisplayName("Schedule을 저장하고 같은 식별자로 찾으면 같은 Schedule이 찾아진다.")
     void saveTest() {
         // given
-        Trip trip = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1));
+        Long tripperId = 1L;
+        LocalDate startDate = LocalDate.of(2023,3,1);
+        LocalDate endDate = LocalDate.of(2023,3,1);
+        Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
         em.persist(trip);
 
         Day day = trip.getDays().get(0);
@@ -68,7 +71,10 @@ public class ScheduleRepositoryTest {
     @DisplayName("65535 바이트보다 큰 본문을 삽입하려 시도하면 데이터베이스 예외가 발생함")
     void contentChangeConstraintsTest() {
         // given
-        Trip trip = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1));
+        Long tripperId = 1L;
+        LocalDate startDate = LocalDate.of(2023,3,1);
+        LocalDate endDate = LocalDate.of(2023,3,1);
+        Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
         em.persist(trip);
 
         Day day = trip.getDays().get(0);
@@ -83,7 +89,7 @@ public class ScheduleRepositoryTest {
 
         Query query = em.createQuery("""
                         UPDATE Schedule s
-                        SET s.scheduleContent.value = :rawContent 
+                        SET s.scheduleContent.value = :rawContent
                         where s.id = :scheduleId
                         """)
                 .setParameter("rawContent", rawContent)
@@ -98,7 +104,10 @@ public class ScheduleRepositoryTest {
     @DisplayName("delete로 일정을 삭제하면, 해당 일정이 삭제된다.")
     void deleteTest() {
         // given
-        Trip trip = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1));
+        Long tripperId = 1L;
+        LocalDate startDate = LocalDate.of(2023,3,1);
+        LocalDate endDate = LocalDate.of(2023,3,1);
+        Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
         em.persist(trip);
 
         Day day = trip.getDays().get(0);
@@ -122,7 +131,10 @@ public class ScheduleRepositoryTest {
     @DisplayName("deleteAllByTripId로 일정을 삭제하면, 해당 여행의 모든 일정들이 삭제된다.")
     void deleteAllByTripIdTest() {
         // given
-        Trip trip = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 3));
+        Long tripperId = 1L;
+        LocalDate startDate = LocalDate.of(2023,3,1);
+        LocalDate endDate = LocalDate.of(2023,3,3);
+        Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
         em.persist(trip);
 
         Day day1 = trip.getDays().get(0);
@@ -154,7 +166,10 @@ public class ScheduleRepositoryTest {
     @DisplayName("findByIdWithTrip으로 일정을 조회하면 해당 일정만 조회된다.(여행도 같이 묶여서 조회됨)")
     void findByIdWithTripTest() {
         // given
-        Trip trip = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1));
+        Long tripperId = 1L;
+        LocalDate startDate = LocalDate.of(2023,3,1);
+        LocalDate endDate = LocalDate.of(2023,3,1);
+        Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
         em.persist(trip);
 
         Day day = trip.getDays().get(0);
@@ -189,7 +204,10 @@ public class ScheduleRepositoryTest {
         @Test
         void relocateTemporaryStorage() {
             // given
-            Trip trip = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2));
+            Long tripperId = 1L;
+            LocalDate startDate = LocalDate.of(2023,3,1);
+            LocalDate endDate = LocalDate.of(2023,3,2);
+            Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
             em.persist(trip);
 
             Day day1 = trip.getDays().get(0);
@@ -241,7 +259,10 @@ public class ScheduleRepositoryTest {
         @Test
         void relocateDaySchedules() {
             // given
-            Trip trip = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2));
+            Long tripperId = 1L;
+            LocalDate startDate = LocalDate.of(2023,3,1);
+            LocalDate endDate = LocalDate.of(2023,3,2);
+            Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
             em.persist(trip);
 
             Day day1 = trip.getDays().get(0);
@@ -298,7 +319,10 @@ public class ScheduleRepositoryTest {
         @DisplayName("임시보관함에 다른 일정이 있으면, 맨 뒤 순서값 뒤에 day들의 일정들이 date, 순서값 순으로 오름차순으로 옮겨짐")
         public void test_When_TemporaryStorage_not_empty() {
             // given
-            Trip trip = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 3));
+            Long tripperId = 1L;
+            LocalDate startDate = LocalDate.of(2023,3,1);
+            LocalDate endDate = LocalDate.of(2023,3,3);
+            Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
             em.persist(trip);
 
             Day day1 = trip.getDays().get(0);
@@ -362,7 +386,10 @@ public class ScheduleRepositoryTest {
         @DisplayName("임시보관함이 비어있으면, day들의 일정들이 date, 순서값 순으로 오름차순으로 0번 순서부터 지정되어 옮겨짐")
         public void test_When_TemporaryStorage_empty() {
             // given
-            Trip trip = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 3));
+            Long tripperId = 1L;
+            LocalDate startDate = LocalDate.of(2023,3,1);
+            LocalDate endDate = LocalDate.of(2023,3,3);
+            Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
             em.persist(trip);
 
             Day day1 = trip.getDays().get(0);
@@ -445,7 +472,10 @@ public class ScheduleRepositoryTest {
         @DisplayName("Trip의 어떤 Day에 일정 3개 -> 3 반환")
         @Test
         public void dayScheduleScheduleTest() {
-            Trip trip = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1));
+            Long tripperId = 1L;
+            LocalDate startDate = LocalDate.of(2023,3,1);
+            LocalDate endDate = LocalDate.of(2023,3,1);
+            Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
             em.persist(trip);
 
             Day day = trip.getDays().get(0);
@@ -465,7 +495,10 @@ public class ScheduleRepositoryTest {
         @DisplayName("Trip의 임시보관함, 여러 Day에 일정 -> 여행 소속 일정 갯수 반환")
         @Test
         public void manyDayScheduleTest() {
-            Trip trip = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 3));
+            Long tripperId = 1L;
+            LocalDate startDate = LocalDate.of(2023,3,1);
+            LocalDate endDate = LocalDate.of(2023,3,3);
+            Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
             em.persist(trip);
 
             Day day1 = trip.getDays().get(0);
@@ -508,7 +541,10 @@ public class ScheduleRepositoryTest {
         @DisplayName("Day에 아무 일정도 없음 -> 0 반환")
         @Test
         void noDayScheduleTest() {
-            Trip trip = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 1));
+            Long tripperId = 1L;
+            LocalDate startDate = LocalDate.of(2023,3,1);
+            LocalDate endDate = LocalDate.of(2023,3,1);
+            Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
             em.persist(trip);
 
             Day day = trip.getDays().get(0);
@@ -521,7 +557,10 @@ public class ScheduleRepositoryTest {
         @DisplayName("Day에 일정 3개 -> 3 반환")
         @Test
         void threeDayScheduleTest() {
-            Trip trip = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 2));
+            Long tripperId = 1L;
+            LocalDate startDate = LocalDate.of(2023,3,1);
+            LocalDate endDate = LocalDate.of(2023,3,2);
+            Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
             em.persist(trip);
 
             Day day1 = trip.getDays().get(0);
@@ -549,9 +588,11 @@ public class ScheduleRepositoryTest {
     class deleteAllByTripIdsTest{
         @Test
         void 전달받은_여행_ID_목록에_해당하는_모든_일정이_삭제된다(){
-
             // given
-            Trip trip = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023,3,1), LocalDate.of(2023,3,2));
+            Long tripperId = 1L;
+            LocalDate startDate = LocalDate.of(2023,3,1);
+            LocalDate endDate = LocalDate.of(2023,3,2);
+            Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
             em.persist(trip);
 
             Day day1 = trip.getDays().get(0);

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/repository/TripRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/repository/TripRepositoryTest.java
@@ -123,7 +123,10 @@ public class TripRepositoryTest {
         @DisplayName("Day를 가지고 있는 Trip을 조회하면 Trip이 Day들을 가진 채 조회된다.")
         void if_trip_has_days_then_trip_and_its_trip_found(){
             // given
-            Trip trip = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023,5,1), LocalDate.of(2023,5,3));
+            Long tripperId = 1L;
+            LocalDate startDate = LocalDate.of(2023,5,1);
+            LocalDate endDate = LocalDate.of(2023,5,3);
+            Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
             em.persist(trip);
 
             Day day1 = trip.getDays().get(0);

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/repository/TripRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/repository/TripRepositoryTest.java
@@ -104,7 +104,8 @@ public class TripRepositoryTest {
         @DisplayName("UnDecided 상태의 Trip을 조회하면 여행만 조회된다.")
         public void findUndecidedTripTest() {
             // given
-            Trip trip = Trip.create(TripTitle.of("제목"), 1L);
+            Long tripperId = 1L;
+            Trip trip = TripFixture.undecided_nullId(tripperId);
             em.persist(trip);
 
             em.clear();

--- a/src/test/java/com/cosain/trilo/unit/trip/infra/repository/DayQueryRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/infra/repository/DayQueryRepositoryTest.java
@@ -34,7 +34,10 @@ public class DayQueryRepositoryTest {
     @Test
     void Day_조회를_하면_해당_Day정보와_해당_Day에_속한_Schedule들의_요약정보와_함께_조회된다(){
         // given
-        Trip trip = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023,5,1), LocalDate.of(2023,5,2));
+        Long tripperId = 1L;
+        LocalDate startDate = LocalDate.of(2023,5,1);
+        LocalDate endDate = LocalDate.of(2023,5,2);
+        Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
         em.persist(trip);
 
         Day day1 = trip.getDays().get(0);
@@ -86,7 +89,10 @@ public class DayQueryRepositoryTest {
         @DisplayName("tripId를 통해 Trip 에 매핑된 Day 들과 해당 Day 와 매핑된 Schedule 들이 조회되며 DTO 로 반환된다.")
         void findTest() {
             // given
-            Trip trip = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023,5,10), LocalDate.of(2023,5,11));
+            Long tripperId = 1L;
+            LocalDate startDate = LocalDate.of(2023,5,10);
+            LocalDate endDate = LocalDate.of(2023,5,11);
+            Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
             em.persist(trip);
 
             Day day1 = trip.getDays().get(0);
@@ -123,7 +129,11 @@ public class DayQueryRepositoryTest {
         @Test
         void Day에_해당하는_Schedule이_하나도_존재하지_않는_경우_ScheduleSummary_리스트의_크기는_0_이된다() {
             // given
-            Trip trip = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023,5,10), LocalDate.of(2023,5,11));
+            Long tripperId = 1L;
+            LocalDate startDate = LocalDate.of(2023,5,10);
+            LocalDate endDate = LocalDate.of(2023,5,11);
+            Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
+            em.persist(trip);
 
             Day day1 = trip.getDays().get(0);
             Day day2 = trip.getDays().get(1);
@@ -144,9 +154,11 @@ public class DayQueryRepositoryTest {
         @Test
         @DisplayName("여행 날짜 기준 오름차순, 일정 순서값 기준 오름 차순으로 조회된다.")
         void sortTest(){
-
             // given
-            Trip trip = TripFixture.DECIDED_TRIP.createDecided(null, 1L, "여행 제목", LocalDate.of(2023,5,10), LocalDate.of(2023,5,11));
+            Long tripperId = 1L;
+            LocalDate startDate = LocalDate.of(2023,5,10);
+            LocalDate endDate = LocalDate.of(2023,5,11);
+            Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
             em.persist(trip);
 
             Day day1 = trip.getDays().get(0); // 테스트의 편의를 위해 순서를 바꿔서 저장함.

--- a/src/test/java/com/cosain/trilo/unit/trip/infra/repository/TripQueryRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/infra/repository/TripQueryRepositoryTest.java
@@ -1,11 +1,9 @@
 
 package com.cosain.trilo.unit.trip.infra.repository;
 
+import com.cosain.trilo.fixture.TripFixture;
 import com.cosain.trilo.support.RepositoryTest;
 import com.cosain.trilo.trip.domain.entity.Trip;
-import com.cosain.trilo.trip.domain.vo.TripPeriod;
-import com.cosain.trilo.trip.domain.vo.TripStatus;
-import com.cosain.trilo.trip.domain.vo.TripTitle;
 import com.cosain.trilo.trip.infra.dto.TripDetail;
 import com.cosain.trilo.trip.infra.dto.TripSummary;
 import com.cosain.trilo.trip.infra.repository.trip.TripQueryRepository;
@@ -36,15 +34,15 @@ public class TripQueryRepositoryTest {
 
     @Test
     @DirtiesContext
-    void findTripDetailTest(){
+    void findTripDetailTest() {
         // given
-        Trip trip = Trip.builder()
-                .tripperId(1L)
-                .tripTitle(TripTitle.of("제목"))
-                .status(TripStatus.DECIDED)
-                .tripPeriod(TripPeriod.of(LocalDate.of(2023, 5, 5), LocalDate.of(2023, 5, 10)))
-                .build();
+        Long tripperId = 1L;
+        LocalDate startDate = LocalDate.of(2023, 3, 1);
+        LocalDate endDate = LocalDate.of(2023, 3, 2);
+
+        Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
         em.persist(trip);
+        trip.getDays().forEach(em::persist);
 
         // when
         TripDetail tripDetail = tripQueryRepository.findTripDetailById(1L).get();
@@ -60,36 +58,28 @@ public class TripQueryRepositoryTest {
 
     @Nested
     @DisplayName("사용자의 여행 목록을 조회 하면")
-    class findTripDetailListByTripperIdTest{
+    class findTripDetailListByTripperIdTest {
 
         @Test
         @DirtiesContext
         @DisplayName("여행의 TipperId가 일치하는 여행들이 커서에 해당하는 tripId 미만 row가 size 만큼 조회된다")
-        void findTest(){
+        void findTest() {
             // given
-            Long tripperId = 1L;
             Long tripId = 3L;
+            Long tripperId = 1L;
+
             int size = 2;
             TripPageCondition tripPageCondition = new TripPageCondition(tripperId, tripId);
             Pageable pageable = PageRequest.ofSize(size);
-            Trip trip1 = Trip.builder()
-                    .tripperId(tripperId)
-                    .tripTitle(TripTitle.of("제목 1"))
-                    .status(TripStatus.DECIDED)
-                    .tripPeriod(TripPeriod.of(LocalDate.of(2023, 5, 5), LocalDate.of(2023, 5, 10)))
-                    .build();
 
-            Trip trip2 = Trip.builder()
-                    .tripperId(tripperId)
-                    .tripTitle(TripTitle.of("제목 2"))
-                    .status(TripStatus.DECIDED)
-                    .tripPeriod(TripPeriod.of(LocalDate.of(2023, 5, 5), LocalDate.of(2023, 5, 10)))
-                    .build();
-
+            Trip trip1 = TripFixture.undecided_nullId(tripperId);
+            Trip trip2 = TripFixture.undecided_nullId(tripperId);
             em.persist(trip1);
             em.persist(trip2);
 
-            System.out.println(trip1.getId() +" "+ trip2.getId());
+            System.out.printf("trip ids = [%d, %d]%n", trip1.getId(), trip2.getId());
+            em.flush();
+            em.clear();
 
             // when
             Slice<TripSummary> tripSummariesByTripperId = tripQueryRepository.findTripSummariesByTripperId(tripPageCondition, pageable);
@@ -101,32 +91,22 @@ public class TripQueryRepositoryTest {
         @Test
         @DirtiesContext
         @DisplayName("가장 최근에 생성된 여행 순으로 조회된다")
-        void sortTest(){
+        void sortTest() {
             // given
             Long tripperId = 1L;
             Long tripId = 3L;
             TripPageCondition tripPageCondition = new TripPageCondition(tripperId, tripId);
             Pageable pageable = PageRequest.ofSize(3);
-            Trip trip1 = Trip.builder()
-                    .tripperId(tripperId)
-                    .tripTitle(TripTitle.of("제목 1"))
-                    .status(TripStatus.DECIDED)
-                    .tripPeriod(TripPeriod.of(LocalDate.of(2023, 5, 5), LocalDate.of(2023, 5, 10)))
-                    .build();
 
-            Trip trip2 = Trip.builder()
-                    .tripperId(tripperId)
-                    .tripTitle(TripTitle.of("제목 2"))
-                    .status(TripStatus.DECIDED)
-                    .tripPeriod(TripPeriod.of(LocalDate.of(2023, 5, 5), LocalDate.of(2023, 5, 10)))
-                    .build();
-
-
+            Trip trip1 = TripFixture.undecided_nullId(tripperId);
+            Trip trip2 = TripFixture.undecided_nullId(tripperId);
             em.persist(trip1);
             em.persist(trip2);
+            em.flush();
+            em.clear();
 
             // when
-            Slice<TripSummary> tripSummariesByTripperId = tripQueryRepository.findTripSummariesByTripperId(tripPageCondition,pageable);
+            Slice<TripSummary> tripSummariesByTripperId = tripQueryRepository.findTripSummariesByTripperId(tripPageCondition, pageable);
 
 
             // then
@@ -136,16 +116,14 @@ public class TripQueryRepositoryTest {
 
         @Test
         @DirtiesContext
-        void existByIdTest(){
+        void existByIdTest() {
             // given
-            Trip trip = Trip.builder()
-                    .tripperId(1L)
-                    .tripTitle(TripTitle.of("제목 1"))
-                    .status(TripStatus.DECIDED)
-                    .tripPeriod(TripPeriod.of(LocalDate.of(2023, 5, 5), LocalDate.of(2023, 5, 10)))
-                    .build();
+            Long tripperId = 5L;
+
+            Trip trip = TripFixture.undecided_nullId(tripperId);
             em.persist(trip);
             em.flush();
+            em.clear();
 
             // when & then
             long notExistTripId = 2L;


### PR DESCRIPTION
# JIRA 티켓
- [TRL-399]

# 작업 내역
- [x] 기존 TripFixture 코드 수정 및 의존 코드 일괄 수정
- [x] 테스트 코드에서 Trip, Day를 수동으로 생성하고 있는 부분을 Fixture를 사용하도록 수정

# 설명
기존에는 enum을 undecide인 경우 undecided 메서드만 호출하기로 하고
decided인 경우 decided  메서드만 호출하도록 규약을 정했습니다.

![image](https://github.com/teamCoSaIn/trilo-be/assets/88282356/195d4dde-e764-452c-89be-0d164c026bd2)


하지만 결국 undecide 상태로도 decided 메서드들을 호출 가능하다거나, 같은 상태의 fixture 메서드 호출만을 강제하지 못 하는 문제가 있습니다.

그리고 undecided 가 필요한 상황과 decided가 필요한 상황, 목적은 제각각 다른 경우가 많기 때문에 차라리 케이스를 나눠서 각 케이스별로 특화된 static 메서드들로만 fixtrue 생성을 만드는게 낫다는 판단을 했습니다.

![image](https://github.com/teamCoSaIn/trilo-be/assets/88282356/32ec9208-3644-4835-9cc0-f964cd80b573)
![image](https://github.com/teamCoSaIn/trilo-be/assets/88282356/7bf99b11-07b5-4cfd-912d-ba30c738be9f)

예를 들어 undecide 메서드를 ide에서 작성하면 u를 타이핑한 순간부터 decided 에 해당하는 메서드들은 자동 완성의 대상이 되지 않게 될 수 있습니다.



# 참고자료


[TRL-399]: https://cosain.atlassian.net/browse/TRL-399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ