### PR TITLE
[TRL-397] refactor: AuthService 강결합 문제 개선

### DIFF
--- a/src/main/java/com/cosain/trilo/auth/application/AuthService.java
+++ b/src/main/java/com/cosain/trilo/auth/application/AuthService.java
@@ -12,14 +12,11 @@ import com.cosain.trilo.auth.infra.TokenProvider;
 import com.cosain.trilo.auth.presentation.dto.RefreshTokenStatusResponse;
 import com.cosain.trilo.common.exception.NotExistRefreshTokenException;
 import com.cosain.trilo.common.exception.NotValidTokenException;
-import com.cosain.trilo.user.domain.User;
-import com.cosain.trilo.user.domain.UserRepository;
+import com.cosain.trilo.user.application.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 @Slf4j
 @Service
@@ -30,7 +27,7 @@ public class AuthService {
     private final TokenProvider tokenProvider;
     private final TokenAnalyzer tokenAnalyzer;
     private final OAuthProfileRequestService OAuthProfileRequestService;
-    private final UserRepository userRepository;
+    private final UserService userService;
 
     @Transactional
     public ReIssueAccessTokenResult reissueAccessToken(String refreshToken){
@@ -38,7 +35,7 @@ public class AuthService {
         checkTokenExistenceOrThrow(refreshToken);
         Long userId = tokenAnalyzer.getUserIdFromToken(refreshToken);
         String accessToken = tokenProvider.createAccessTokenById(userId);
-        return ReIssueAccessTokenResult.of(accessToken, userId);
+        return ReIssueAccessTokenResult.of(accessToken);
     }
     private void checkIfValidTokenOrThrow(String refreshToken){
         if(!tokenAnalyzer.validateToken(refreshToken)){
@@ -89,31 +86,19 @@ public class AuthService {
     public LoginResult login(OAuthLoginParams oAuthLoginParams){
 
         OAuthProfileDto oAuthProfileDto = getUserProfileResponse(oAuthLoginParams);
-        User user = addOrUpdateUser(oAuthProfileDto);
+        Long userId = userService.createOrUpdate(oAuthProfileDto);
 
-        String accessToken = tokenProvider.createAccessTokenById(user.getId());
-        String refreshToken = tokenProvider.createRefreshTokenById(user.getId());
+        String accessToken = tokenProvider.createAccessTokenById(userId);
+        String refreshToken = tokenProvider.createRefreshTokenById(userId);
 
         Long tokenExpiry = tokenAnalyzer.getTokenRemainExpiryFrom(refreshToken);
         tokenRepository.saveRefreshToken(RefreshToken.of(refreshToken, tokenExpiry));
 
-        return LoginResult.of(accessToken, refreshToken, user.getId());
+        return LoginResult.of(accessToken, refreshToken);
     }
 
     private OAuthProfileDto getUserProfileResponse(OAuthLoginParams oAuthLoginParams) {
         return OAuthProfileRequestService.request(oAuthLoginParams);
-    }
-
-    private User addOrUpdateUser(OAuthProfileDto oAuthProfileDto){
-        Optional<User> userOptional = userRepository.findByEmail(oAuthProfileDto.getEmail());
-        User user;
-        if(userOptional.isPresent()){
-            user = userOptional.get();
-            user.updateUserByOauthProfile(oAuthProfileDto);
-        }else{
-            user = userRepository.save(User.from(oAuthProfileDto));
-        }
-        return user;
     }
 
 }

--- a/src/main/java/com/cosain/trilo/auth/application/dto/LoginResult.java
+++ b/src/main/java/com/cosain/trilo/auth/application/dto/LoginResult.java
@@ -7,14 +7,12 @@ public class LoginResult {
 
     private String accessToken;
     private String refreshToken;
-    private Long id;
 
-    private LoginResult(String accessToken, String refreshToken, Long id) {
+    private LoginResult(String accessToken, String refreshToken) {
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
-        this.id = id;
     }
-    public static LoginResult of(String accessToken, String refreshToken, Long id) {
-        return new LoginResult(accessToken, refreshToken, id);
+    public static LoginResult of(String accessToken, String refreshToken) {
+        return new LoginResult(accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/cosain/trilo/auth/application/dto/ReIssueAccessTokenResult.java
+++ b/src/main/java/com/cosain/trilo/auth/application/dto/ReIssueAccessTokenResult.java
@@ -6,13 +6,11 @@ import lombok.Getter;
 public class ReIssueAccessTokenResult {
 
     private String accessToken;
-    private Long userId;
 
-    private ReIssueAccessTokenResult(String accessToken, Long userId) {
+    private ReIssueAccessTokenResult(String accessToken) {
         this.accessToken = accessToken;
-        this.userId = userId;
     }
-    public static ReIssueAccessTokenResult of(String accessToken, Long userId) {
-        return new ReIssueAccessTokenResult(accessToken, userId);
+    public static ReIssueAccessTokenResult of(String accessToken) {
+        return new ReIssueAccessTokenResult(accessToken);
     }
 }

--- a/src/main/java/com/cosain/trilo/auth/presentation/dto/AuthResponse.java
+++ b/src/main/java/com/cosain/trilo/auth/presentation/dto/AuthResponse.java
@@ -9,19 +9,17 @@ public class AuthResponse {
 
     private String authType;
     private String accessToken;
-    private Long userId;
 
     public static AuthResponse from(LoginResult result) {
-        return new AuthResponse(result.getAccessToken(), result.getId());
+        return new AuthResponse(result.getAccessToken());
     }
 
     public static AuthResponse from(ReIssueAccessTokenResult result){
-        return new AuthResponse(result.getAccessToken(), result.getUserId());
+        return new AuthResponse(result.getAccessToken());
     }
 
-    private AuthResponse(String accessToken, Long userId){
+    private AuthResponse(String accessToken){
         this.authType = "Bearer";
         this.accessToken = accessToken;
-        this.userId = userId;
     }
 }

--- a/src/test/java/com/cosain/trilo/unit/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/auth/application/AuthServiceTest.java
@@ -13,17 +13,14 @@ import com.cosain.trilo.auth.infra.TokenProvider;
 import com.cosain.trilo.auth.presentation.dto.RefreshTokenStatusResponse;
 import com.cosain.trilo.common.exception.NotExistRefreshTokenException;
 import com.cosain.trilo.common.exception.NotValidTokenException;
+import com.cosain.trilo.user.application.UserService;
 import com.cosain.trilo.user.domain.AuthProvider;
-import com.cosain.trilo.user.domain.User;
-import com.cosain.trilo.user.domain.UserRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
@@ -41,7 +38,7 @@ class AuthServiceTest {
     @Mock
     private TokenProvider tokenProvider;
     @Mock
-    private UserRepository userRepository;
+    private UserService userService;
     @Mock
     private OAuthProfileRequestService OAuthProfileRequestService;
     private final String ACCESS_TOKEN = "slkdfjasjeoifjse.siejfoajseifjasolef.sliejfaisjelfsjefsdcv";
@@ -56,7 +53,6 @@ class AuthServiceTest {
         given(tokenProvider.createAccessTokenById(anyLong())).willReturn(ACCESS_TOKEN);
 
         ReIssueAccessTokenResult result = authService.reissueAccessToken(any());
-        Assertions.assertThat(result.getUserId()).isEqualTo(id);
         Assertions.assertThat(result.getAccessToken()).isEqualTo(ACCESS_TOKEN);
     }
 
@@ -125,7 +121,8 @@ class AuthServiceTest {
                 .provider(AuthProvider.KAKAO)
                 .profileImageUrl("image_url")
                 .build();
-        given(userRepository.findByEmail(any())).willReturn(Optional.ofNullable(User.from(oAuthProfileDto)));
+
+        given(userService.createOrUpdate(any(OAuthProfileDto.class))).willReturn(1L);
         given(OAuthProfileRequestService.request(any(OAuthLoginParams.class))).willReturn(oAuthProfileDto);
         given(tokenProvider.createAccessTokenById(any())).willReturn(ACCESS_TOKEN);
         given(tokenProvider.createRefreshTokenById(any())).willReturn(REFRESH_TOKEN);

--- a/src/test/java/com/cosain/trilo/unit/auth/presentation/api/AuthRestControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/auth/presentation/api/AuthRestControllerTest.java
@@ -35,7 +35,7 @@ class AuthRestControllerTest extends RestControllerTest {
     @Test
     void 쿠키를_포함한_접근_토큰_재발급_요청시_200_상태코드_반환_확인() throws Exception{
 
-        ReIssueAccessTokenResult result = ReIssueAccessTokenResult.of("accessToken", 1L);
+        ReIssueAccessTokenResult result = ReIssueAccessTokenResult.of("accessToken");
         given(authService.reissueAccessToken(any())).willReturn(result);
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/reissue")
@@ -120,7 +120,7 @@ class AuthRestControllerTest extends RestControllerTest {
 
     @Test
     void 카카오_로그인_정상_동작_확인() throws Exception{
-        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken", 1L));
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
         KakaoOAuthLoginRequest kakaoOAuthLoginRequest = new KakaoOAuthLoginRequest("code", "redirect_uri");
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/kakao")
@@ -133,7 +133,7 @@ class AuthRestControllerTest extends RestControllerTest {
     void 카카오_로그인_요청시_본문에_code가_존재하지_않으면_400_에러를_발생시킨다() throws Exception{
 
         KakaoOAuthLoginRequest kakaoOAuthLoginRequest = new KakaoOAuthLoginRequest(null, "redirect_uri");
-        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken", 1L));
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/kakao")
                         .content(createJson(kakaoOAuthLoginRequest))
@@ -144,7 +144,7 @@ class AuthRestControllerTest extends RestControllerTest {
     @Test
     void 카카오_로그인_요청시_쿼리_파라미터에_redirect_uri가_존재하지_않으면_400_에러를_발생시킨다() throws Exception{
         KakaoOAuthLoginRequest kakaoOAuthLoginRequest = new KakaoOAuthLoginRequest("code", null);
-        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken", 1L));
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/kakao")
                         .content(createJson(kakaoOAuthLoginRequest))
@@ -154,7 +154,7 @@ class AuthRestControllerTest extends RestControllerTest {
 
     @Test
     void 네이버_로그인_정상_동작_확인() throws Exception{
-        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken", 1L));
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
         NaverOAuthLoginRequest naverOAuthLoginRequest = new NaverOAuthLoginRequest("code", "state");
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/naver")
@@ -167,7 +167,7 @@ class AuthRestControllerTest extends RestControllerTest {
     void 네이버_로그인_요청시_본문에_code가_존재하지_않으면_400_에러를_발생시킨다() throws Exception{
 
         NaverOAuthLoginRequest naverOAuthLoginRequest = new NaverOAuthLoginRequest(null, "state");
-        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken", 1L));
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/naver")
                         .content(createJson(naverOAuthLoginRequest))
@@ -179,7 +179,7 @@ class AuthRestControllerTest extends RestControllerTest {
     void 네이버_로그인_요청시_본문에_state가_존재하지_않으면_400_에러를_발생시킨다() throws Exception{
 
         NaverOAuthLoginRequest naverOAuthLoginRequest = new NaverOAuthLoginRequest("code",null);
-        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken",1L));
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/naver")
                         .content(createJson(naverOAuthLoginRequest))
@@ -190,7 +190,7 @@ class AuthRestControllerTest extends RestControllerTest {
 
     @Test
     void 구글_로그인_정상_동작_확인() throws Exception{
-        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken", 1L));
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
         GoogleOAuthLoginRequest googleOAuthLoginRequest = new GoogleOAuthLoginRequest("code", "redirect_uri");
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/google")
@@ -201,7 +201,7 @@ class AuthRestControllerTest extends RestControllerTest {
 
     @Test
     void 구글_로그인_요청시_본문에_code가_존재하지_않으면_400_에러를_발생시킨다() throws Exception{
-        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken", 1L));
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
         GoogleOAuthLoginRequest googleOAuthLoginRequest = new GoogleOAuthLoginRequest(null, "redirect_uri");
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/google")
@@ -212,7 +212,7 @@ class AuthRestControllerTest extends RestControllerTest {
 
     @Test
     void 구글_로그인_요청시_본문에_redirect_uri가_존재하지_않으면_400_에러를_발생시킨다() throws Exception{
-        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken", 1L));
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
         GoogleOAuthLoginRequest googleOAuthLoginRequest = new GoogleOAuthLoginRequest("code", null);
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/google")

--- a/src/test/java/com/cosain/trilo/unit/auth/presentation/docs/AuthRestControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/auth/presentation/docs/AuthRestControllerDocsTest.java
@@ -39,7 +39,7 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
     @Test
     void 접근토큰_재발급_요청() throws Exception{
 
-        ReIssueAccessTokenResult result = ReIssueAccessTokenResult.of("accessToken", 1L);
+        ReIssueAccessTokenResult result = ReIssueAccessTokenResult.of("accessToken");
         given(authService.reissueAccessToken(any())).willReturn(result);
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL +"/reissue")
@@ -50,7 +50,6 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
                                 cookieWithName("refreshToken").description("접근 토큰 발급에 사용될 재발급 토큰")
                         ),
                         responseFields(
-                                fieldWithPath("userId").type(NUMBER).description("사용자 ID"),
                                 fieldWithPath("authType").type(STRING).description("인증 타입 (Bearer)"),
                                 fieldWithPath("accessToken").type(STRING).description("재발급한 접근 토큰")
                         )
@@ -96,9 +95,8 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
     @Test
     void 카카오_로그인_요청() throws Exception{
 
-        Long userId = 1L;
         KakaoOAuthLoginRequest kakaoOAuthLoginRequest = new KakaoOAuthLoginRequest("code", "redirect_uri");
-        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken", userId));
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/kakao")
                         .content(createJson(kakaoOAuthLoginRequest))
@@ -110,7 +108,6 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
                             fieldWithPath("redirect_uri").type(STRING).description("인증 코드 발급에 사용했던 Redirect Uri")
                     ),
                     responseFields(
-                            fieldWithPath("userId").type(NUMBER).description("사용자 ID"),
                             fieldWithPath("authType").type(STRING).description("인증 타입 (Bearer)"),
                             fieldWithPath("accessToken").description("AccessToken")
                     ),
@@ -124,9 +121,8 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
     @Test
     void 네이버_로그인_요청() throws Exception {
 
-        Long userId = 1L;
         NaverOAuthLoginRequest naverOAuthLoginRequest = new NaverOAuthLoginRequest("code", "state");
-        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken", userId));
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/naver")
                         .content(createJson(naverOAuthLoginRequest))
@@ -138,7 +134,6 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
                            fieldWithPath("state").type(STRING).description("Authorization Code 발급시 전달했던 redirect_uri")
                    ),
                    responseFields(
-                           fieldWithPath("userId").type(NUMBER).description("사용자 ID"),
                            fieldWithPath("authType").type(STRING).description("인증 타입 (Bearer)"),
                            fieldWithPath("accessToken").description("AccessToken")
                    ),
@@ -151,9 +146,8 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
     @Test
     void 구글_로그인_요청() throws Exception {
 
-        Long userId = 1L;
         GoogleOAuthLoginRequest googleOAuthLoginRequest = new GoogleOAuthLoginRequest("code", "redirectUrl");
-        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken", userId));
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/google")
                         .content(createJson(googleOAuthLoginRequest))
@@ -165,7 +159,6 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
                                 fieldWithPath("redirect_uri").type(STRING).description("Authorization Code 발급시 전달했던 redirect_uri")
                         ),
                         responseFields(
-                                fieldWithPath("userId").type(NUMBER).description("사용자 ID"),
                                 fieldWithPath("authType").type(STRING).description("인증 타입 (Bearer)"),
                                 fieldWithPath("accessToken").description("AccessToken")
                         ),

--- a/src/test/java/com/cosain/trilo/unit/user/application/UserServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/user/application/UserServiceTest.java
@@ -1,5 +1,6 @@
 package com.cosain.trilo.unit.user.application;
 
+import com.cosain.trilo.auth.infra.OAuthProfileDto;
 import com.cosain.trilo.user.application.UserService;
 import com.cosain.trilo.user.application.event.UserDeleteEvent;
 import com.cosain.trilo.user.application.exception.NoUserDeleteAuthorityException;
@@ -9,6 +10,7 @@ import com.cosain.trilo.user.domain.AuthProvider;
 import com.cosain.trilo.user.domain.Role;
 import com.cosain.trilo.user.domain.User;
 import com.cosain.trilo.user.domain.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,11 +22,12 @@ import org.springframework.context.ApplicationEventPublisher;
 import java.util.Optional;
 
 import static com.cosain.trilo.fixture.UserFixture.KAKAO_MEMBER;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class UserServiceTest {
@@ -33,9 +36,55 @@ public class UserServiceTest {
     private UserService userService;
     @Mock
     private UserRepository userRepository;
-
     @Mock
     private ApplicationEventPublisher eventPublisher;
+
+    @Nested
+    class 회원_생성_또는_업데이트_기능{
+        private String email;
+        private OAuthProfileDto oAuthProfileDto;
+        @BeforeEach
+        void setUp(){
+            email = "aaaa@nate.com";
+            oAuthProfileDto = OAuthProfileDto.builder()
+                    .name("김규성")
+                    .profileImageUrl("profile-image-url")
+                    .provider(AuthProvider.KAKAO)
+                    .email(email)
+                    .build();
+        }
+
+        @Test
+        void 신규_회원일_경우_저장(){
+            // given
+            User user = mock(User.class);
+            given(userRepository.findByEmail(eq(email))).willReturn(Optional.empty());
+            given(userRepository.save(any(User.class))).willReturn(user);
+
+            // when
+            Long userId = userService.createOrUpdate(oAuthProfileDto);
+
+            // then
+            assertThat(userId).isEqualTo(user.getId());
+            verify(userRepository, times(1)).save(any(User.class));
+        }
+
+        @Test
+        void 기존_회원일_경우_업데이트_후_저장(){
+            // given
+            User user = mock(User.class);
+            given(userRepository.findByEmail(eq(email))).willReturn(Optional.ofNullable(user));
+            given(userRepository.save(eq(user))).willReturn(user);
+
+            // when
+            Long userId = userService.createOrUpdate(oAuthProfileDto);
+
+            // then
+            assertThat(userId).isEqualTo(user.getId());
+            verify(user, times(1)).updateUserByOauthProfile(any());
+            verify(userRepository, times(1)).save(eq(user));
+        }
+    }
 
 
     @Nested


### PR DESCRIPTION
# JIRA 티켓
[TRL-395]

# 작업 내역
- [x] AuthService 강결합 문제 개선 (리팩토링)

# 설명

`User` 영속화 로직은 `UserRepository.save()` 를 호출하기 때문에 `User` 도메인에 의존성이 발생합니다. 즉 `User` 도메인의 변경이 `AuthService`에 영향을 미칠 수 있으며, `User` 도메인과 `AuthService`를 독립적으로 수정하거나 변경하기 어려워집니다. 

이 다음 PR 에서 `User` 에 대한 마이페이지 URL 컬럼이 추가가 될 예정인데 `User` 도메인에 대한 코드 변경점이 `UserService` 에서 일어나지 않고 `AuthService` 에서 일어나는 문제가 있어서 이번 PR 을 통해 개선 하게 되었습니다.

### 변경 전 (의존 방향)

![image](https://github.com/teamCoSaIn/trilo-be/assets/53935439/fcaa8a76-35c4-492a-a905-7532386ddf72)

### 변경 후 (의존 방향)

![image](https://github.com/teamCoSaIn/trilo-be/assets/53935439/5b4c2684-fcab-49d1-9e6d-7556d5070789)



[TRL-395]: https://cosain.atlassian.net/browse/TRL-395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ