### PR TITLE
[TRL-397] refactor: AuthService 에서의 강한 결합 문제 개선

### DIFF
--- a/src/main/java/com/cosain/trilo/auth/application/AuthService.java
+++ b/src/main/java/com/cosain/trilo/auth/application/AuthService.java
@@ -12,14 +12,11 @@ import com.cosain.trilo.auth.infra.TokenProvider;
 import com.cosain.trilo.auth.presentation.dto.RefreshTokenStatusResponse;
 import com.cosain.trilo.common.exception.NotExistRefreshTokenException;
 import com.cosain.trilo.common.exception.NotValidTokenException;
-import com.cosain.trilo.user.domain.User;
-import com.cosain.trilo.user.domain.UserRepository;
+import com.cosain.trilo.user.application.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 @Slf4j
 @Service
@@ -30,7 +27,7 @@ public class AuthService {
     private final TokenProvider tokenProvider;
     private final TokenAnalyzer tokenAnalyzer;
     private final OAuthProfileRequestService OAuthProfileRequestService;
-    private final UserRepository userRepository;
+    private final UserService userService;
 
     @Transactional
     public ReIssueAccessTokenResult reissueAccessToken(String refreshToken){
@@ -89,31 +86,19 @@ public class AuthService {
     public LoginResult login(OAuthLoginParams oAuthLoginParams){
 
         OAuthProfileDto oAuthProfileDto = getUserProfileResponse(oAuthLoginParams);
-        User user = addOrUpdateUser(oAuthProfileDto);
+        Long userId = userService.createOrUpdate(oAuthProfileDto);
 
-        String accessToken = tokenProvider.createAccessTokenById(user.getId());
-        String refreshToken = tokenProvider.createRefreshTokenById(user.getId());
+        String accessToken = tokenProvider.createAccessTokenById(userId);
+        String refreshToken = tokenProvider.createRefreshTokenById(userId);
 
         Long tokenExpiry = tokenAnalyzer.getTokenRemainExpiryFrom(refreshToken);
         tokenRepository.saveRefreshToken(RefreshToken.of(refreshToken, tokenExpiry));
 
-        return LoginResult.of(accessToken, refreshToken, user.getId());
+        return LoginResult.of(accessToken, refreshToken, userId);
     }
 
     private OAuthProfileDto getUserProfileResponse(OAuthLoginParams oAuthLoginParams) {
         return OAuthProfileRequestService.request(oAuthLoginParams);
-    }
-
-    private User addOrUpdateUser(OAuthProfileDto oAuthProfileDto){
-        Optional<User> userOptional = userRepository.findByEmail(oAuthProfileDto.getEmail());
-        User user;
-        if(userOptional.isPresent()){
-            user = userOptional.get();
-            user.updateUserByOauthProfile(oAuthProfileDto);
-        }else{
-            user = userRepository.save(User.from(oAuthProfileDto));
-        }
-        return user;
     }
 
 }

--- a/src/test/java/com/cosain/trilo/unit/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/auth/application/AuthServiceTest.java
@@ -13,17 +13,14 @@ import com.cosain.trilo.auth.infra.TokenProvider;
 import com.cosain.trilo.auth.presentation.dto.RefreshTokenStatusResponse;
 import com.cosain.trilo.common.exception.NotExistRefreshTokenException;
 import com.cosain.trilo.common.exception.NotValidTokenException;
+import com.cosain.trilo.user.application.UserService;
 import com.cosain.trilo.user.domain.AuthProvider;
-import com.cosain.trilo.user.domain.User;
-import com.cosain.trilo.user.domain.UserRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
@@ -41,7 +38,7 @@ class AuthServiceTest {
     @Mock
     private TokenProvider tokenProvider;
     @Mock
-    private UserRepository userRepository;
+    private UserService userService;
     @Mock
     private OAuthProfileRequestService OAuthProfileRequestService;
     private final String ACCESS_TOKEN = "slkdfjasjeoifjse.siejfoajseifjasolef.sliejfaisjelfsjefsdcv";
@@ -125,7 +122,8 @@ class AuthServiceTest {
                 .provider(AuthProvider.KAKAO)
                 .profileImageUrl("image_url")
                 .build();
-        given(userRepository.findByEmail(any())).willReturn(Optional.ofNullable(User.from(oAuthProfileDto)));
+
+        given(userService.createOrUpdate(any(OAuthProfileDto.class))).willReturn(1L);
         given(OAuthProfileRequestService.request(any(OAuthLoginParams.class))).willReturn(oAuthProfileDto);
         given(tokenProvider.createAccessTokenById(any())).willReturn(ACCESS_TOKEN);
         given(tokenProvider.createRefreshTokenById(any())).willReturn(REFRESH_TOKEN);

--- a/src/test/java/com/cosain/trilo/unit/user/application/UserServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/user/application/UserServiceTest.java
@@ -74,7 +74,7 @@ public class UserServiceTest {
             // given
             User user = mock(User.class);
             given(userRepository.findByEmail(eq(email))).willReturn(Optional.ofNullable(user));
-            given(userRepository.save(eq(user))).willReturn(user);
+            given(userRepository.save(any(User.class))).willReturn(user);
 
             // when
             Long userId = userService.createOrUpdate(oAuthProfileDto);

--- a/src/test/java/com/cosain/trilo/unit/user/application/UserServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/user/application/UserServiceTest.java
@@ -1,5 +1,6 @@
 package com.cosain.trilo.unit.user.application;
 
+import com.cosain.trilo.auth.infra.OAuthProfileDto;
 import com.cosain.trilo.user.application.UserService;
 import com.cosain.trilo.user.application.event.UserDeleteEvent;
 import com.cosain.trilo.user.application.exception.NoUserDeleteAuthorityException;
@@ -9,6 +10,7 @@ import com.cosain.trilo.user.domain.AuthProvider;
 import com.cosain.trilo.user.domain.Role;
 import com.cosain.trilo.user.domain.User;
 import com.cosain.trilo.user.domain.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,11 +22,12 @@ import org.springframework.context.ApplicationEventPublisher;
 import java.util.Optional;
 
 import static com.cosain.trilo.fixture.UserFixture.KAKAO_MEMBER;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class UserServiceTest {
@@ -33,9 +36,55 @@ public class UserServiceTest {
     private UserService userService;
     @Mock
     private UserRepository userRepository;
-
     @Mock
     private ApplicationEventPublisher eventPublisher;
+
+    @Nested
+    class 회원_생성_또는_업데이트_기능{
+        private String email;
+        private OAuthProfileDto oAuthProfileDto;
+        @BeforeEach
+        void setUp(){
+            email = "aaaa@nate.com";
+            oAuthProfileDto = OAuthProfileDto.builder()
+                    .name("김규성")
+                    .profileImageUrl("profile-image-url")
+                    .provider(AuthProvider.KAKAO)
+                    .email(email)
+                    .build();
+        }
+
+        @Test
+        void 신규_회원일_경우_저장(){
+            // given
+            User user = mock(User.class);
+            given(userRepository.findByEmail(eq(email))).willReturn(Optional.empty());
+            given(userRepository.save(any(User.class))).willReturn(user);
+
+            // when
+            Long userId = userService.createOrUpdate(oAuthProfileDto);
+
+            // then
+            assertThat(userId).isEqualTo(user.getId());
+            verify(userRepository, times(1)).save(any(User.class));
+        }
+
+        @Test
+        void 기존_회원일_경우_업데이트_후_저장(){
+            // given
+            User user = mock(User.class);
+            given(userRepository.findByEmail(eq(email))).willReturn(Optional.ofNullable(user));
+            given(userRepository.save(eq(user))).willReturn(user);
+
+            // when
+            Long userId = userService.createOrUpdate(oAuthProfileDto);
+
+            // then
+            assertThat(userId).isEqualTo(user.getId());
+            verify(user, times(1)).updateUserByOauthProfile(any());
+            verify(userRepository, times(1)).save(eq(user));
+        }
+    }
 
 
     @Nested


### PR DESCRIPTION
# JIRA 티켓
[TRL-397]

# 작업 내역

- [x] AuthService 강결합 문제 개선 (리팩토링)

# 설명

`User` 영속화 로직은 `UserRepository.save()` 를 호출하기 때문에 `User` 도메인에 의존성이 발생합니다. 즉 `User` 도메인의 변경이 `AuthService`에 영향을 미칠 수 있으며, `User` 도메인과 `AuthService`를 독립적으로 수정하거나 변경하기 어려워집니다. 

이 다음 PR 에서 `User` 에 대한 마이페이지 URL 컬럼이 추가가 될 예정인데 `User` 도메인에 대한 코드 변경점이 `UserService` 에서 일어나지 않고 `AuthService` 에서 일어나는 문제가 있어서 이번 PR 을 통해 개선 하게 되었습니다.

### 변경 전 (의존 방향)

![image](https://github.com/teamCoSaIn/trilo-be/assets/53935439/fcaa8a76-35c4-492a-a905-7532386ddf72)

### 변경 후 (의존 방향)

![image](https://github.com/teamCoSaIn/trilo-be/assets/53935439/5b4c2684-fcab-49d1-9e6d-7556d5070789)


[TRL-397]: https://cosain.atlassian.net/browse/TRL-397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ