### PR TITLE
[TRL-400] fix: 인증 관련 응답 데이터에서 사용자 ID 제거

### DIFF
--- a/src/main/java/com/cosain/trilo/auth/application/AuthService.java
+++ b/src/main/java/com/cosain/trilo/auth/application/AuthService.java
@@ -35,7 +35,7 @@ public class AuthService {
         checkTokenExistenceOrThrow(refreshToken);
         Long userId = tokenAnalyzer.getUserIdFromToken(refreshToken);
         String accessToken = tokenProvider.createAccessTokenById(userId);
-        return ReIssueAccessTokenResult.of(accessToken, userId);
+        return ReIssueAccessTokenResult.of(accessToken);
     }
     private void checkIfValidTokenOrThrow(String refreshToken){
         if(!tokenAnalyzer.validateToken(refreshToken)){
@@ -94,7 +94,7 @@ public class AuthService {
         Long tokenExpiry = tokenAnalyzer.getTokenRemainExpiryFrom(refreshToken);
         tokenRepository.saveRefreshToken(RefreshToken.of(refreshToken, tokenExpiry));
 
-        return LoginResult.of(accessToken, refreshToken, userId);
+        return LoginResult.of(accessToken, refreshToken);
     }
 
     private OAuthProfileDto getUserProfileResponse(OAuthLoginParams oAuthLoginParams) {

--- a/src/main/java/com/cosain/trilo/auth/application/dto/LoginResult.java
+++ b/src/main/java/com/cosain/trilo/auth/application/dto/LoginResult.java
@@ -7,14 +7,12 @@ public class LoginResult {
 
     private String accessToken;
     private String refreshToken;
-    private Long id;
 
-    private LoginResult(String accessToken, String refreshToken, Long id) {
+    private LoginResult(String accessToken, String refreshToken) {
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
-        this.id = id;
     }
-    public static LoginResult of(String accessToken, String refreshToken, Long id) {
-        return new LoginResult(accessToken, refreshToken, id);
+    public static LoginResult of(String accessToken, String refreshToken) {
+        return new LoginResult(accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/cosain/trilo/auth/application/dto/ReIssueAccessTokenResult.java
+++ b/src/main/java/com/cosain/trilo/auth/application/dto/ReIssueAccessTokenResult.java
@@ -6,13 +6,11 @@ import lombok.Getter;
 public class ReIssueAccessTokenResult {
 
     private String accessToken;
-    private Long userId;
 
-    private ReIssueAccessTokenResult(String accessToken, Long userId) {
+    private ReIssueAccessTokenResult(String accessToken) {
         this.accessToken = accessToken;
-        this.userId = userId;
     }
-    public static ReIssueAccessTokenResult of(String accessToken, Long userId) {
-        return new ReIssueAccessTokenResult(accessToken, userId);
+    public static ReIssueAccessTokenResult of(String accessToken) {
+        return new ReIssueAccessTokenResult(accessToken);
     }
 }

--- a/src/main/java/com/cosain/trilo/auth/presentation/dto/AuthResponse.java
+++ b/src/main/java/com/cosain/trilo/auth/presentation/dto/AuthResponse.java
@@ -9,19 +9,17 @@ public class AuthResponse {
 
     private String authType;
     private String accessToken;
-    private Long userId;
 
     public static AuthResponse from(LoginResult result) {
-        return new AuthResponse(result.getAccessToken(), result.getId());
+        return new AuthResponse(result.getAccessToken());
     }
 
     public static AuthResponse from(ReIssueAccessTokenResult result){
-        return new AuthResponse(result.getAccessToken(), result.getUserId());
+        return new AuthResponse(result.getAccessToken());
     }
 
-    private AuthResponse(String accessToken, Long userId){
+    private AuthResponse(String accessToken){
         this.authType = "Bearer";
         this.accessToken = accessToken;
-        this.userId = userId;
     }
 }

--- a/src/test/java/com/cosain/trilo/unit/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/auth/application/AuthServiceTest.java
@@ -53,7 +53,6 @@ class AuthServiceTest {
         given(tokenProvider.createAccessTokenById(anyLong())).willReturn(ACCESS_TOKEN);
 
         ReIssueAccessTokenResult result = authService.reissueAccessToken(any());
-        Assertions.assertThat(result.getUserId()).isEqualTo(id);
         Assertions.assertThat(result.getAccessToken()).isEqualTo(ACCESS_TOKEN);
     }
 

--- a/src/test/java/com/cosain/trilo/unit/auth/presentation/api/AuthRestControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/auth/presentation/api/AuthRestControllerTest.java
@@ -35,7 +35,7 @@ class AuthRestControllerTest extends RestControllerTest {
     @Test
     void 쿠키를_포함한_접근_토큰_재발급_요청시_200_상태코드_반환_확인() throws Exception{
 
-        ReIssueAccessTokenResult result = ReIssueAccessTokenResult.of("accessToken", 1L);
+        ReIssueAccessTokenResult result = ReIssueAccessTokenResult.of("accessToken");
         given(authService.reissueAccessToken(any())).willReturn(result);
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/reissue")
@@ -120,7 +120,7 @@ class AuthRestControllerTest extends RestControllerTest {
 
     @Test
     void 카카오_로그인_정상_동작_확인() throws Exception{
-        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken", 1L));
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
         KakaoOAuthLoginRequest kakaoOAuthLoginRequest = new KakaoOAuthLoginRequest("code", "redirect_uri");
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/kakao")
@@ -133,7 +133,7 @@ class AuthRestControllerTest extends RestControllerTest {
     void 카카오_로그인_요청시_본문에_code가_존재하지_않으면_400_에러를_발생시킨다() throws Exception{
 
         KakaoOAuthLoginRequest kakaoOAuthLoginRequest = new KakaoOAuthLoginRequest(null, "redirect_uri");
-        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken", 1L));
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/kakao")
                         .content(createJson(kakaoOAuthLoginRequest))
@@ -144,7 +144,7 @@ class AuthRestControllerTest extends RestControllerTest {
     @Test
     void 카카오_로그인_요청시_쿼리_파라미터에_redirect_uri가_존재하지_않으면_400_에러를_발생시킨다() throws Exception{
         KakaoOAuthLoginRequest kakaoOAuthLoginRequest = new KakaoOAuthLoginRequest("code", null);
-        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken", 1L));
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/kakao")
                         .content(createJson(kakaoOAuthLoginRequest))
@@ -154,7 +154,7 @@ class AuthRestControllerTest extends RestControllerTest {
 
     @Test
     void 네이버_로그인_정상_동작_확인() throws Exception{
-        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken", 1L));
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
         NaverOAuthLoginRequest naverOAuthLoginRequest = new NaverOAuthLoginRequest("code", "state");
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/naver")
@@ -167,7 +167,7 @@ class AuthRestControllerTest extends RestControllerTest {
     void 네이버_로그인_요청시_본문에_code가_존재하지_않으면_400_에러를_발생시킨다() throws Exception{
 
         NaverOAuthLoginRequest naverOAuthLoginRequest = new NaverOAuthLoginRequest(null, "state");
-        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken", 1L));
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/naver")
                         .content(createJson(naverOAuthLoginRequest))
@@ -179,7 +179,7 @@ class AuthRestControllerTest extends RestControllerTest {
     void 네이버_로그인_요청시_본문에_state가_존재하지_않으면_400_에러를_발생시킨다() throws Exception{
 
         NaverOAuthLoginRequest naverOAuthLoginRequest = new NaverOAuthLoginRequest("code",null);
-        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken",1L));
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/naver")
                         .content(createJson(naverOAuthLoginRequest))
@@ -190,7 +190,7 @@ class AuthRestControllerTest extends RestControllerTest {
 
     @Test
     void 구글_로그인_정상_동작_확인() throws Exception{
-        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken", 1L));
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
         GoogleOAuthLoginRequest googleOAuthLoginRequest = new GoogleOAuthLoginRequest("code", "redirect_uri");
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/google")
@@ -201,7 +201,7 @@ class AuthRestControllerTest extends RestControllerTest {
 
     @Test
     void 구글_로그인_요청시_본문에_code가_존재하지_않으면_400_에러를_발생시킨다() throws Exception{
-        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken", 1L));
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
         GoogleOAuthLoginRequest googleOAuthLoginRequest = new GoogleOAuthLoginRequest(null, "redirect_uri");
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/google")
@@ -212,7 +212,7 @@ class AuthRestControllerTest extends RestControllerTest {
 
     @Test
     void 구글_로그인_요청시_본문에_redirect_uri가_존재하지_않으면_400_에러를_발생시킨다() throws Exception{
-        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken", 1L));
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
         GoogleOAuthLoginRequest googleOAuthLoginRequest = new GoogleOAuthLoginRequest("code", null);
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/google")

--- a/src/test/java/com/cosain/trilo/unit/auth/presentation/docs/AuthRestControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/auth/presentation/docs/AuthRestControllerDocsTest.java
@@ -39,7 +39,7 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
     @Test
     void 접근토큰_재발급_요청() throws Exception{
 
-        ReIssueAccessTokenResult result = ReIssueAccessTokenResult.of("accessToken", 1L);
+        ReIssueAccessTokenResult result = ReIssueAccessTokenResult.of("accessToken");
         given(authService.reissueAccessToken(any())).willReturn(result);
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL +"/reissue")
@@ -50,7 +50,6 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
                                 cookieWithName("refreshToken").description("접근 토큰 발급에 사용될 재발급 토큰")
                         ),
                         responseFields(
-                                fieldWithPath("userId").type(NUMBER).description("사용자 ID"),
                                 fieldWithPath("authType").type(STRING).description("인증 타입 (Bearer)"),
                                 fieldWithPath("accessToken").type(STRING).description("재발급한 접근 토큰")
                         )
@@ -96,9 +95,8 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
     @Test
     void 카카오_로그인_요청() throws Exception{
 
-        Long userId = 1L;
         KakaoOAuthLoginRequest kakaoOAuthLoginRequest = new KakaoOAuthLoginRequest("code", "redirect_uri");
-        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken", userId));
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/kakao")
                         .content(createJson(kakaoOAuthLoginRequest))
@@ -110,7 +108,6 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
                             fieldWithPath("redirect_uri").type(STRING).description("인증 코드 발급에 사용했던 Redirect Uri")
                     ),
                     responseFields(
-                            fieldWithPath("userId").type(NUMBER).description("사용자 ID"),
                             fieldWithPath("authType").type(STRING).description("인증 타입 (Bearer)"),
                             fieldWithPath("accessToken").description("AccessToken")
                     ),
@@ -124,9 +121,8 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
     @Test
     void 네이버_로그인_요청() throws Exception {
 
-        Long userId = 1L;
         NaverOAuthLoginRequest naverOAuthLoginRequest = new NaverOAuthLoginRequest("code", "state");
-        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken", userId));
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/naver")
                         .content(createJson(naverOAuthLoginRequest))
@@ -138,7 +134,6 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
                            fieldWithPath("state").type(STRING).description("Authorization Code 발급시 전달했던 redirect_uri")
                    ),
                    responseFields(
-                           fieldWithPath("userId").type(NUMBER).description("사용자 ID"),
                            fieldWithPath("authType").type(STRING).description("인증 타입 (Bearer)"),
                            fieldWithPath("accessToken").description("AccessToken")
                    ),
@@ -151,9 +146,8 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
     @Test
     void 구글_로그인_요청() throws Exception {
 
-        Long userId = 1L;
         GoogleOAuthLoginRequest googleOAuthLoginRequest = new GoogleOAuthLoginRequest("code", "redirectUrl");
-        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken", userId));
+        given(authService.login(any(OAuthLoginParams.class))).willReturn(LoginResult.of("accessToken", "refreshToken"));
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login/google")
                         .content(createJson(googleOAuthLoginRequest))
@@ -165,7 +159,6 @@ class AuthRestControllerDocsTest extends RestDocsTestSupport {
                                 fieldWithPath("redirect_uri").type(STRING).description("Authorization Code 발급시 전달했던 redirect_uri")
                         ),
                         responseFields(
-                                fieldWithPath("userId").type(NUMBER).description("사용자 ID"),
                                 fieldWithPath("authType").type(STRING).description("인증 타입 (Bearer)"),
                                 fieldWithPath("accessToken").description("AccessToken")
                         ),


### PR DESCRIPTION
# JIRA 티켓
[TRL-400]

# 작업 내역
- [x] 접근 토큰 재발급 요청에 대한 응답에서 사용자 ID 필드 제거
- [x] OAuth2.0 로그인 요청에 대한 응답에서 사용자 ID 필드 제거

# 설명

Json Web Token Payload 에 사용자 ID가 포함되어 전달되고 있으므로, 중복을 제거합니다.


[TRL-400]: https://cosain.atlassian.net/browse/TRL-400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ