### PR TITLE
[TRL-403] test: ScheduleFixture 추가 및 기존 테스트코드 반영

### DIFF
--- a/src/test/java/com/cosain/trilo/fixture/ScheduleFixture.java
+++ b/src/test/java/com/cosain/trilo/fixture/ScheduleFixture.java
@@ -1,0 +1,103 @@
+package com.cosain.trilo.fixture;
+
+import com.cosain.trilo.trip.domain.entity.Day;
+import com.cosain.trilo.trip.domain.entity.Schedule;
+import com.cosain.trilo.trip.domain.entity.Trip;
+import com.cosain.trilo.trip.domain.vo.*;
+
+import java.util.Comparator;
+import java.util.List;
+
+public class ScheduleFixture {
+
+    /**
+     * 임시보관함에 속한 일정을 생성하고, 실제로 해당 Trip의 임시보관함 컬렉션에 일정을 추가합니다.
+     * @param scheduleId : 일정에 부여할 식별자(id)
+     * @param trip : 여행
+     * @param scheduleIndexValue : 순서값(다른 일정들의 순서값과 비교했을 때 작을 수록 앞에 위치하고, 클 수록 뒤에 위치함)
+     * @return 일정
+     */
+    public static Schedule temporaryStorage_Id(Long scheduleId, Trip trip, long scheduleIndexValue) {
+        Schedule schedule = temporaryStorage_Id_NoAdd(scheduleId, trip, scheduleIndexValue);
+        addToCollection(schedule, trip, null);
+        return schedule;
+    }
+
+    /**
+     * 임시보관함에 속한 일정을 생성하고, 실제로 해당 Trip의 임시보관함 컬렉션에 일정을 추가합니다. 이 때 식별자는 부여하지 않습니다.
+     * @param trip : 여행
+     * @param scheduleIndexValue : 순서값(다른 일정들의 순서값과 비교했을 때 작을 수록 앞에 위치하고, 클 수록 뒤에 위치함)
+     * @return 일정
+     */
+    public static Schedule temporaryStorage_NullId(Trip trip, long scheduleIndexValue) {
+        return temporaryStorage_Id(null, trip, scheduleIndexValue);
+    }
+
+    /**
+     * 임시보관함에 속한 일정을 생성합니다. 단, 임시보관함 컬렉션에 일정을 추가하지 않습니다.
+     * @param scheduleId : 일정에 부여할 식별자(id)
+     * @param trip : 여행
+     * @param scheduleIndexValue : 순서값(다른 일정들의 순서값과 비교했을 때 작을 수록 앞에 위치하고, 클 수록 뒤에 위치함)
+     * @return 일정
+     */
+    public static Schedule temporaryStorage_Id_NoAdd(Long scheduleId, Trip trip, long scheduleIndexValue) {
+        return createMockSchedule(scheduleId, trip, null, scheduleIndexValue, "일정 제목", "일정 본문");
+    }
+
+    /**
+     * Day에 속한 일정을 생성하고 실제 Day의 Schedule 컬렉션에 추가합니다.
+     * @param scheduleId : 일정에 부여할 식별자(id)
+     * @param trip : 여행
+     * @param day : 속한 Day
+     * @param scheduleIndexValue : 순서값(다른 일정들의 순서값과 비교했을 때 작을 수록 앞에 위치하고, 클 수록 뒤에 위치함)
+     * @return 일정
+     */
+    public static Schedule day_Id(Long scheduleId, Trip trip, Day day, long scheduleIndexValue) {
+        Schedule schedule = day_Id_notAdd(scheduleId, trip, day, scheduleIndexValue);
+        addToCollection(schedule, trip, day);
+        return schedule;
+    }
+
+    /**
+     * Day에 속한 일정을 생성하고 실제 Day의 Schedule 컬렉션에 추가합니다. 이 때 식별자 값을 부여하지 않습니다.
+     * @param trip : 여행
+     * @param day : 속한 Day
+     * @param scheduleIndexValue : 순서값(다른 일정들의 순서값과 비교했을 때 작을 수록 앞에 위치하고, 클 수록 뒤에 위치함)
+     * @return 일정
+     */
+    public static Schedule day_NullId(Trip trip, Day day, long scheduleIndexValue) {
+        return day_Id(null, trip, day, scheduleIndexValue);
+    }
+
+    /**
+     * Day에 속한 일정을 생성하고 실제 Day의 Schedule 컬렉션에 추가합니다. 이 때, 실제 Day의 컬렉션에 추가하지는 않습니다.
+     * @param scheduleId : 부여할 일정 식별자(id)
+     * @param trip : 여행
+     * @param day : 속한 Day
+     * @param scheduleIndexValue : 순서값(다른 일정들의 순서값과 비교했을 때 작을 수록 앞에 위치하고, 클 수록 뒤에 위치함)
+     * @return 일정
+     */
+    public static Schedule day_Id_notAdd(Long scheduleId, Trip trip, Day day, long scheduleIndexValue) {
+        return createMockSchedule(scheduleId, trip, day, scheduleIndexValue, "일정 제목", "일정 본문");
+    }
+
+    private static Schedule createMockSchedule(Long scheduleId, Trip trip, Day day, long scheduleIndexValue, String rawTitle, String rawContent) {
+        return Schedule.builder()
+                .id(scheduleId)
+                .trip(trip)
+                .day(day)
+                .scheduleIndex(ScheduleIndex.of(scheduleIndexValue))
+                .scheduleTitle(ScheduleTitle.of(rawTitle))
+                .scheduleContent(ScheduleContent.of(rawContent))
+                .scheduleTime(ScheduleTime.defaultTime())
+                .place(Place.of("place-id", "place-name", Coordinate.of(37.123, 132.145)))
+                .build();
+    }
+
+    private static void addToCollection(Schedule schedule, Trip trip, Day day) {
+        List<Schedule> schedules = (day == null) ? trip.getTemporaryStorage() : day.getSchedules();
+        schedules.add(schedule);
+        schedules.sort(Comparator.comparing(sch -> sch.getScheduleIndex().getValue()));
+    }
+
+}

--- a/src/test/java/com/cosain/trilo/unit/trip/application/day/command/service/DayColorUpdateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/day/command/service/DayColorUpdateServiceTest.java
@@ -67,7 +67,7 @@ public class DayColorUpdateServiceTest {
 
         DayColor beforeDayColor = DayColor.BLACK;
         DayColor requestDayColor = DayColor.RED;
-        Day day = fixtureDay(tripId, tripOwnerId, beforeDayColor);
+        Day day = fixtureDayForColorTest(tripId, tripOwnerId, beforeDayColor);
         DayColorUpdateCommand updateCommand = new DayColorUpdateCommand(requestDayColor);
 
         given(dayRepository.findByIdWithTrip(eq(dayId))).willReturn(Optional.of(day));
@@ -89,7 +89,7 @@ public class DayColorUpdateServiceTest {
         DayColor beforeDayColor = DayColor.BLACK;
         DayColor requestDayColor = DayColor.RED;
 
-        Day day = fixtureDay(tripId, tripOwnerId, beforeDayColor);
+        Day day = fixtureDayForColorTest(tripId, tripOwnerId, beforeDayColor);
         DayColorUpdateCommand updateCommand = new DayColorUpdateCommand(requestDayColor);
 
         given(dayRepository.findByIdWithTrip(eq(dayId))).willReturn(Optional.of(day));
@@ -102,7 +102,7 @@ public class DayColorUpdateServiceTest {
         assertThat(day.getDayColor()).isSameAs(requestDayColor);
     }
 
-    private Day fixtureDay(Long tripId, Long tripperId, DayColor dayColor) {
+    private Day fixtureDayForColorTest(Long tripId, Long tripperId, DayColor dayColor) {
         LocalDate startDate = LocalDate.of(2023,3,1);
         LocalDate endDate = LocalDate.of(2023,3,1);
         Trip trip = TripFixture.decided_Id_Color(tripId, tripperId, startDate, endDate, 1L, dayColor);

--- a/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleCreateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleCreateServiceTest.java
@@ -1,5 +1,6 @@
 package com.cosain.trilo.unit.trip.application.schedule.command.service;
 
+import com.cosain.trilo.fixture.ScheduleFixture;
 import com.cosain.trilo.fixture.TripFixture;
 import com.cosain.trilo.trip.application.exception.NoScheduleCreateAuthorityException;
 import com.cosain.trilo.trip.application.exception.TooManyDayScheduleException;
@@ -14,7 +15,6 @@ import com.cosain.trilo.trip.domain.repository.ScheduleRepository;
 import com.cosain.trilo.trip.domain.repository.TripRepository;
 import com.cosain.trilo.trip.domain.vo.Coordinate;
 import com.cosain.trilo.trip.domain.vo.Place;
-import com.cosain.trilo.trip.domain.vo.ScheduleIndex;
 import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -27,6 +27,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDate;
 import java.util.Optional;
 
+import static com.cosain.trilo.trip.domain.vo.ScheduleIndex.*;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
@@ -60,36 +61,26 @@ public class ScheduleCreateServiceTest {
             Long dayId = 3L;
             LocalDate startDate = LocalDate.of(2023,3,1);
             LocalDate endDate = LocalDate.of(2023,3,1);
+            ScheduleCreateCommand scheduleCreateCommand = commandFixture(tripId, dayId);
 
+            // Mock : 리포지토리에서 가져올 Trip, Day
             Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, dayId);
             Day day = trip.getDays().get(0);
-
-            ScheduleCreateCommand scheduleCreateCommand = ScheduleCreateCommand.builder()
-                    .dayId(dayId)
-                    .tripId(tripId)
-                    .scheduleTitle(ScheduleTitle.of("일정 제목"))
-                    .place(Place.of("장소식별자", "장소명", Coordinate.of(23.21, 23.24)))
-                    .build();
-
-            Schedule createdSchedule = Schedule.builder()
-                    .id(1L)
-                    .day(day)
-                    .trip(trip)
-                    .scheduleTitle(ScheduleTitle.of("일정 제목"))
-                    .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
-                    .scheduleIndex(ScheduleIndex.ZERO_INDEX)
-                    .build();
-
             given(dayRepository.findByIdWithTrip(eq(dayId))).willReturn(Optional.of(day));
             given(tripRepository.findById(eq(tripId))).willReturn(Optional.of(trip));
-            given(scheduleRepository.save(any(Schedule.class))).willReturn(createdSchedule);
+
+            // Mock : Trip, Day가 가진 Schedule 갯수
             given(scheduleRepository.findTripScheduleCount(eq(tripId))).willReturn(0);
             given(scheduleRepository.findDayScheduleCount(eq(dayId))).willReturn(0);
 
-            // when
+            // Mock : 생성될 Schedule
+            Schedule createdSchedule = ScheduleFixture.temporaryStorage_Id_NoAdd(1L, trip, 0);
+            given(scheduleRepository.save(any(Schedule.class))).willReturn(createdSchedule);
+
+            // when : 서비스 측에 일정을 생성하라고 요청할 때
             scheduleCreateService.createSchedule(tripperId, scheduleCreateCommand);
 
-            // then
+            // then : 리포지토리 호출 횟수 검증
             verify(dayRepository, times(1)).findByIdWithTrip(eq(dayId));
             verify(tripRepository, times(1)).findById(eq(tripId));
             verify(scheduleRepository, times(0)).relocateDaySchedules(eq(tripId), eq(dayId));
@@ -99,7 +90,7 @@ public class ScheduleCreateServiceTest {
         }
 
         @Test
-        @DisplayName("범위를 넘길 때, 리포지토리 호출이 한번씩만 이루어지는지 테스트")
+        @DisplayName("범위를 넘길 때, 재배치가 이루어지는 지 테스트")
         public void when_day_scheduleIndex_is_over_limit_then_relocate_called() {
             // given
             Long tripperId = 1L;
@@ -107,51 +98,20 @@ public class ScheduleCreateServiceTest {
             Long dayId = 3L;
             LocalDate startDate = LocalDate.of(2023,3,1);
             LocalDate endDate = LocalDate.of(2023,3,1);
+            ScheduleCreateCommand scheduleCreateCommand = commandFixture(tripId, dayId);
 
+            // Mock : 재배치 이전에 가져올 Trip, Day, Day가 가진 Schedule
             Trip beforeTrip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, dayId);
             Day beforeDay = beforeTrip.getDays().get(0);
+            Schedule beforeSchedule = ScheduleFixture.day_Id(1L, beforeTrip, beforeDay, MAX_INDEX_VALUE);
 
-            Schedule beforeSchedule = Schedule.builder()
-                    .id(1L)
-                    .day(beforeDay)
-                    .trip(beforeTrip)
-                    .scheduleTitle(ScheduleTitle.of("제목"))
-                    .place(Place.of("장소식별자", "장소명", Coordinate.of(23.21, 23.24)))
-                    .scheduleIndex(ScheduleIndex.of(ScheduleIndex.MAX_INDEX_VALUE))
-                    .build();
-            beforeDay.getSchedules().add(beforeSchedule);
-            beforeTrip.getDays().add(beforeDay);
-
-            ScheduleCreateCommand scheduleCreateCommand = ScheduleCreateCommand.builder()
-                    .dayId(dayId)
-                    .tripId(tripId)
-                    .scheduleTitle(ScheduleTitle.of("일정 제목"))
-                    .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
-                    .build();
-
+            // Mock : 재배치 이후 다시 가져올 Trip, Day, Day가 가진 Schedule
             Trip rediscoveredTrip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, dayId);
             Day rediscoveredDay = rediscoveredTrip.getDays().get(0);
+            Schedule rediscoveredBeforeSchedule = ScheduleFixture.day_Id(1L, rediscoveredTrip, rediscoveredDay, 0L);
 
-            Schedule rediscoveredBeforeSchedule = Schedule.builder()
-                    .id(1L)
-                    .day(rediscoveredDay)
-                    .trip(rediscoveredTrip)
-                    .scheduleTitle(ScheduleTitle.of("제목"))
-                    .place(Place.of("장소식별자", "장소명", Coordinate.of(23.21, 23.24)))
-                    .scheduleIndex(ScheduleIndex.ZERO_INDEX)
-                    .build();
-
-            rediscoveredDay.getSchedules().add(rediscoveredBeforeSchedule);
-            rediscoveredTrip.getDays().add(rediscoveredDay);
-
-            Schedule createdSchedule = Schedule.builder()
-                    .id(2L)
-                    .day(rediscoveredDay)
-                    .trip(rediscoveredTrip)
-                    .scheduleTitle(ScheduleTitle.of("일정 제목"))
-                    .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
-                    .scheduleIndex(ScheduleIndex.of(ScheduleIndex.DEFAULT_SEQUENCE_GAP))
-                    .build();
+            // Mock : 생성된 Schedule
+            Schedule createdSchedule = ScheduleFixture.day_Id_notAdd(2L, rediscoveredTrip, rediscoveredDay, DEFAULT_SEQUENCE_GAP);
 
             when(dayRepository.findByIdWithTrip(eq(dayId)))
                     .thenReturn(Optional.of(beforeDay))
@@ -166,10 +126,10 @@ public class ScheduleCreateServiceTest {
             given(scheduleRepository.findTripScheduleCount(eq(tripId))).willReturn(1);
             given(scheduleRepository.findDayScheduleCount(eq(dayId))).willReturn(1);
 
-            // when
+            // when : 서비스 클래스에 일정을 생성해달라고 요청할 때
             scheduleCreateService.createSchedule(tripperId, scheduleCreateCommand);
 
-            // then
+            // then : 리포지토리 호출 횟수 검증
             verify(dayRepository, times(2)).findByIdWithTrip(eq(dayId));
             verify(tripRepository, times(2)).findById(eq(tripId));
             verify(scheduleRepository, times(1)).relocateDaySchedules(eq(tripId), eq(dayId));
@@ -184,39 +144,29 @@ public class ScheduleCreateServiceTest {
     class Case_Create_To_TemporaryStorage {
 
         @Test
-        @DisplayName("범위를 넘기지 않을 때, 리포지토리 호출이 한번씩만 이루어지는지 테스트")
+        @DisplayName("범위를 넘기지 않을 때, 재배치 없이 리포지토리 호출이 한번씩만 이루어지는지 테스트")
         public void when_there_is_no_scheduleIndexRangeException_repository_is_called_only_once() {
             // given
             Long tripperId = 1L;
             Long tripId = 2L;
             Long dayId = null;
+            ScheduleCreateCommand scheduleCreateCommand = commandFixture(tripId, dayId);
 
+            // Mock : 가져올 Trip
             Trip trip = TripFixture.undecided_Id(tripId, tripperId);
-
-            ScheduleCreateCommand scheduleCreateCommand = ScheduleCreateCommand.builder()
-                    .dayId(dayId)
-                    .tripId(tripId)
-                    .scheduleTitle(ScheduleTitle.of("일정 제목"))
-                    .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
-                    .build();
-
-            Schedule createdSchedule = Schedule.builder()
-                    .id(1L)
-                    .day(null)
-                    .trip(trip)
-                    .scheduleTitle(ScheduleTitle.of("일정 제목"))
-                    .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
-                    .scheduleIndex(ScheduleIndex.ZERO_INDEX)
-                    .build();
-
             given(tripRepository.findById(eq(tripId))).willReturn(Optional.of(trip));
-            given(scheduleRepository.save(any(Schedule.class))).willReturn(createdSchedule);
+
+            // Mock : DB에서 조회하는 값 - Trip이 가지고 있는 Schedule의 갯수
             given(scheduleRepository.findTripScheduleCount(eq(tripId))).willReturn(0);
 
-            // when
+            // Mock : 생성될 Schedule
+            Schedule createdSchedule = ScheduleFixture.temporaryStorage_Id_NoAdd(1L, trip, 0);
+            given(scheduleRepository.save(any(Schedule.class))).willReturn(createdSchedule);
+
+            // when : 서비스 클래스에 일정을 생성해달라고 요청할 때
             scheduleCreateService.createSchedule(tripperId, scheduleCreateCommand);
 
-            // then
+            // then : 리포지토리 호출 횟수 검증
             verify(dayRepository, times(0)).findByIdWithTrip(isNull());
             verify(tripRepository, times(1)).findById(eq(tripId));
             verify(scheduleRepository, times(0)).relocateDaySchedules(eq(tripId), isNull());
@@ -231,44 +181,18 @@ public class ScheduleCreateServiceTest {
             // given
             Long tripId = 1L;
             Long tripperId = 2L;
+            ScheduleCreateCommand scheduleCreateCommand = commandFixture(tripId, null);
+
+            // Mock: 재배치 이전의 Trip과 임시보관함의 Schedule
             Trip trip = TripFixture.undecided_Id(tripId, tripperId);
+            Schedule beforeSchedule = ScheduleFixture.temporaryStorage_Id(1L, trip, MIN_INDEX_VALUE);
 
-            Schedule beforeSchedule = Schedule.builder()
-                    .id(1L)
-                    .day(null)
-                    .trip(trip)
-                    .scheduleTitle(ScheduleTitle.of("제목"))
-                    .place(Place.of("장소식별자", "장소명", Coordinate.of(23.21, 23.24)))
-                    .scheduleIndex(ScheduleIndex.of(ScheduleIndex.MIN_INDEX_VALUE))
-                    .build();
-            trip.getTemporaryStorage().add(beforeSchedule);
-
+            // Mock: 재배치 이후의 Trip과 임시보관함의 Schedule
             Trip rediscoveredTrip = TripFixture.undecided_Id(tripId, tripperId);
-            Schedule relocatedSchedule = Schedule.builder()
-                    .id(1L)
-                    .day(null)
-                    .trip(trip)
-                    .scheduleTitle(ScheduleTitle.of("제목"))
-                    .place(Place.of("장소식별자", "장소명", Coordinate.of(23.21, 23.24)))
-                    .scheduleIndex(ScheduleIndex.ZERO_INDEX)
-                    .build();
-            rediscoveredTrip.getTemporaryStorage().add(relocatedSchedule);
+            Schedule relocatedSchedule = ScheduleFixture.temporaryStorage_Id(1L, trip, 0L);
 
-            ScheduleCreateCommand scheduleCreateCommand = ScheduleCreateCommand.builder()
-                    .dayId(null)
-                    .tripId(tripId)
-                    .scheduleTitle(ScheduleTitle.of("일정제목2"))
-                    .place(Place.of("장소식별자2", "장소이름2", Coordinate.of(19.18, 27.15)))
-                    .build();
-
-            Schedule newSchedule = Schedule.builder()
-                    .id(2L)
-                    .day(null)
-                    .trip(trip)
-                    .scheduleTitle(ScheduleTitle.of("일정제목2"))
-                    .place(Place.of("장소식별자2", "장소이름2", Coordinate.of(19.18, 27.15)))
-                    .scheduleIndex(ScheduleIndex.of(-ScheduleIndex.DEFAULT_SEQUENCE_GAP))
-                    .build();
+            // Mock: 새로 생성될 Schedule
+            Schedule newSchedule = ScheduleFixture.temporaryStorage_Id_NoAdd(2L, trip, DEFAULT_SEQUENCE_GAP);
 
             when(tripRepository.findById(eq(tripId)))
                     .thenReturn(Optional.of(trip))
@@ -277,10 +201,10 @@ public class ScheduleCreateServiceTest {
             given(scheduleRepository.save(any(Schedule.class))).willReturn(newSchedule);
             given(scheduleRepository.findTripScheduleCount(eq(tripId))).willReturn(1);
 
-            // when
+            // when : 일정을 생성하라고 서비스에 요청할 때
             scheduleCreateService.createSchedule(tripperId, scheduleCreateCommand);
 
-            // then
+            // then : 리포지토리 호출 횟수 검증
             verify(dayRepository, times(0)).findByIdWithTrip(isNull());
             verify(tripRepository, times(2)).findById(eq(tripId));
             verify(scheduleRepository, times(1)).relocateDaySchedules(eq(tripId), isNull());
@@ -301,21 +225,15 @@ public class ScheduleCreateServiceTest {
         Long dayId = 4L;
         LocalDate startDate = LocalDate.of(2023,4,1);
         LocalDate endDate = LocalDate.of(2023,4,1);
+        ScheduleCreateCommand scheduleCreateCommand = commandFixture(tripId, dayId);
 
+        // mock: 리포지토리에서 가져올 Trip, Day
         Trip trip = TripFixture.decided_Id(tripId, tripOwnerId, startDate, endDate, 1L);
         Day day = trip.getDays().get(0);
-
-        ScheduleCreateCommand scheduleCreateCommand = ScheduleCreateCommand.builder()
-                .dayId(dayId)
-                .tripId(tripId)
-                .scheduleTitle(ScheduleTitle.of("제목"))
-                .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
-                .build();
-
         given(dayRepository.findByIdWithTrip(eq(dayId))).willReturn(Optional.of(day));
         given(tripRepository.findById(eq(tripId))).willReturn(Optional.of(trip));
 
-        // when & then
+        // when & then : 발생 예외 및 리포지토리 호출 횟수 검증
         assertThatThrownBy(() -> scheduleCreateService.createSchedule(noAuthorityTripperId, scheduleCreateCommand))
                 .isInstanceOf(NoScheduleCreateAuthorityException.class);
         verify(dayRepository).findByIdWithTrip(eq(dayId));
@@ -328,25 +246,18 @@ public class ScheduleCreateServiceTest {
         // given
         Long tripperId = 1L;
         Long tripId = 2L;
+        ScheduleCreateCommand scheduleCreateCommand = commandFixture(tripId, null);
 
+        // mock : 리포지토리에서 가져올 Trip
         Trip trip = TripFixture.undecided_Id(tripId, tripperId);
-
-        ScheduleCreateCommand scheduleCreateCommand = ScheduleCreateCommand.builder()
-                .dayId(null)
-                .tripId(tripId)
-                .scheduleTitle(ScheduleTitle.of("일정 제목"))
-                .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
-                .build();
-
-
         given(tripRepository.findById(eq(tripId))).willReturn(Optional.of(trip));
+
+        // mock : Trip 아래에 최대 갯수의 Schedule이 있는 상황
         given(scheduleRepository.findTripScheduleCount(eq(tripId))).willReturn(110);
 
-        // when
+        // when & then : 발생 예외 및 리포지토리 호출 횟수 검증
         assertThatThrownBy(() -> scheduleCreateService.createSchedule(tripperId, scheduleCreateCommand))
                 .isInstanceOf(TooManyTripScheduleException.class);
-
-        // then
         verify(dayRepository, times(0)).findByIdWithTrip(isNull());
         verify(tripRepository, times(1)).findById(eq(tripId));
         verify(scheduleRepository, times(0)).relocateDaySchedules(eq(tripId), isNull());
@@ -363,34 +274,45 @@ public class ScheduleCreateServiceTest {
         Long dayId = 3L;
         LocalDate startDate = LocalDate.of(2023,3,1);
         LocalDate endDate = LocalDate.of(2023,3,1);
+        ScheduleCreateCommand scheduleCreateCommand = commandFixture(tripId, dayId);
 
+        // mock : 리포지토리에서 가져올 Trip 및 Day
         Trip trip = TripFixture.decided_Id(tripId, tripperId, startDate, endDate, dayId);
         Day day = trip.getDays().get(0);
-
-        ScheduleCreateCommand scheduleCreateCommand = ScheduleCreateCommand.builder()
-                .dayId(dayId)
-                .tripId(tripId)
-                .scheduleTitle(ScheduleTitle.of("일정 제목"))
-                .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
-                .build();
-
-
         given(tripRepository.findById(eq(tripId))).willReturn(Optional.of(trip));
         given(dayRepository.findByIdWithTrip(eq(dayId))).willReturn(Optional.of(day));
+
+        // mock : Trip 하위의 일정 갯수
         given(scheduleRepository.findTripScheduleCount(eq(tripId))).willReturn(10);
+
+        // mock : Day 하위의 일정 갯수
         given(scheduleRepository.findDayScheduleCount(eq(dayId))).willReturn(10);
 
-        // when
+        // when && then : 발생 예외 및 리포지토리 호출 횟수 검증
         assertThatThrownBy(() -> scheduleCreateService.createSchedule(tripperId, scheduleCreateCommand))
                 .isInstanceOf(TooManyDayScheduleException.class);
-
-        // then
         verify(dayRepository, times(0)).findByIdWithTrip(isNull());
         verify(tripRepository, times(1)).findById(eq(tripId));
         verify(scheduleRepository, times(0)).relocateDaySchedules(eq(tripId), isNull());
         verify(scheduleRepository, times(0)).save(any(Schedule.class));
         verify(scheduleRepository, times(1)).findTripScheduleCount(eq(tripId));
         verify(scheduleRepository, times(1)).findDayScheduleCount(eq(dayId));
+    }
+
+    /**
+     * 이 테스트 클래스에서만 사용할 ScheduleCreateCommand Fixture입니다.
+     * 이 테스트에서 사용할 command에서 유의미한 변경값은 tripId, dayId뿐이기 때문에 해당 값들만 변경하여 사용할 수 있도록 합니다.
+     * @param tripId : 여행의 식별자
+     * @param dayId : Day의 식별자
+     * @return ScheduleCreateCommand
+     */
+    private ScheduleCreateCommand commandFixture(Long tripId, Long dayId) {
+        return ScheduleCreateCommand.builder()
+                .dayId(dayId)
+                .tripId(tripId)
+                .scheduleTitle(ScheduleTitle.of("일정 제목"))
+                .place(Place.of("장소 식별자", "장소명", Coordinate.of(23.21, 23.24)))
+                .build();
     }
 
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleDeleteServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleDeleteServiceTest.java
@@ -1,5 +1,6 @@
 package com.cosain.trilo.unit.trip.application.schedule.command.service;
 
+import com.cosain.trilo.fixture.ScheduleFixture;
 import com.cosain.trilo.fixture.TripFixture;
 import com.cosain.trilo.trip.application.exception.NoScheduleDeleteAuthorityException;
 import com.cosain.trilo.trip.application.exception.ScheduleNotFoundException;
@@ -8,9 +9,6 @@ import com.cosain.trilo.trip.domain.entity.Day;
 import com.cosain.trilo.trip.domain.entity.Schedule;
 import com.cosain.trilo.trip.domain.entity.Trip;
 import com.cosain.trilo.trip.domain.repository.ScheduleRepository;
-import com.cosain.trilo.trip.domain.vo.Coordinate;
-import com.cosain.trilo.trip.domain.vo.Place;
-import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -27,7 +25,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.verify;
 
 @Slf4j
@@ -40,6 +37,31 @@ public class ScheduleDeleteServiceTest {
 
     @Mock
     private ScheduleRepository scheduleRepository;
+
+    @Test
+    @DisplayName("정상적인 일정 삭제 요청 -> 리포지토리 호출 횟수 검증")
+    public void deleteSuccessTest() {
+        // given
+        Long tripId = 1L;
+        Long tripOwnerId = 2L;
+        Long deleteTripperId = 2L;
+        Long scheduleId = 3L;
+        LocalDate startDate = LocalDate.of(2023,3,1);
+        LocalDate endDate = LocalDate.of(2023,3,1);
+
+        // mock: 리포지토리에서 가져올 Schedule 설정
+        Trip trip = TripFixture.decided_Id(tripId, tripOwnerId, startDate, endDate, 1L);
+        Day day = trip.getDays().get(0);
+        Schedule schedule = ScheduleFixture.day_Id(scheduleId, trip, day, 0L);
+        given(scheduleRepository.findByIdWithTrip(eq(scheduleId))).willReturn(Optional.of(schedule));
+
+        // when : 서비스에 일정 삭제 요청
+        scheduleDeleteService.deleteSchedule(scheduleId, deleteTripperId);
+
+        // then : 리포지토리 호출 횟수 검증
+        verify(scheduleRepository).findByIdWithTrip(eq(scheduleId));
+        verify(scheduleRepository).delete(any(Schedule.class));
+    }
 
     @Test
     @DisplayName("존재하지 않는 일정을 삭제하려 하면, ScheduleNotFoundException 발생")
@@ -65,64 +87,22 @@ public class ScheduleDeleteServiceTest {
             // given
             Long tripId = 1L;
             Long tripOwnerId = 2L;
-            Long invalidTripperId = 3L;
             Long scheduleId = 4L;
-
             LocalDate startDate = LocalDate.of(2023,3,1);
             LocalDate endDate = LocalDate.of(2023,3,1);
+
+            // mock: 리포지토리에서 가져올 Schedule 설정
             Trip trip = TripFixture.decided_Id(tripId, tripOwnerId, startDate, endDate, 1L);
             Day day = trip.getDays().get(0);
-
-            Schedule schedule = Schedule.builder()
-                    .id(scheduleId)
-                    .scheduleTitle(ScheduleTitle.of("일정"))
-                    .day(day)
-                    .trip(trip)
-                    .place(Place.of("place-id", "광안리 해수욕장", Coordinate.of(35.1551, 129.1220)))
-                    .build();
-
+            Schedule schedule = ScheduleFixture.day_Id(scheduleId, trip, day, 0);
             given(scheduleRepository.findByIdWithTrip(eq(scheduleId))).willReturn(Optional.of(schedule));
 
-            // when & then
+            // when & then : 소유자가 아닌 사람의 삭제 요청 -> 발생 예외 및 리포지토리 호출 횟수 검증
+            Long invalidTripperId = 3L;
             assertThatThrownBy(() -> scheduleDeleteService.deleteSchedule(scheduleId, invalidTripperId))
                     .isInstanceOf(NoScheduleDeleteAuthorityException.class);
-
             verify(scheduleRepository).findByIdWithTrip(eq(scheduleId));
         }
-    }
-
-    @Test
-    @DisplayName("정상 삭제 요청이 들어왔을 때, 리포지토리가 정상적으로 호출되는 지 여부 테스트")
-    public void deleteSuccess_and_Repository_Called_Test() {
-        // given
-        Long tripId = 1L;
-        Long tripOwnerId = 2L;
-        Long deleteTripperId = 2L;
-        Long scheduleId = 3L;
-        LocalDate startDate = LocalDate.of(2023,3,1);
-        LocalDate endDate = LocalDate.of(2023,3,1);
-
-        Trip trip = TripFixture.decided_Id(tripId, tripOwnerId, startDate, endDate, 1L);
-        Day day = trip.getDays().get(0);
-
-        Schedule schedule = Schedule.builder()
-                .id(scheduleId)
-                .scheduleTitle(ScheduleTitle.of("일정"))
-                .day(day)
-                .trip(trip)
-                .place(Place.of("place-id", "광안리 해수욕장", Coordinate.of(35.1551, 129.1220)))
-                .build();
-
-        given(scheduleRepository.findByIdWithTrip(eq(scheduleId))).willReturn(Optional.of(schedule));
-        willDoNothing().given(scheduleRepository).delete(any(Schedule.class));
-
-
-        // when
-        scheduleDeleteService.deleteSchedule(scheduleId, deleteTripperId);
-
-        // then
-        verify(scheduleRepository).findByIdWithTrip(eq(scheduleId));
-        verify(scheduleRepository).delete(any(Schedule.class));
     }
 
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleUpdateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/schedule/command/service/ScheduleUpdateServiceTest.java
@@ -1,5 +1,6 @@
 package com.cosain.trilo.unit.trip.application.schedule.command.service;
 
+import com.cosain.trilo.fixture.ScheduleFixture;
 import com.cosain.trilo.fixture.TripFixture;
 import com.cosain.trilo.trip.application.exception.NoScheduleUpdateAuthorityException;
 import com.cosain.trilo.trip.application.exception.ScheduleNotFoundException;
@@ -9,7 +10,6 @@ import com.cosain.trilo.trip.domain.entity.Schedule;
 import com.cosain.trilo.trip.domain.entity.Trip;
 import com.cosain.trilo.trip.domain.repository.ScheduleRepository;
 import com.cosain.trilo.trip.domain.vo.ScheduleContent;
-import com.cosain.trilo.trip.domain.vo.ScheduleIndex;
 import com.cosain.trilo.trip.domain.vo.ScheduleTime;
 import com.cosain.trilo.trip.domain.vo.ScheduleTitle;
 import org.junit.jupiter.api.DisplayName;
@@ -39,27 +39,20 @@ public class ScheduleUpdateServiceTest {
     private ScheduleRepository scheduleRepository;
 
     @Test
-    @DisplayName("호출이 제대로 이루어 지는지 테스트")
+    @DisplayName("일정 수정(제목, 본문, 시간) 요청 -> 수정 성공")
     public void update_schedule_test(){
         // given
         Long tripId = 1L;
         Long tripperId = 2L;
         Long scheduleId = 3L;
 
-        ScheduleTitle newTitle = ScheduleTitle.of("변경할 제목");
-        ScheduleContent newContent = ScheduleContent.of("변경할 내용");
+        ScheduleTitle newTitle = ScheduleTitle.of("수정 제목");
+        ScheduleContent newContent = ScheduleContent.of("수정 본문");
         ScheduleTime newScheduleTime = ScheduleTime.of(LocalTime.of(13,0), LocalTime.of(13,5));
         ScheduleUpdateCommand command = new ScheduleUpdateCommand(newTitle, newContent, newScheduleTime);
 
         Trip trip = TripFixture.undecided_Id(tripId, tripperId);
-        Schedule schedule = Schedule.builder()
-                .id(scheduleId)
-                .trip(trip)
-                .day(null)
-                .scheduleTitle(ScheduleTitle.of("기존 제목"))
-                .scheduleContent(ScheduleContent.of("기존 본문"))
-                .scheduleIndex(ScheduleIndex.ZERO_INDEX)
-                .build();
+        Schedule schedule = ScheduleFixture.temporaryStorage_Id(scheduleId, trip, 0L);
 
         given(scheduleRepository.findByIdWithTrip(anyLong())).willReturn(Optional.of(schedule));
         // when
@@ -79,8 +72,8 @@ public class ScheduleUpdateServiceTest {
         Long scheduleId = 1L;
         Long tripperId = 2L;
 
-        ScheduleTitle newTitle = ScheduleTitle.of("변경할 제목");
-        ScheduleContent newContent = ScheduleContent.of("변경할 내용");
+        ScheduleTitle newTitle = ScheduleTitle.of("수정 제목");
+        ScheduleContent newContent = ScheduleContent.of("수정 내용");
         ScheduleTime newScheduleTime = ScheduleTime.of(LocalTime.of(13,0), LocalTime.of(13,5));
         ScheduleUpdateCommand command = new ScheduleUpdateCommand(newTitle, newContent, newScheduleTime);
 
@@ -100,21 +93,15 @@ public class ScheduleUpdateServiceTest {
         Long scheduleId = 3L;
         Long noAuthorityTripperId = 4L;
 
-        ScheduleTitle newTitle = ScheduleTitle.of("변경할 제목");
-        ScheduleContent newContent = ScheduleContent.of("변경할 내용");
+        ScheduleTitle newTitle = ScheduleTitle.of("수정 제목");
+        ScheduleContent newContent = ScheduleContent.of("수정 내용");
         ScheduleTime newScheduleTime = ScheduleTime.of(LocalTime.of(13,0), LocalTime.of(13,5));
         ScheduleUpdateCommand command = new ScheduleUpdateCommand(newTitle, newContent, newScheduleTime);
 
         Trip trip = TripFixture.undecided_Id(tripId, tripperId);
-        Schedule schedule = Schedule.builder()
-                .id(scheduleId)
-                .day(null)
-                .trip(trip)
-                .scheduleTitle(ScheduleTitle.of("원래 제목"))
-                .scheduleContent(ScheduleContent.of("원래 내용"))
-                .build();
-
+        Schedule schedule = ScheduleFixture.temporaryStorage_Id(scheduleId, trip, 0L);
         given(scheduleRepository.findByIdWithTrip(eq(scheduleId))).willReturn(Optional.of(schedule));
+
         // when & then
         assertThatThrownBy(() -> scheduleUpdateService.updateSchedule(scheduleId, noAuthorityTripperId, command))
                 .isInstanceOf(NoScheduleUpdateAuthorityException.class);

--- a/src/test/java/com/cosain/trilo/unit/trip/application/trip/command/service/TripImageUpdateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/trip/command/service/TripImageUpdateServiceTest.java
@@ -1,15 +1,13 @@
 package com.cosain.trilo.unit.trip.application.trip.command.service;
 
 import com.cosain.trilo.common.file.ImageFile;
+import com.cosain.trilo.fixture.TripFixture;
 import com.cosain.trilo.trip.application.exception.NoTripUpdateAuthorityException;
 import com.cosain.trilo.trip.application.exception.TripNotFoundException;
 import com.cosain.trilo.trip.application.trip.command.service.TripImageUpdateService;
 import com.cosain.trilo.trip.domain.entity.Trip;
 import com.cosain.trilo.trip.domain.repository.TripRepository;
 import com.cosain.trilo.trip.domain.vo.TripImage;
-import com.cosain.trilo.trip.domain.vo.TripPeriod;
-import com.cosain.trilo.trip.domain.vo.TripStatus;
-import com.cosain.trilo.trip.domain.vo.TripTitle;
 import com.cosain.trilo.trip.infra.adapter.TripImageOutputAdapter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -55,7 +53,7 @@ public class TripImageUpdateServiceTest {
 
         ImageFile imageFile = imageFileFixture("test-jpeg-image.jpeg");
 
-        Trip trip = unDecidedTripFixture(tripId, tripperId);
+        Trip trip = TripFixture.undecided_Id(tripId, tripperId);
         given(tripRepository.findById(eq(tripId))).willReturn(Optional.of(trip));
 
         willDoNothing().given(tripImageOutputAdapter).uploadImage(any(ImageFile.class), anyString());
@@ -103,7 +101,7 @@ public class TripImageUpdateServiceTest {
 
         ImageFile imageFile = imageFileFixture("test-jpeg-image.jpeg");
 
-        Trip trip = unDecidedTripFixture(tripId, tripperId);
+        Trip trip = TripFixture.undecided_Id(tripId, tripperId);
         given(tripRepository.findById(eq(tripId))).willReturn(Optional.of(trip));
 
         // when & then
@@ -122,16 +120,5 @@ public class TripImageUpdateServiceTest {
 
         MockMultipartFile multipartFile = new MockMultipartFile(name, testImageResourceFileName, contentType, fileInputStream);
         return ImageFile.from(multipartFile);
-    }
-
-    private Trip unDecidedTripFixture(Long tripId, Long tripperId) {
-        return Trip.builder()
-                .id(tripId)
-                .tripperId(tripperId)
-                .tripTitle(TripTitle.of("여행 제목"))
-                .status(TripStatus.UNDECIDED)
-                .tripPeriod(TripPeriod.empty())
-                .tripImage(TripImage.defaultImage())
-                .build();
     }
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/infra/repository/DayQueryRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/infra/repository/DayQueryRepositoryTest.java
@@ -1,11 +1,11 @@
 package com.cosain.trilo.unit.trip.infra.repository;
 
+import com.cosain.trilo.fixture.ScheduleFixture;
 import com.cosain.trilo.fixture.TripFixture;
 import com.cosain.trilo.support.RepositoryTest;
 import com.cosain.trilo.trip.domain.entity.Day;
 import com.cosain.trilo.trip.domain.entity.Schedule;
 import com.cosain.trilo.trip.domain.entity.Trip;
-import com.cosain.trilo.trip.domain.vo.*;
 import com.cosain.trilo.trip.infra.dto.DayScheduleDetail;
 import com.cosain.trilo.trip.infra.dto.ScheduleSummary;
 import com.cosain.trilo.trip.infra.repository.day.DayQueryRepository;
@@ -32,29 +32,24 @@ public class DayQueryRepositoryTest {
     private EntityManager em;
 
     @Test
-    void Day_조회를_하면_해당_Day정보와_해당_Day에_속한_Schedule들의_요약정보와_함께_조회된다(){
+    @DisplayName("findDayWithSchedulesByDayId -> Day 및 소속 Schedule 요약정보 목록(순서 오름차순) 함께 조회됨")
+    void testFindDayWithSchedulesByDayId() {
         // given
         Long tripperId = 1L;
-        LocalDate startDate = LocalDate.of(2023,5,1);
-        LocalDate endDate = LocalDate.of(2023,5,2);
-        Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
-        em.persist(trip);
+        LocalDate startDate = LocalDate.of(2023, 5, 1);
+        LocalDate endDate = LocalDate.of(2023, 5, 2);
 
+        Trip trip = setupDecidedTripAndPersist(tripperId, startDate, endDate);
         Day day1 = trip.getDays().get(0);
         Day day2 = trip.getDays().get(1);
-        em.persist(day1);
-        em.persist(day2);
 
-        Schedule schedule1 = createSchedule(trip, day1,10000L);
-        Schedule schedule2 = createSchedule(trip, day1,20000L);
-        Schedule schedule3 = createSchedule(trip, day1,30000L);
-        Schedule schedule4 = createSchedule(trip, day2,10000L);
+        Schedule schedule1 = setupDayScheduleAndPersist(trip, day1, 10000L);
+        Schedule schedule2 = setupDayScheduleAndPersist(trip, day1, 20000L);
+        Schedule schedule3 = setupDayScheduleAndPersist(trip, day1, 30000L);
+        Schedule schedule4 = setupDayScheduleAndPersist(trip, day2, 10000L);
 
-        em.persist(schedule1);
-        em.persist(schedule2);
-        em.persist(schedule3);
-        em.persist(schedule4);
         em.flush();
+        em.clear();
 
         // when
         long findDayId = day1.getId();
@@ -70,55 +65,38 @@ public class DayQueryRepositoryTest {
         assertThat(dayScheduleDetail.getSchedules().get(2).getScheduleId()).isEqualTo(schedule3.getId());
     }
 
-    private Schedule createSchedule(Trip trip, Day day, Long scheduleIndexValue){
-        return Schedule.builder()
-                .trip(trip)
-                .day(day)
-                .scheduleTitle(ScheduleTitle.of("Test Schedule"))
-                .place(Place.of("장소 1", "광산구", Coordinate.of(62.62, 62.62)))
-                .scheduleIndex(ScheduleIndex.of(scheduleIndexValue))
-                .scheduleContent(ScheduleContent.of("일정 본문"))
-                .build();
-    }
-
     @Nested
-    @DisplayName("Day_목록_조회_시")
-    class FindDayScheduleListByTripIdTest{
+    @DisplayName("Trip에 속한 Day 목록 조회 시")
+    class FindDayScheduleListByTripIdTest {
         @Test
         @DirtiesContext
         @DisplayName("tripId를 통해 Trip 에 매핑된 Day 들과 해당 Day 와 매핑된 Schedule 들이 조회되며 DTO 로 반환된다.")
         void findTest() {
             // given
             Long tripperId = 1L;
-            LocalDate startDate = LocalDate.of(2023,5,10);
-            LocalDate endDate = LocalDate.of(2023,5,11);
-            Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
-            em.persist(trip);
+            LocalDate startDate = LocalDate.of(2023, 5, 10);
+            LocalDate endDate = LocalDate.of(2023, 5, 11);
 
+            Trip trip = setupDecidedTripAndPersist(tripperId, startDate, endDate);
             Day day1 = trip.getDays().get(0);
             Day day2 = trip.getDays().get(1);
-            em.persist(day1);
-            em.persist(day2);
 
-            Schedule schedule1 = createSchedule(trip, day1,10000L);
-            Schedule schedule2 = createSchedule(trip, day1,20000L);
-            Schedule schedule3 = createSchedule(trip, day1,30000L);
-            Schedule schedule4 = createSchedule(trip, day2,10000L);
-
-            em.persist(schedule1);
-            em.persist(schedule2);
-            em.persist(schedule3);
-            em.persist(schedule4);
+            Schedule schedule1 = setupDayScheduleAndPersist(trip, day1, 10000L);
+            Schedule schedule2 = setupDayScheduleAndPersist(trip, day1, 20000L);
+            Schedule schedule3 = setupDayScheduleAndPersist(trip, day1, 30000L);
+            Schedule schedule4 = setupDayScheduleAndPersist(trip, day2, 10000L);
             em.flush();
+            em.clear();
 
             // when
             List<DayScheduleDetail> dayScheduleDetails = dayQueryRepository.findDayScheduleListByTripId(trip.getId());
+
+            // then
             DayScheduleDetail dayScheduleDetail1 = dayScheduleDetails.get(0);
             DayScheduleDetail dayScheduleDetail2 = dayScheduleDetails.get(1);
             List<ScheduleSummary> schedules1 = dayScheduleDetail1.getSchedules();
             List<ScheduleSummary> schedules2 = dayScheduleDetail2.getSchedules();
 
-            // then
             assertThat(dayScheduleDetails.size()).isEqualTo(2);
             assertThat(dayScheduleDetail1.getDayId()).isEqualTo(day1.getId());
             assertThat(dayScheduleDetail2.getDayId()).isEqualTo(day2.getId());
@@ -127,53 +105,50 @@ public class DayQueryRepositoryTest {
         }
 
         @Test
-        void Day에_해당하는_Schedule이_하나도_존재하지_않는_경우_ScheduleSummary_리스트의_크기는_0_이된다() {
+        void Day에_속하는_Schedule이_하나도_존재하지_않는_경우_ScheduleSummary_리스트의_크기는_0_이된다() {
             // given
             Long tripperId = 1L;
-            LocalDate startDate = LocalDate.of(2023,5,10);
-            LocalDate endDate = LocalDate.of(2023,5,11);
+            LocalDate startDate = LocalDate.of(2023, 5, 10);
+            LocalDate endDate = LocalDate.of(2023, 5, 11);
+
+            Trip trip = setupDecidedTripAndPersist(tripperId, startDate, endDate);
+
+            em.flush();
+            em.clear();
+
+            // when
+            List<DayScheduleDetail> dayScheduleDetails = dayQueryRepository.findDayScheduleListByTripId(trip.getId());
+            List<ScheduleSummary> findSchedules = dayScheduleDetails.get(0).getSchedules();
+            assertThat(findSchedules).isEmpty();
+        }
+
+
+        @Test
+        @DisplayName("여행 날짜 기준 오름차순, 일정 순서값 기준 오름 차순으로 조회된다.")
+        void sortTest() {
+            // given
+            Long tripperId = 1L;
+            LocalDate startDate = LocalDate.of(2023, 5, 10);
+            LocalDate endDate = LocalDate.of(2023, 5, 11);
+
+
             Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
             em.persist(trip);
 
             Day day1 = trip.getDays().get(0);
             Day day2 = trip.getDays().get(1);
-            em.persist(trip);
-            em.persist(day1);
-            em.persist(day2);
-
-            // when
-            List<DayScheduleDetail> dayScheduleDetails = dayQueryRepository.findDayScheduleListByTripId(trip.getId());
-            List<ScheduleSummary> findSchedules = dayScheduleDetails.get(0).getSchedules();
-
-            assertThat(findSchedules).isEmpty();
-            assertThat(findSchedules.size()).isEqualTo(0);
-        }
-
-
-
-        @Test
-        @DisplayName("여행 날짜 기준 오름차순, 일정 순서값 기준 오름 차순으로 조회된다.")
-        void sortTest(){
-            // given
-            Long tripperId = 1L;
-            LocalDate startDate = LocalDate.of(2023,5,10);
-            LocalDate endDate = LocalDate.of(2023,5,11);
-            Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
-            em.persist(trip);
-
-            Day day1 = trip.getDays().get(0); // 테스트의 편의를 위해 순서를 바꿔서 저장함.
-            Day day2 = trip.getDays().get(1);
-            em.persist(day2);
+            em.persist(day2);  // 테스트의 편의를 위해 순서를 바꿔서 저장함.
             em.persist(day1);
 
-            Schedule schedule1 = createSchedule(trip, day1,10000L);
-            Schedule schedule2 = createSchedule(trip, day1,20000L);
-            Schedule schedule3 = createSchedule(trip, day1,30000L);
+            Schedule schedule1 = ScheduleFixture.day_NullId(trip, day1, 10000L);
+            Schedule schedule2 = ScheduleFixture.day_NullId(trip, day1, 20000L);
+            Schedule schedule3 = ScheduleFixture.day_NullId(trip, day1, 30000L);
 
             em.persist(schedule3); // 테스트의 편의를 위해 순서를 바꿔서 저장함. (3,1,2 순)
             em.persist(schedule1);
             em.persist(schedule2);
             em.flush();
+            em.clear();
 
             // when
             List<DayScheduleDetail> dayScheduleDetails = dayQueryRepository.findDayScheduleListByTripId(trip.getId());
@@ -189,6 +164,17 @@ public class DayQueryRepositoryTest {
         }
     }
 
+    private Trip setupDecidedTripAndPersist(Long tripperId, LocalDate startDate, LocalDate endDate) {
+        Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
+        em.persist(trip);
+        trip.getDays().forEach(em::persist);
+        return trip;
+    }
 
+    private Schedule setupDayScheduleAndPersist(Trip trip, Day day, long scheduleIndexValue) {
+        Schedule schedule = ScheduleFixture.day_NullId(trip, day, scheduleIndexValue);
+        em.persist(schedule);
+        return schedule;
+    }
 
 }


### PR DESCRIPTION
# JIRA 티켓
- [TRL-403]

# 작업 내역
- [x] ScheduleFixture 정의
- [x] 기존 테스트코드의 Schedule 생성 로직을 ScheduleFixture를 통하여 생성하도록 간소화
 
# 설명
![image](https://github.com/teamCoSaIn/trilo-be/assets/88282356/d9172149-442a-463e-9dcb-27cd17143d9b)

- 기존 테스트코드의 Schedule 설정부분을 빌더로 수행하는 부분이 많았는데 이 부분을 ScheduleFixture를 통해 대신 수행하도록 합니다.

![image](https://github.com/teamCoSaIn/trilo-be/assets/88282356/7251cca2-6552-453d-9096-8d37353b896c)

- Fixture를 사용한 후 코드 라인수가 많이 줄어들어든 것을 확인할 수 있습니다.


# 참고자료


[TRL-403]: https://cosain.atlassian.net/browse/TRL-403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ