### PR TITLE
[TRL-418] 사용자의 닉네임 필드명 변경 (name -> nickName)

### DIFF
--- a/src/main/java/com/cosain/trilo/config/security/dto/UserPrincipal.java
+++ b/src/main/java/com/cosain/trilo/config/security/dto/UserPrincipal.java
@@ -33,7 +33,7 @@ public class UserPrincipal implements OAuth2User {
 
     @Override
     public String getName() {
-        return user.getName();
+        return user.getNickName();
     }
 
     public static UserPrincipal from(User user){

--- a/src/main/java/com/cosain/trilo/user/domain/User.java
+++ b/src/main/java/com/cosain/trilo/user/domain/User.java
@@ -7,7 +7,7 @@ import lombok.*;
 @Getter
 @Entity
 @Table(name = "users")
-@ToString(of = {"id", "name", "email", "profileImageURL", "authProvider", "role", "myPageImage"})
+@ToString(of = {"id", "nickName", "email", "profileImageURL", "authProvider", "role", "myPageImage"})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
 
@@ -16,7 +16,7 @@ public class User {
     private Long id;
 
     @Column(nullable = false)
-    private String name;
+    private String nickName;
 
     @Column(nullable = false)
     private String email;
@@ -37,9 +37,9 @@ public class User {
     private MyPageImage myPageImage;
 
     @Builder(access = AccessLevel.PUBLIC)
-    private User(Long id,String name, String email, String profileImageUrl, AuthProvider authProvider, Role role) {
+    private User(Long id,String nickName, String email, String profileImageUrl, AuthProvider authProvider, Role role) {
         this.id = id;
-        this.name = name;
+        this.nickName = nickName;
         this.email = email;
         this.profileImageURL = profileImageUrl;
         this.authProvider = authProvider;
@@ -49,7 +49,7 @@ public class User {
 
     public static User from(OAuthProfileDto oAuthProfileDto) {
         return User.builder()
-                .name(oAuthProfileDto.getName())
+                .nickName(oAuthProfileDto.getName())
                 .email(oAuthProfileDto.getEmail())
                 .profileImageUrl(oAuthProfileDto.getProfileImageUrl())
                 .role(Role.MEMBER)
@@ -58,7 +58,7 @@ public class User {
     }
 
     public void updateUserByOauthProfile(OAuthProfileDto oAuthProfileDto) {
-        this.name = oAuthProfileDto.getName();
+        this.nickName = oAuthProfileDto.getName();
         this.profileImageURL = oAuthProfileDto.getProfileImageUrl();
     }
 }

--- a/src/main/java/com/cosain/trilo/user/presentation/dto/UserMyPageResponse.java
+++ b/src/main/java/com/cosain/trilo/user/presentation/dto/UserMyPageResponse.java
@@ -6,12 +6,12 @@ import lombok.Getter;
 
 @Getter
 public class UserMyPageResponse {
-    private String name;
+    private String nickName;
     private String imageURL;
     private TripStatistics tripStatistics;
 
     private UserMyPageResponse(User user, String imageBaseURL, TripStatistics tripStatistics) {
-        this.name = user.getName();
+        this.nickName = user.getNickName();
         this.imageURL = imageBaseURL.concat(user.getMyPageImage().getFileName());
         this.tripStatistics = tripStatistics;
     }

--- a/src/main/java/com/cosain/trilo/user/presentation/dto/UserProfileResponse.java
+++ b/src/main/java/com/cosain/trilo/user/presentation/dto/UserProfileResponse.java
@@ -11,16 +11,16 @@ import lombok.Getter;
 public class UserProfileResponse {
 
     private Long id;
-    private String name;
+    private String nickName;
     private String email;
     private String profileImageURL;
     private AuthProvider authProvider;
     private Role role;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private UserProfileResponse(Long id, String name, String email, String profileImageURL, AuthProvider authProvider, Role role) {
+    private UserProfileResponse(Long id, String nickName, String email, String profileImageURL, AuthProvider authProvider, Role role) {
         this.id = id;
-        this.name = name;
+        this.nickName = nickName;
         this.email = email;
         this.profileImageURL = profileImageURL;
         this.authProvider = authProvider;
@@ -30,7 +30,7 @@ public class UserProfileResponse {
     public static UserProfileResponse from(User user) {
         return UserProfileResponse.builder()
                 .id(user.getId())
-                .name(user.getName())
+                .nickName(user.getNickName())
                 .email(user.getEmail())
                 .profileImageURL(user.getProfileImageURL())
                 .authProvider(user.getAuthProvider())

--- a/src/test/java/com/cosain/trilo/fixture/UserFixture.java
+++ b/src/test/java/com/cosain/trilo/fixture/UserFixture.java
@@ -33,7 +33,7 @@ public enum UserFixture {
     public User create(){
         return User.builder()
                 .id(id)
-                .name(name)
+                .nickName(name)
                 .profileImageUrl(profileImageURL)
                 .email(email)
                 .authProvider(authProvider)

--- a/src/test/java/com/cosain/trilo/integration/user/UserIntegrationTest.java
+++ b/src/test/java/com/cosain/trilo/integration/user/UserIntegrationTest.java
@@ -55,7 +55,7 @@ public class UserIntegrationTest extends IntegrationTest {
                             .header(HttpHeaders.AUTHORIZATION, authorizationHeader(user)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.id").value(user.getId()))
-                    .andExpect(jsonPath("$.name").value(user.getName()))
+                    .andExpect(jsonPath("$.nickName").value(user.getNickName()))
                     .andExpect(jsonPath("$.email").value(user.getEmail()))
                     .andExpect(jsonPath("$.profileImageURL").value(user.getProfileImageURL()))
                     .andExpect(jsonPath("$.role").value(user.getRole().name()));
@@ -137,7 +137,7 @@ public class UserIntegrationTest extends IntegrationTest {
             mockMvc.perform(RestDocumentationRequestBuilders.get(BASE_URL + "/{userId}/my-page", user.getId())
                             .header(HttpHeaders.AUTHORIZATION, authorizationHeader(user)))
                     .andExpect(MockMvcResultMatchers.status().isOk())
-                    .andExpect(jsonPath("$.name").value(user.getName()))
+                    .andExpect(jsonPath("$.nickName").value(user.getNickName()))
                     .andExpect(jsonPath("$.imageURL").value(myPageBaseUrl.concat(user.getMyPageImage().getFileName())))
                     .andExpect(jsonPath("$.tripStatistics.totalTripCnt").value(totalTripCnt))
                     .andExpect(jsonPath("$.tripStatistics.terminatedTripCnt").value(terminatedTripCnt));

--- a/src/test/java/com/cosain/trilo/support/IntegrationTest.java
+++ b/src/test/java/com/cosain/trilo/support/IntegrationTest.java
@@ -85,7 +85,7 @@ public class IntegrationTest {
 
     private User createMockUser(String email, AuthProvider authProvider) {
         User mockUser = User.builder()
-                .name("사용자")
+                .nickName("사용자")
                 .email(email)
                 .profileImageUrl("https://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg")
                 .authProvider(authProvider)

--- a/src/test/java/com/cosain/trilo/unit/user/application/UserServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/user/application/UserServiceTest.java
@@ -210,7 +210,7 @@ public class UserServiceTest {
             UserMyPageResponse myPageResponse = userService.getMyPage(userId, today);
 
             // then
-            assertThat(myPageResponse.getName()).isEqualTo(user.getName());
+            assertThat(myPageResponse.getNickName()).isEqualTo(user.getNickName());
             assertThat(myPageResponse.getTripStatistics().getTotalTripCnt()).isEqualTo(tripStatistics.getTotalTripCnt());
             assertThat(myPageResponse.getTripStatistics().getTerminatedTripCnt()).isEqualTo(tripStatistics.getTerminatedTripCnt());
         }

--- a/src/test/java/com/cosain/trilo/unit/user/presentation/UserRestControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/user/presentation/UserRestControllerDocsTest.java
@@ -64,7 +64,7 @@ public class UserRestControllerDocsTest extends RestDocsTestSupport {
                         ),
                         responseFields(
                                 fieldWithPath("id").type(JsonFieldType.NUMBER).description("회원 ID"),
-                                fieldWithPath("name").type(JsonFieldType.STRING).description("회원 이름"),
+                                fieldWithPath("nickName").type(JsonFieldType.STRING).description("회원 이름"),
                                 fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
                                 fieldWithPath("profileImageURL").type(JsonFieldType.STRING).description("회원 프로필 이미지 URL(경로)"),
                                 fieldWithPath("authProvider").type(JsonFieldType.STRING).description("소셜 로그인 제공자"),
@@ -122,7 +122,7 @@ public class UserRestControllerDocsTest extends RestDocsTestSupport {
                                 parameterWithName("userId").description("조회할 회원 ID")
                         ),
                         responseFields(
-                                fieldWithPath("name").type(JsonFieldType.STRING).description("회원 이름"),
+                                fieldWithPath("nickName").type(JsonFieldType.STRING).description("회원 이름"),
                                 fieldWithPath("imageURL").type(JsonFieldType.STRING).description("이미지 URL"),
                                 subsectionWithPath("tripStatistics").type("TripStatistics").description("여행 통계 정보 (하단 표 참고)")
                         ),


### PR DESCRIPTION
# JIRA 티켓
[TRL-418] 

# 작업 내역

- [x] 사용자 닉네임 필드명 변경 (`name` -> `nickName`)
- [x] 마이페이지 조회 응답 필드명 변경 (`name` -> `nickName`)
- [x] 프로필 조회 응답 필드명 변경 (`name` -> `nickName`)

# 설명

초기 소셜 로그인으로 Resource Server 에서 사용자에 대한 정보를 받아와서 사용자의 `name` 필드를 초기화했습니다. 서비스에서는 사실 상 사용될 일이 없는 `name` 을 두기보다는 `nickName` 필드로 수정하여 이후 커스텀하게 사용자가 수정할 수 있도록 할 생각이기 때문에 거기에 어울리게 기존 `name` 필드명을 `nickName` 으로 수정합니다.

따라서 기존 프로필 조회 API & 마이페이지 조회 API 응답 필드 `name` 을 `nickName` 으로 수정했습니다. 

[TRL-418]: https://cosain.atlassian.net/browse/TRL-418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ