### PR TITLE
[TRL-430] refactor: 회원 탈퇴 기능 이벤트 처리 방식 변경

### DIFF
--- a/src/main/java/com/cosain/trilo/trip/application/event/TripEventListener.java
+++ b/src/main/java/com/cosain/trilo/trip/application/event/TripEventListener.java
@@ -3,9 +3,8 @@ package com.cosain.trilo.trip.application.event;
 import com.cosain.trilo.trip.application.trip.service.trip_all_delete.TripAllDeleteService;
 import com.cosain.trilo.user.application.event.UserDeleteEvent;
 import lombok.RequiredArgsConstructor;
-import org.springframework.scheduling.annotation.Async;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
@@ -13,8 +12,7 @@ public class TripEventListener {
 
     private final TripAllDeleteService tripAllDeleteService;
 
-    @Async
-    @TransactionalEventListener
+    @EventListener
     public void handle(UserDeleteEvent event){
         Long tripperId = event.getUserId();
         tripAllDeleteService.deleteAllByTripperId(tripperId);


### PR DESCRIPTION
# JIRA 티켓
[TRL-430]

# 작업 내역

- [x] 회원 탈퇴 기능 이벤트 처리 방식 변경

# 설명 

SQL 스크립트를 통해 User-Trip 간 외래키 제약을 추가함에 따라 비동기로 이벤트를 발행할 경우, 참조 무결성 원칙을 위반합니다. 
이 부분은 서로 의견차이가 있으므로 일단, 동기적으로 처리하도록 하여 문제를 해결하고, 추후 여러 질문글을 취합하여 필요하다면 다시 변경하도록 하겠습니다.

[TRL-430]: https://cosain.atlassian.net/browse/TRL-430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ