### PR TITLE
[TRL-440] fix: 일정 제목 길이 제약조건 수정(20자 -> 35자)

### DIFF
--- a/src/main/java/com/cosain/trilo/trip/domain/vo/ScheduleTitle.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/vo/ScheduleTitle.java
@@ -12,7 +12,7 @@ import lombok.*;
 @Embeddable
 public class ScheduleTitle {
 
-    private static final int MAX_LENGTH = 20;
+    private static final int MAX_LENGTH = 35;
 
     @Column(name = "schedule_title")
     private String value;

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -38,7 +38,7 @@ CREATE TABLE IF NOT EXISTS `trilo_db`.`schedules` (
     trip_id          BIGINT      NOT NULL,
     day_id           BIGINT,
     schedule_index   BIGINT      NOT NULL,
-    schedule_title   VARCHAR(20) NOT NULL,
+    schedule_title   VARCHAR(35) NOT NULL,
     schedule_content TEXT        NOT NULL,
     place_id         VARCHAR(255),
     place_name       VARCHAR(255),

--- a/src/test/java/com/cosain/trilo/integration/trip/ScheduleCreateIntegrationTest.java
+++ b/src/test/java/com/cosain/trilo/integration/trip/ScheduleCreateIntegrationTest.java
@@ -406,13 +406,13 @@ class ScheduleCreateIntegrationTest extends IntegrationTest {
                 .andExpect(jsonPath("$.errors[0].errorDetail").exists());
     }
     @Test
-    @DisplayName("20자를 넘는 일정 제목 -> 입력 검증 실패 400 예외")
+    @DisplayName("35자를 넘는 일정 제목 -> 입력 검증 실패 400 예외")
     public void tooLongScheduleTitle() throws Exception {
         // given
         User user = setupMockNaverUser();
         Trip trip = setupUndecidedTrip(user.getId());
 
-        String tooLongTitle = "가".repeat(21);
+        String tooLongTitle = "가".repeat(36);
         var request = defaultRequestBuilder(null, trip.getId()).title(tooLongTitle).build();
         flushAndClear();
 

--- a/src/test/java/com/cosain/trilo/unit/trip/application/schedule/service/schedule_create/ScheduleCreateCommandFactoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/schedule/service/schedule_create/ScheduleCreateCommandFactoryTest.java
@@ -136,13 +136,13 @@ public class ScheduleCreateCommandFactoryTest {
         assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidScheduleTitleException.class);
     }
 
-    @DisplayName("제목이 20자보다 긴 문자열 -> 검증 예외 발생")
+    @DisplayName("제목이 35자보다 긴 문자열 -> 검증 예외 발생")
     @Test
     void tooLongScheduleTitleTest() {
         // given
         Long dayId = 1L;
         Long tripId = 1L;
-        String rawScheduleTitle = "가".repeat(21);
+        String rawScheduleTitle = "가".repeat(36);
         String placeId = "place-id";
         String placeName = "place-name";
         Double latitude = 39.123;

--- a/src/test/java/com/cosain/trilo/unit/trip/application/schedule/service/schedule_update/ScheduleUpdateCommandFactoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/schedule/service/schedule_update/ScheduleUpdateCommandFactoryTest.java
@@ -44,11 +44,11 @@ public class ScheduleUpdateCommandFactoryTest {
         assertThat(scheduleUpdateCommand.getScheduleTime()).isEqualTo(ScheduleTime.of(startTime, endTime));
     }
 
-    @DisplayName("제목이 20자보다 긴 문자열 -> 검증 예외 발생")
+    @DisplayName("제목이 35자보다 긴 문자열 -> 검증 예외 발생")
     @Test
     void tooLongScheduleTitleTest() {
         // given
-        String rawScheduleTitle = "가".repeat(21);
+        String rawScheduleTitle = "가".repeat(36);
         String rawScheduleContent = "일정 본문";
         LocalTime startTime = LocalTime.of(13,0);
         LocalTime endTime = LocalTime.of(13,5);

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/vo/ScheduleTitleTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/vo/ScheduleTitleTest.java
@@ -39,10 +39,10 @@ public class ScheduleTitleTest {
     }
 
     @Test
-    @DisplayName("20자보다 긴 제목 -> InvalidScheduleTitleException 발생")
+    @DisplayName("35자보다 긴 제목 -> InvalidScheduleTitleException 발생")
     void tooLongScheduleTitleTest() {
         // given
-        String tooLongTitle = "A".repeat(21);
+        String tooLongTitle = "A".repeat(36);
 
         // when
         assertThatThrownBy(() -> ScheduleTitle.of(tooLongTitle))

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/docs/ScheduleUpdateControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/schedule/docs/ScheduleUpdateControllerDocsTest.java
@@ -91,7 +91,7 @@ public class ScheduleUpdateControllerDocsTest extends RestDocsTestSupport {
                                 fieldWithPath("title")
                                         .type(STRING)
                                         .description("일정의 제목")
-                                        .attributes(key("constraints").value("null 일 수 없으며, 길이는 20자 이하까지 허용됩니다. (공백, 빈 문자열 허용)")),
+                                        .attributes(key("constraints").value("null 일 수 없으며, 길이는 35자 이하까지 허용됩니다. (공백, 빈 문자열 허용)")),
                                 fieldWithPath("content")
                                         .type(STRING)
                                         .description("일정의 본문")

--- a/src/test/resources/test_schema.sql
+++ b/src/test/resources/test_schema.sql
@@ -38,7 +38,7 @@ CREATE TABLE IF NOT EXISTS `trilo_db_test`.`schedules` (
     trip_id BIGINT NOT NULL,
     day_id BIGINT,
     schedule_index BIGINT NOT NULL,
-    schedule_title VARCHAR(20) NOT NULL,
+    schedule_title VARCHAR(35) NOT NULL,
     schedule_content TEXT NOT NULL,
     place_id VARCHAR(255),
     place_name VARCHAR(255),


### PR DESCRIPTION
# JIRA 티켓
- [TRL-440]

# 작업 내역
- [x] 일정 제목 길이 제약 조건 20자 -> 35자 수정
- [x] 일정 제목 데이터베이스 칼럼 타입 VARCHAR(35)로 수정

# 설명

# 참고자료


[TRL-440]: https://cosain.atlassian.net/browse/TRL-440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ