### PR TITLE
[TRL-451] docs: 여행 생성 기능 - 주석 추가 및 JavaDoc 작성

### DIFF
--- a/src/main/java/com/cosain/trilo/common/exception/trip/InvalidTripTitleException.java
+++ b/src/main/java/com/cosain/trilo/common/exception/trip/InvalidTripTitleException.java
@@ -1,4 +1,4 @@
-package com.cosain.trilo.trip.domain.exception;
+package com.cosain.trilo.common.exception.trip;
 
 import com.cosain.trilo.common.exception.CustomException;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/cosain/trilo/trip/application/trip/service/trip_create/TripCreateCommand.java
+++ b/src/main/java/com/cosain/trilo/trip/application/trip/service/trip_create/TripCreateCommand.java
@@ -9,18 +9,39 @@ import lombok.Getter;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * 여행 생성에 필요한 명령(command, 비즈니스 입력 모델)입니다.
+ * @see TripCreateService
+ */
 @Getter
 @EqualsAndHashCode(of = {"tripperId", "tripTitle"})
 public class TripCreateCommand {
 
+    /**
+     * 여행 생성을 시도하는 여행자(사용자) 식별자
+     */
     private final long tripperId;
+
+    /**
+     * 생성하고자 하는 여행의 제목
+     * @see TripTitle
+     */
     private final TripTitle tripTitle;
 
-    public static TripCreateCommand of(Long tripperId, String rawTitle) {
-        List<CustomException> exceptions = new ArrayList<>();
+    /**
+     * 여행 생성 명령(비즈니스 입력 모델)을 생성합니다.
+     * @param tripperId : 여행 생성을 시도하는 여행자(사용자) 식별자)
+     * @param rawTitle : 생성하고자 하는 여행의 제목
+     * @return 여행생성명령
+     * @throws CustomValidationException : 명령 생성과정에서 발생한 예외들을 묶은 예외
+     */
+    public static TripCreateCommand of(Long tripperId, String rawTitle) throws CustomValidationException {
+        List<CustomException> exceptions = new ArrayList<>(); // 발생 예외를 수집할 예외 수집기
 
-        TripTitle tripTitle = makeTripTitle(rawTitle, exceptions);
+        TripTitle tripTitle = makeTripTitleAndValidate(rawTitle, exceptions); // 여행 제목 생성 및 비즈니스 입력 검증
+
         if (!exceptions.isEmpty()) {
+            // 입력 검증 과정에서 예외가 하나라도 발생할 경우 이들을 모아서, 검증 예외를 발생시킴.
             throw new CustomValidationException(exceptions);
         }
         return new TripCreateCommand(tripperId, tripTitle);
@@ -31,10 +52,19 @@ public class TripCreateCommand {
         this.tripTitle = tripTitle;
     }
 
-    private static TripTitle makeTripTitle(String rawTitle, List<CustomException> exceptions) {
+    /**
+     * <p>여행제목({@link TripTitle})을 생성하고, 이 과정에서 여행 제목에 대한 입력 검증을 수행합니다.</p>
+     * <p>여행제목 생성 과정에서 예외가 발생하면 예외 수집기에 비즈니스 예외를 수집합니다.</p>
+     * @param rawTitle : 여행의 제목
+     * @param exceptions : 검증 과정에서 발생한 예외를 수집할 컬렉션
+     * @return 정상적인 입력이면 여행 제목 객체를, 그렇지 않을 경우 null 반환
+     * @see TripTitle
+     */
+    private static TripTitle makeTripTitleAndValidate(String rawTitle, List<CustomException> exceptions) {
         try {
             return TripTitle.of(rawTitle);
         } catch (CustomException e) {
+            // 비즈니스 예외가 발생할 경우 예외 수집
             exceptions.add(e);
         }
         return null;

--- a/src/main/java/com/cosain/trilo/trip/application/trip/service/trip_create/TripCreateService.java
+++ b/src/main/java/com/cosain/trilo/trip/application/trip/service/trip_create/TripCreateService.java
@@ -6,20 +6,27 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+/**
+ * 여행 생성을 수행하는 애플리케이션 서비스입니다.
+ */
 @Service
 @RequiredArgsConstructor
 public class TripCreateService {
 
+    /**
+     * 생성 여행을 저장할 리포지토리
+     */
     private final TripRepository tripRepository;
 
     /**
-     * Trip을 생성하여 등록하고, 식별자를 반환합니다.
-     * @param createCommand : 여행 생성에 필요한 정보들
-     * @return 생성된 여행의 식별자
+     * Trip(여행)을 생성하여 등록하고, 생성된 여행의 식별자(id)를 반환합니다.
+     * @param command : 여행 생성 명령(비즈니스 입력 모델)
+     * @return 생성된 여행의 식별자(id)
+     * @see TripCreateCommand
      */
     @Transactional
-    public Long createTrip(TripCreateCommand createCommand) {
-        Trip trip = Trip.create(createCommand.getTripTitle(), createCommand.getTripperId());
+    public Long createTrip(TripCreateCommand command) {
+        Trip trip = Trip.create(command.getTripTitle(), command.getTripperId());
         Trip savedTrip = tripRepository.save(trip);
         return savedTrip.getId();
     }

--- a/src/main/java/com/cosain/trilo/trip/domain/entity/Trip.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/entity/Trip.java
@@ -17,6 +17,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
+/**
+ * 여행의 도메인 엔티티(Entity)입니다.
+ */
 @Getter
 @Slf4j
 @ToString(of = {"id", "tripperId", "tripTitle", "status", "tripPeriod", "tripImage"})
@@ -25,43 +28,87 @@ import java.util.Random;
 @Entity
 public class Trip {
 
+    /**
+     * 하나의 여행이 가질 수 있는 일정의 최대 갯수
+     */
     public static final int MAX_TRIP_SCHEDULE_COUNT = 110;
 
+    /**
+     * 여행의 식별자(id)
+     */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "trip_id")
     private Long id;
 
+    /**
+     * 여행을 소유한 여행자(사용자)의 식별자(id)
+     */
     @Column(name = "tripper_id")
     private Long tripperId;
 
+    /**
+     * 여행의 제목
+     * @see TripTitle
+     */
     @Embedded
     private TripTitle tripTitle;
 
+    /**
+     * 여행의 상태
+     * @see TripStatus
+     */
     @Enumerated(EnumType.STRING)
     @Column(name = "trip_status")
     private TripStatus status;
 
+    /**
+     * 여행의 기간
+     * @see TripPeriod
+     */
     @Embedded
     private TripPeriod tripPeriod;
 
+    /**
+     * 여행에 소속된 Day들의 컬렉션
+     * @see Day
+     */
     @OneToMany(mappedBy = "trip")
     private final List<Day> days = new ArrayList<>();
 
+    /**
+     * 여행의 이미지
+     * @see TripImage
+     */
     @Embedded
     private TripImage tripImage;
 
+    /**
+     * <p>여행의 임시보관함에 소속된 일정({@link Schedule})들의 컬렉션입니다. 어떤 {@link Day}에도 속해있지 않은 일정들이 여기에 보관됩니다.</p>
+     * <p>일정들은 {@link ScheduleIndex} 기준 오름차순으로 정렬되어 있습니다.</p>
+     * @see Schedule
+     * @see ScheduleIndex
+     */
     @OneToMany(mappedBy = "trip")
     @Where(clause = "day_id is NULL")
     @OrderBy("scheduleIndex.value asc")
     private final List<Schedule> temporaryStorage = new ArrayList<>();
 
     /**
-     * 여행(Trip)을 최초로 생성합니다. 최초 생성된 Trip은 UNDECIDED 상태입니다.
-     *
+     * <p>여행(Trip)을 최초로 생성합니다.</p>
+     * <p>명시적으로 전달된 파라미터 외의 필드들은 다음과 같이 초기화됩니다.</p>
+     * <ul>
+     *     <li>id : null (리포지토리에 저장 후 발급받아서 초기화해야합니다.)</li>
+     *     <li>status : {@link TripStatus#UNDECIDED}</li>
+     *     <li>period : {@link TripPeriod#empty()}</li>
+     *     <li>image : {@link TripImage#defaultImage()}</li>
+     * </ul>
      * @param tripTitle:    여행의 제목
      * @param tripperId : 여행자의 식별자
-     * @return 생성된 Trip
+     * @return 생성된 여행(Trip)
+     * @see TripStatus
+     * @see TripPeriod
+     * @see TripImage
      */
     public static Trip create(TripTitle tripTitle, Long tripperId) {
         return Trip.builder()

--- a/src/main/java/com/cosain/trilo/trip/domain/repository/TripRepository.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/repository/TripRepository.java
@@ -6,8 +6,16 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * 여행 엔티티 또는 여행 엔티티에 관한 정보를 조회해오거나 등록/수정/삭제하는 리포지토리입니다.
+ */
 public interface TripRepository {
 
+    /**
+     * 여행을 저장소에 등록 후, 저장된 여행을 반환받습니다.
+     * @param trip : 저장할 여행
+     * @return : 저장된 여행
+     */
     Trip save(Trip trip);
 
     Optional<Trip> findById(Long tripId);

--- a/src/main/java/com/cosain/trilo/trip/domain/vo/TripImage.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/vo/TripImage.java
@@ -2,15 +2,13 @@ package com.cosain.trilo.trip.domain.vo;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 /**
  * 여행이미지 VO(값 객체)입니다.
  */
 @Getter
+@EqualsAndHashCode(of = {"fileName"})
 @ToString(of = {"fileName"})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Embeddable

--- a/src/main/java/com/cosain/trilo/trip/domain/vo/TripImage.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/vo/TripImage.java
@@ -7,25 +7,47 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+/**
+ * 여행이미지 VO(값 객체)입니다.
+ */
 @Getter
 @ToString(of = {"fileName"})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Embeddable
 public class TripImage {
 
-    public static final String DEFAULT_IMAGE_NAME = "trips/trip-default-image.png";
+    /**
+     * 여행이미지의 디폴트 파일명
+     */
+    private static final String DEFAULT_IMAGE_NAME = "trips/trip-default-image.png";
+
+    /**
+     * 여행이미지 디폴트 VO(값 객체)
+     */
     private static final TripImage DEFAULT_IMAGE = new TripImage(DEFAULT_IMAGE_NAME);
 
+    /**
+     * 여행이미지의 파일명
+     */
     @Column(name = "trip_image_file_name")
     private String fileName;
 
+    /**
+     * 여행이미지 VO(값 객체)를 생성합니다.
+     * @param fileName : 이미지 파일명
+     * @return : 여행 이미지 VO(값 객체)
+     */
     public static TripImage of(String fileName) {
-        if (fileName.equals(DEFAULT_IMAGE_NAME)) {
-            return DEFAULT_IMAGE;
-        }
-        return new TripImage(fileName);
+        return fileName.equals(DEFAULT_IMAGE_NAME)
+                ? DEFAULT_IMAGE
+                : new TripImage(fileName);
     }
 
+    /**
+     * 여행이미지 디폴트 VO(값 객체)를 반환합니다.
+     * @return 여행 이미지 디폴트 VO(값 객체)
+     * @see TripImage#DEFAULT_IMAGE
+     */
     public static TripImage defaultImage() {
         return DEFAULT_IMAGE;
     }

--- a/src/main/java/com/cosain/trilo/trip/domain/vo/TripPeriod.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/vo/TripPeriod.java
@@ -10,6 +10,9 @@ import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.stream.Stream;
 
+/**
+ * 여행 기간을 정의한 VO(값 객체)입니다.
+ */
 @Getter
 @ToString(of = {"startDate", "endDate"})
 @EqualsAndHashCode(of = {"startDate", "endDate"})
@@ -17,17 +20,42 @@ import java.util.stream.Stream;
 @Embeddable
 public class TripPeriod {
 
+    /**
+     * 여행 기간이 정해지지 않았을 때의, 여행 기간
+     *
+     * @see TripStatus#UNDECIDED
+     */
     private static final TripPeriod EMPTY_PERIOD = new TripPeriod(null, null);
+
+    /**
+     * 여행 기간의 최대 일수
+     */
     public static final int MAX_DAYS = 10;
 
+    /**
+     * 여행의 시작일
+     */
     @Column(name = "start_date")
     private LocalDate startDate;
 
+    /**
+     * 여행의 종료일
+     */
     @Column(name = "end_date")
     private LocalDate endDate;
 
-    public static TripPeriod of(LocalDate startDate, LocalDate endDate) {
+    /**
+     * 여행기간 VO(값 객체)를 생성합니다.
+     *
+     * @param startDate 여행의 시작일
+     * @param endDate   여행의 종료일
+     * @return 여행기간 VO(값 객체)
+     * @throws InvalidPeriodException 시작일 또는 종료일 어느 한 쪽이 null이거나, 종료일이 시작일보다 앞설 때
+     * @throws TooLongPeriodException 여행기간의 일수가, 시스템에서 허용하는 최대 일수를 넘을 때
+     */
+    public static TripPeriod of(LocalDate startDate, LocalDate endDate) throws InvalidPeriodException, TooLongPeriodException {
         if (startDate == null && endDate == null) {
+            // 시작일과 종료일이 모두 null 인 경우는 비즈니스 규칙적으로 허용함. (빈 기간)
             return EMPTY_PERIOD;
         }
         validateDateCombination(startDate, endDate);
@@ -35,18 +63,35 @@ public class TripPeriod {
         return new TripPeriod(startDate, endDate);
     }
 
-    private static void validateDateCombination(LocalDate startDate, LocalDate endDate) {
+    /**
+     * 여행 기간의 시작일, 종료일 조합의 유효성을 검증합니다.
+     *
+     * @param startDate 여행의 시작일
+     * @param endDate   여행의 종료일
+     * @throws InvalidPeriodException 시작일 또는 종료일 어느 한 쪽이 null이거나, 종료일이 시작일보다 앞설 때
+     */
+    private static void validateDateCombination(LocalDate startDate, LocalDate endDate) throws InvalidPeriodException {
         if ((startDate != null && endDate == null) || (startDate == null && endDate != null)) {
+            // 어느 한 쪽만 null인 경우는 비즈니스 규칙적으로 허용하지 않음
             throw new InvalidPeriodException("시작일 또는 종료일 어느 한 쪽만 null일 수 없습니다.");
         }
         if (endDate.isBefore(startDate)) {
+            // 종료일이 시작일보다 앞서는 경우는 비즈니스 규칙적으로 허용하지 않음
             throw new InvalidPeriodException("종료일이 시작일보다 앞섭니다.");
         }
     }
 
+    /**
+     * 여행기간의 일수가 유효한 지 검증합니다.
+     *
+     * @param startDate 여행의 시작일
+     * @param endDate   여행의 종료일
+     * @throws TooLongPeriodException 여행기간의 일수가, 시스템에서 허용하는 최대 일수를 넘을 때
+     */
     private static void validateDayLength(LocalDate startDate, LocalDate endDate) {
         long numberOfDays = ChronoUnit.DAYS.between(startDate, endDate) + 1; // between은 날짜의 차를 구하므로, 사이에 속한 일수를 구하려면 1을 더해야함.
         if (numberOfDays > MAX_DAYS) {
+            // 기간에 속한 여행 일수가, 최대 여행 일수보다 많은 경우는 비즈니스 규칙적으로 허용하지 않음
             throw new TooLongPeriodException("여행 일수가 너무 많음.");
         }
     }
@@ -57,17 +102,16 @@ public class TripPeriod {
     }
 
     /**
-     * 기간이 없는 TripPeriod를 반환합니다.
+     * 기간이 없는(시작일, 종료일 모두 없는) TripPeriod를 반환합니다.
      */
     public static TripPeriod empty() {
         return EMPTY_PERIOD;
     }
 
     /**
-     * 겹치는 기간을 반환합니다.
-     *
-     * @param other
-     * @return
+     * 전달받은 다른 여행 기간과, 겹치는 여행기간을 반환합니다.
+     * @param other 다른 여행 기간
+     * @return 겹치는 여행 기간
      */
     public TripPeriod intersection(TripPeriod other) {
         return hasNoIntersection(other)
@@ -75,25 +119,45 @@ public class TripPeriod {
                 : calculateIntersectionPeriod(other);
     }
 
+    /**
+     * 다른 여행기간과 겹치는 구간이 없는 지 여부를 반환합니다.
+     * @param other : 다른 여행기간
+     * @return 겹치는 구간이 없으면 true, 겹치는 구간이 있으면 false
+     */
     private boolean hasNoIntersection(TripPeriod other) {
-        return this.equals(empty()) || other.equals(empty()) || this.startDate.isAfter(other.endDate) || this.endDate.isBefore(other.startDate);
+        return this.equals(EMPTY_PERIOD) // 자신이 빈 기간이거나
+                || other.equals(EMPTY_PERIOD) // 다른 쪽이 빈 기간이거나
+                || this.startDate.isAfter(other.endDate)  // 자신의 시작일이 반대쪽의 종료일 이후거나
+                || this.endDate.isBefore(other.startDate); // 자신의 종료일이 반대쪽의 시작일 이전일 때
     }
 
+    /**
+     * 다른 여행기간과, 겹치는 여행기간을 반환합니다.(앞에서 겹치는 여행기간이 있음이 확인됐음을 전제)
+     * @param other 다른 여행기간
+     * @return 겹치는 여행기간
+     */
     private TripPeriod calculateIntersectionPeriod(TripPeriod other) {
         LocalDate newStartDate = this.startDate.isAfter(other.startDate) ? this.startDate : other.startDate;
         LocalDate newEndDate = this.endDate.isBefore(other.endDate) ? this.endDate : other.endDate;
         return TripPeriod.of(newStartDate, newEndDate);
     }
 
+    /**
+     * 파라미터로 전달된 날짜가 여행기간에 속하는 지 여부를 반환합니다.
+     * @param date 날짜
+     * @return 해당 날짜가 여행 기간에 속하면 true, 속하지 않으면 false
+     */
     public boolean contains(LocalDate date) {
-        return !this.equals(empty()) &&
+        return !this.equals(EMPTY_PERIOD) // 자신이 비어있지 않은 기간이고
+                &&
+                // 파라미터의 date가 시작일이거나, 시작일 이후 이고 종료일 이전이거나, 종료일일 때
                 (date.isEqual(startDate) || (date.isAfter(startDate) && date.isBefore(endDate)) || date.isEqual(endDate));
     }
 
     /**
-     * 해당 기간에 속하는 날짜들을 Stream으로 반환합니다.
-     *
-     * @return
+     * 여행기간에 속하는 날짜들을 Stream으로 반환합니다.
+     * @return 기간에 속하는 날짜들의 Stream
+     * @see Stream
      */
     public Stream<LocalDate> dateStream() {
         if (this.equals(EMPTY_PERIOD)) {

--- a/src/main/java/com/cosain/trilo/trip/domain/vo/TripStatus.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/vo/TripStatus.java
@@ -1,8 +1,27 @@
 package com.cosain.trilo.trip.domain.vo;
 
+/**
+ * <p>여행의 상태를 정의한 enum입니다. 여행은 다음 3가지 상태 중 하나를 가집니다.</p>
+ * <ul>
+ *     <li>{@link TripStatus#UNDECIDED}</li>
+ *     <li>{@link TripStatus#DECIDED}</li>
+ *     <li>{@link TripStatus#FINISHED}</li>
+ * </ul>
+ */
 public enum TripStatus {
 
+    /**
+     * 여행의 기간이 정해지지 않은 경우
+     */
     UNDECIDED,
+
+    /**
+     * 여행의 기간이 정해진 경우
+     */
     DECIDED,
+
+    /**
+     * 여행이 완료된 경우
+     */
     FINISHED
 }

--- a/src/main/java/com/cosain/trilo/trip/domain/vo/TripTitle.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/vo/TripTitle.java
@@ -5,6 +5,9 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.*;
 
+/**
+ * 여행제목 VO(값 객체)입니다.
+ */
 @Getter
 @ToString(of = {"value"})
 @EqualsAndHashCode(of = {"value"})
@@ -12,23 +15,49 @@ import lombok.*;
 @Embeddable
 public class TripTitle {
 
+    /**
+     * 여행 제목의 최소 길이 제한입니다.
+     */
     private static final int MIN_LENGTH = 1;
+
+    /**
+     * 여행 제목의 최대 길이 제한입니다.
+     */
     private static final int MAX_LENGTH = 20;
 
+    /**
+     * 여행제목의 원시 문자열 값입니다.
+     */
     @Column(name = "trip_title")
     private String value;
 
-    public static TripTitle of(String value) {
+    /**
+     * 여행제목 VO(값 객체)를 생성합니다.
+     * @param value : 여행 제목 문자열
+     * @return 여행 제목 VO(값 객체)
+     * @throws InvalidTripTitleException : 여행 제목이 유효하지 않을 때
+     */
+    public static TripTitle of(String value) throws InvalidTripTitleException {
         if (isNullOrBlank(value) || hasInvalidLength(value)) {
             throw new InvalidTripTitleException("null 또는 공백이거나, 길이 조건에 맞지 않는 여행 제목");
         }
         return new TripTitle(value);
     }
 
+    /**
+     * 여행 제목이 null 또는 공백으로만 구성됐는 지 여부를 반환합니다.
+     * @param value : 여행 제목 문자열
+     * @return 여행 제목이 null 이거나 공백으로만 구성되면 true, 아니면 false
+     */
     private static boolean isNullOrBlank(String value) {
         return value == null || value.isBlank();
     }
 
+    /**
+     * 여행 제목이 유효하지 않은 길이를 가졌는 지 여부를 반환합니다.
+     * @param value : 여행 제목
+     * @return 여행 제목 길이가 유효하지 않으면 true, 유효하면 false
+     */
     private static boolean hasInvalidLength(String value) {
         return value.length() < MIN_LENGTH || value.length() > MAX_LENGTH;
     }

--- a/src/main/java/com/cosain/trilo/trip/domain/vo/TripTitle.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/vo/TripTitle.java
@@ -1,6 +1,6 @@
 package com.cosain.trilo.trip.domain.vo;
 
-import com.cosain.trilo.trip.domain.exception.InvalidTripTitleException;
+import com.cosain.trilo.common.exception.trip.InvalidTripTitleException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.*;

--- a/src/main/java/com/cosain/trilo/trip/domain/vo/TripTitle.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/vo/TripTitle.java
@@ -12,8 +12,8 @@ import lombok.*;
 @Embeddable
 public class TripTitle {
 
-    public static final int MIN_LENGTH = 1;
-    public static final int MAX_LENGTH = 20;
+    private static final int MIN_LENGTH = 1;
+    private static final int MAX_LENGTH = 20;
 
     @Column(name = "trip_title")
     private String value;

--- a/src/main/java/com/cosain/trilo/trip/infra/repository/TripRepositoryImpl.java
+++ b/src/main/java/com/cosain/trilo/trip/infra/repository/TripRepositoryImpl.java
@@ -9,14 +9,27 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * 여행 엔티티 또는 여행 엔티티에 관한 정보를 조회해오거나 등록/수정/삭제하는 리포지토리 구현체입니다.
+ * @see TripRepository
+ */
 @Component
 @RequiredArgsConstructor
 public class TripRepositoryImpl implements TripRepository {
 
+    /**
+     * Trip 엔티티를 조회해오는 Spring Data JPA Repository
+     */
     private final JpaTripRepository jpaTripRepository;
 
+    /**
+     * <p>여행을 저장하고, 저장된 여행을 반환합니다. </p>
+     * @param trip : 저장할 여행
+     * @return 저장된 여행
+     */
     @Override
     public Trip save(Trip trip) {
+        // JPA에 의해 여행 엔티티가 저장되고 식별자(id)가 초기화된 뒤 동일한 참조의 객체가 그대로 반환됨에 주의
         return jpaTripRepository.save(trip);
     }
 

--- a/src/main/java/com/cosain/trilo/trip/presentation/trip/TripCreateController.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/trip/TripCreateController.java
@@ -3,6 +3,7 @@ package com.cosain.trilo.trip.presentation.trip;
 import com.cosain.trilo.auth.application.token.UserPayload;
 import com.cosain.trilo.auth.presentation.Login;
 import com.cosain.trilo.auth.presentation.LoginUser;
+import com.cosain.trilo.common.exception.CustomValidationException;
 import com.cosain.trilo.trip.application.trip.service.trip_create.TripCreateCommand;
 import com.cosain.trilo.trip.application.trip.service.trip_create.TripCreateService;
 import com.cosain.trilo.trip.presentation.trip.dto.request.TripCreateRequest;
@@ -10,30 +11,42 @@ import com.cosain.trilo.trip.presentation.trip.dto.response.TripCreateResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 여행 생성 웹 요청을 처리하는 Controller
+ */
 @Slf4j
 @RequiredArgsConstructor
 @RestController
 public class TripCreateController {
 
+    /**
+     * 여행 생성 서비스
+     */
     private final TripCreateService tripCreateService;
 
-    @PostMapping("/api/trips")
+    /**
+     * 사용자 여행 생성 웹 요청({@link TripCreateRequest})을 받아 처리 후, 생성된 여행에 대한 정보({@link TripCreateResponse})를 응답합니다.
+     * @param userPayload : 인증 사용자 정보
+     * @param request : 사용자 여행 생성 웹 요청
+     * @return 생성된 여행에 대한 정보
+     * @throws CustomValidationException : 비즈니스 입력 검증에서 발생한 검증 예외
+     * @see TripCreateRequest
+     * @see TripCreateResponse
+     */
     @Login
-    public ResponseEntity<TripCreateResponse> createTrip(@LoginUser UserPayload userPayload, @RequestBody TripCreateRequest request) {
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/api/trips")
+    public TripCreateResponse createTrip(@LoginUser UserPayload userPayload, @RequestBody TripCreateRequest request) throws CustomValidationException {
         Long tripperId = userPayload.getId();
-        var command = TripCreateCommand.of(tripperId, request.getTitle());
+        var command = TripCreateCommand.of(tripperId, request.getTitle()); // 비즈니스 입력 모델로 변환하는 과정에서 검증 예외 발생할 수 있음
 
         Long tripId = tripCreateService.createTrip(command);
-        var response = TripCreateResponse.from(tripId);
-
-        return ResponseEntity
-                .status(HttpStatus.CREATED)
-                .body(response);
+        return TripCreateResponse.from(tripId);
     }
 
 }

--- a/src/main/java/com/cosain/trilo/trip/presentation/trip/dto/request/TripCreateRequest.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/trip/dto/request/TripCreateRequest.java
@@ -4,12 +4,22 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 여행 생성을 위한 정보를 이 객체에 바인딩합니다.
+ */
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TripCreateRequest {
 
+    /**
+     * 생성할 여행의 제목
+     */
     private String title;
 
+    /**
+     * 여행생성요청을 생성합니다.
+     * @param title : 생성할 여행의 제목
+     */
     public TripCreateRequest(String title) {
         this.title = title;
     }

--- a/src/main/java/com/cosain/trilo/trip/presentation/trip/dto/response/TripCreateResponse.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/trip/dto/response/TripCreateResponse.java
@@ -4,11 +4,24 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 여행 생성 후, 응답을 바인딩할 객체입니다.
+ * <p>생성된 여행에 대한 정보가 바인딩됩니다.</p>
+ */
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TripCreateResponse {
 
+    /**
+     * 생성된 여행의 식별자(id)
+     */
     private Long tripId;
+
+    /**
+     * 여행생성응답을 생성합니다.
+     * @param tripId : 생성된 여행의 식별자(id)
+     * @return 여행생성응답
+     */
     public static TripCreateResponse from(Long tripId) {
         return new TripCreateResponse(tripId);
     }

--- a/src/test/java/com/cosain/trilo/integration/trip/TripCreateIntegrationTest.java
+++ b/src/test/java/com/cosain/trilo/integration/trip/TripCreateIntegrationTest.java
@@ -26,39 +26,49 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+/**
+ * 여행 생성 기능에 대한 통합 테스트 클래스입니다.
+ */
 @Slf4j
 @DisplayName("[통합] 여행 생성 API 테스트")
 public class TripCreateIntegrationTest extends IntegrationTest {
 
+    /**
+     * 테스트에서 여행의 저장 여부를 확인하기 위한 리포지토리 의존성
+     */
     @Autowired
-    TripRepository tripRepository;
+    private TripRepository tripRepository;
 
+
+    /**
+     * <p>여행 생성 요청을 했을 때, 여행생성 기능이 잘 동작하는 지 검증하고, 해당 API를 문서화합니다.</p>
+     * <ul>
+     *     <li>생성이 성공됐다는 응답이 와야합니다. (201 Created, 생성된 사용자 식별자)</li>
+     *     <li>생성된 사용자가 실제 잘 저장되어 있는 지 검증해야합니다.</li>
+     * </ul>
+     */
     @DisplayName("여행 생성 -> 여행 생성 됨")
     @Test
     void createTest() throws Exception {
         // given
         User user = setupMockKakaoUser();
         String title = "여행 제목";
-        TripCreateRequest createRequest = new TripCreateRequest(title);
+        var request = new TripCreateRequest(title);
 
         // when
-        ResultActions resultActions = mockMvc.perform(post("/api/trips")
-                .header(HttpHeaders.AUTHORIZATION, authorizationHeader(user))
-                .content(createRequestJson(createRequest))
-                .characterEncoding(StandardCharsets.UTF_8)
-                .contentType(MediaType.APPLICATION_JSON));
+        ResultActions resultActions = runTest(createRequestJson(request), user); // 인증된 사용자의 요청
 
         // then
-        TripCreateResponse response = createResponseObject(resultActions, TripCreateResponse.class);
-        Trip createdTrip = tripRepository.findById(response.getTripId()).orElse(null);
+        TripCreateResponse response = createResponseObject(resultActions, TripCreateResponse.class); // 응답 본문을 객체로 바인딩
+        Trip createdTrip = tripRepository.findById(response.getTripId()).orElse(null); // 생성된 여행 조회
 
-        // then 1 - 응답 메시지 검증
+        // 응답 메시지 검증
         resultActions
                 .andDo(print())
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.tripId").isNotEmpty());
 
-        // then - 2 생성된 Trip의 필드 검증
+        // 생성된 Trip의 필드 검증
         assertThat(createdTrip).isNotNull();
         assertThat(createdTrip.getTripperId()).isEqualTo(user.getId());
         assertThat(createdTrip.getTripTitle()).isEqualTo(TripTitle.of(title));
@@ -67,6 +77,20 @@ public class TripCreateIntegrationTest extends IntegrationTest {
         assertThat(createdTrip.getStatus()).isSameAs(TripStatus.UNDECIDED);
         assertThat(createdTrip.getDays()).isEmpty();
         assertThat(createdTrip.getTemporaryStorage()).isEmpty();
+    }
+
+    /**
+     * 인증된 사용자의 요청을 mocking하여 수행하고, 그 결과를 객체로 얻어옵니다.
+     * @param content : 요청 본문(body)
+     * @param requestUser : 요청 사용자
+     * @return 실제 요청 실행 결과
+     */
+    private ResultActions runTest(String content, User requestUser) throws Exception {
+        return mockMvc.perform(post("/api/trips")
+                .header(HttpHeaders.AUTHORIZATION, authorizationHeader(requestUser))
+                .content(content)
+                .characterEncoding(StandardCharsets.UTF_8)
+                .contentType(MediaType.APPLICATION_JSON));
     }
 
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/application/trip/service/trip_create/TripCreateCommandTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/trip/service/trip_create/TripCreateCommandTest.java
@@ -2,7 +2,7 @@ package com.cosain.trilo.unit.trip.application.trip.service.trip_create;
 
 import com.cosain.trilo.common.exception.CustomValidationException;
 import com.cosain.trilo.trip.application.trip.service.trip_create.TripCreateCommand;
-import com.cosain.trilo.trip.domain.exception.InvalidTripTitleException;
+import com.cosain.trilo.common.exception.trip.InvalidTripTitleException;
 import com.cosain.trilo.trip.domain.vo.TripTitle;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/cosain/trilo/unit/trip/application/trip/service/trip_create/TripCreateServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/trip/service/trip_create/TripCreateServiceTest.java
@@ -16,37 +16,53 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+/**
+ * 여행 생성을 담당하는 여행 생성 서비스({@link TripCreateService})의 테스트 코드입니다.
+ * @see TripCreateService
+ */
 @Slf4j
 @ExtendWith(MockitoExtension.class)
-@DisplayName("[TripCommand] TripCreateService에서")
+@DisplayName("여행 생성 서비스 테스트")
 public class TripCreateServiceTest {
 
+    /**
+     * 테스트 대상이 되는 여행 생성 서비스입니다.
+     */
     @InjectMocks
     private TripCreateService tripCreateService;
 
+    /**
+     * TripCreateService의 의존성
+     */
     @Mock
     private TripRepository tripRepository;
 
+    /**
+     * 여행 생성 서비스 기능을 테스트하고 의도한 대로 동작하는 지 테스트합니다.
+     * <ul>
+     *     <li>내부 의존성이 잘 호출됐는 지 검증해야합니다.</li>
+     *     <li>리포지토리에서 발급받은 여행({@link Trip})의 식별자가 반환되는 지 검증합니다.</li>
+     * </ul>
+     */
     @Test
     @DisplayName("create 하면, 내부적으로 repository가 호출된다.")
     public void create_and_repository_called() {
         // given
         Long tripId = 1L;
-        Long tripperId = 2L;
+        Long requestTripperId = 2L;
+        var command = TripCreateCommand.of(requestTripperId, "제목");
 
-        TripCreateCommand command = TripCreateCommand.of(tripperId, "제목");
-
-        // mocking
-        Trip trip = TripFixture.undecided_Id(tripId, tripperId);
-        given(tripRepository.save(any(Trip.class))).willReturn(trip);
+        Trip savedTrip = TripFixture.undecided_Id(tripId, requestTripperId);
+        given(tripRepository.save(any(Trip.class))).willReturn(savedTrip); // 리포지토리에서 가져올 저장된 여행 mocking
 
         // when
         Long returnTripId = tripCreateService.createTrip(command);
 
         // then
-        verify(tripRepository).save(any(Trip.class));
+        verify(tripRepository, times(1)).save(any(Trip.class));
         assertThat(returnTripId).isEqualTo(tripId);
     }
 

--- a/src/test/java/com/cosain/trilo/unit/trip/application/trip/service/trip_title_update/TripTitleUpdateCommandTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/trip/service/trip_title_update/TripTitleUpdateCommandTest.java
@@ -81,11 +81,11 @@ public class TripTitleUpdateCommandTest {
         assertThat(cve.getExceptions().get(0)).isInstanceOf(InvalidTripTitleException.class);
     }
 
-    @DisplayName("제한보다 긴 제목 -> 검증예외 발생")
+    @DisplayName("20자보다 긴 제목 -> 검증예외 발생")
     @Test
     public void tooLongTitle() {
         // given
-        String tooLongTitle = "가".repeat(TripTitle.MAX_LENGTH + 1);
+        String tooLongTitle = "가".repeat(21);
 
         // when
         CustomValidationException cve = catchThrowableOfType(

--- a/src/test/java/com/cosain/trilo/unit/trip/application/trip/service/trip_title_update/TripTitleUpdateCommandTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/trip/service/trip_title_update/TripTitleUpdateCommandTest.java
@@ -3,7 +3,7 @@ package com.cosain.trilo.unit.trip.application.trip.service.trip_title_update;
 
 import com.cosain.trilo.common.exception.CustomValidationException;
 import com.cosain.trilo.trip.application.trip.service.trip_title_update.TripTitleUpdateCommand;
-import com.cosain.trilo.trip.domain.exception.InvalidTripTitleException;
+import com.cosain.trilo.common.exception.trip.InvalidTripTitleException;
 import com.cosain.trilo.trip.domain.vo.TripTitle;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/vo/TripTitleTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/vo/TripTitleTest.java
@@ -46,10 +46,10 @@ public class TripTitleTest {
     }
 
     @Test
-    @DisplayName("제한 길이보다 긴 제목 -> InvalidTripTitleException 발생")
+    @DisplayName("20자보다 긴 제목 -> InvalidTripTitleException 발생")
     void tooLongTripTitleTest() {
         // given
-        String tooLongTitle = "A".repeat(TripTitle.MAX_LENGTH + 1);
+        String tooLongTitle = "A".repeat(21);
 
         // when
         assertThatThrownBy(() -> TripTitle.of(tooLongTitle))

--- a/src/test/java/com/cosain/trilo/unit/trip/domain/vo/TripTitleTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/domain/vo/TripTitleTest.java
@@ -1,6 +1,6 @@
 package com.cosain.trilo.unit.trip.domain.vo;
 
-import com.cosain.trilo.trip.domain.exception.InvalidTripTitleException;
+import com.cosain.trilo.common.exception.trip.InvalidTripTitleException;
 import com.cosain.trilo.trip.domain.vo.TripTitle;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/cosain/trilo/unit/trip/infra/repository/TripRepositoryImplTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/infra/repository/TripRepositoryImplTest.java
@@ -9,6 +9,7 @@ import com.cosain.trilo.trip.domain.entity.Schedule;
 import com.cosain.trilo.trip.domain.entity.Trip;
 import com.cosain.trilo.trip.domain.vo.ScheduleIndex;
 import com.cosain.trilo.trip.domain.vo.TripTitle;
+import com.cosain.trilo.trip.domain.vo.TripStatus;
 import com.cosain.trilo.trip.infra.repository.TripRepositoryImpl;
 import com.cosain.trilo.user.domain.User;
 import org.junit.jupiter.api.DisplayName;
@@ -23,112 +24,108 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * 여행 리포지토리 구현체({@link TripRepositoryImpl}의 테스트 클래스입니다.
+ * @see TripRepositoryImpl
+ */
 @RepositoryTest
 @DisplayName("TripRepositoryImpl 테스트")
 public class TripRepositoryImplTest {
 
+    /**
+     * 테스트할 여행 리포지토리 구현체
+     */
     @Autowired
     private TripRepositoryImpl tripRepositoryImpl;
 
+    /**
+     * 영속성 컨텍스트
+     */
     @Autowired
     private TestEntityManager em;
 
-    @Nested
-    @DisplayName("Trip 저장 후 FindById로 조회")
-    class saveAndFindByIdTest {
+    /**
+     * 여행을 저장 후 같은 id로 조회했을 때, 같은 여행이 찾아지는 지 검증
+     * @see TripRepositoryImpl#save(Trip)
+     * @see TripRepositoryImpl#findById(Long)
+     */
+    @Test
+    @DisplayName("trip 저장 후 같은 id로 조회하면 같은 여행이 찾아진다.")
+    void successTest() {
+        // given
+        Long tripperId = setupTripperId();
+        Trip trip = Trip.create(TripTitle.of("제목"), tripperId);
 
-        @Test
-        @DisplayName("같은 id로 조회하면 같은 여행이 찾아진다.")
-        void successTest() {
-            Long tripperId = setupTripperId();
-            Trip trip = Trip.create(TripTitle.of("제목"), tripperId);
-            tripRepositoryImpl.save(trip);
+        // when
+        tripRepositoryImpl.save(trip);
+        em.flush();
+        em.clear();
 
-            em.clear();
+        // then
+        Trip findTrip = tripRepositoryImpl.findById(trip.getId()).orElseThrow(IllegalStateException::new); // 같은 id로 조회해 옴
 
-            Trip findTrip = tripRepositoryImpl.findById(trip.getId()).get();
-            assertThat(findTrip.getId()).isEqualTo(trip.getId());
-            assertThat(findTrip.getTripperId()).isEqualTo(trip.getTripperId());
-            assertThat(findTrip.getTripPeriod()).isEqualTo(trip.getTripPeriod());
-        }
-
-        @Test
-        @DisplayName("임시보관함을 지연로딩(기본 양방향 매핑)하여 얻어오면, 순서대로 요소들이 가져와진다.")
-        void lazy_loading_TemporaryStorage() {
-            // given
-            Long tripperId = setupTripperId();
-            Trip trip = TripFixture.undecided_nullId(tripperId);
-            tripRepositoryImpl.save(trip);
-
-            Schedule schedule1 = ScheduleFixture.temporaryStorage_NullId(trip, 30_000_000L);
-            Schedule schedule2 = ScheduleFixture.temporaryStorage_NullId(trip, 50_000_000L);
-            Schedule schedule3 = ScheduleFixture.temporaryStorage_NullId(trip, -10_000_000L);
-
-            em.persist(schedule1);
-            em.persist(schedule2);
-            em.persist(schedule3);
-
-            em.clear();
-
-            // when
-            Trip findTrip = tripRepositoryImpl.findById(trip.getId()).get();
-            List<Schedule> temporaryStorage = findTrip.getTemporaryStorage();
-
-            // then
-            assertThat(temporaryStorage).map(Schedule::getScheduleIndex)
-                    .containsExactly(ScheduleIndex.of(-10_000_000L), ScheduleIndex.of(30_000_000L), ScheduleIndex.of(50_000_000L));
-        }
+        assertThat(findTrip.getId()).isEqualTo(trip.getId());
+        assertThat(findTrip.getTripperId()).isEqualTo(trip.getTripperId());
+        assertThat(findTrip.getTripTitle()).isEqualTo(trip.getTripTitle());
+        assertThat(findTrip.getTripPeriod()).isEqualTo(trip.getTripPeriod());
+        assertThat(findTrip.getStatus()).isSameAs(trip.getStatus());
+        assertThat(findTrip.getTripImage()).isEqualTo(trip.getTripImage()); // 필드가 동등한 지 검증
     }
 
-    @Nested
-    @DisplayName("findByIdWithDays")
-    class FindByIdWithDaysTest {
 
-        @Test
-        @DirtiesContext
-        @DisplayName("UnDecided 상태의 Trip을 조회하면 Trip만 조회된다.")
-        public void findUndecidedTripTest() {
-            // given
-            Long tripperId = setupTripperId();
-            Trip trip = TripFixture.undecided_nullId(tripperId);
-            em.persist(trip);
+    /**
+     * 여행을 저장하고, 여행의 임시보관함 요소들을 지연 로딩을 통해 얻어왔을 때, 일정 순서 기준으로 오름차순으로 일정들이 가져와지는 지 검증합니다.
+     * <ul>
+     *     <li>임시보관함에서의 일정 순서값({@link ScheduleIndex})이 클 수록 뒤에 놓여야합니다.</li>
+     * </ul>
+     */
+    @Test
+    @DisplayName("여행 저장 -> 임시보관함을 지연로딩(기본 양방향 매핑)하여 얻어오면, 일정 순서 기준 오름차순으로 일정들이 가져와진다.")
+    void testTemporaryStorageLazyLoading() {
+        // given
+        Long tripperId = setupTripperId();
+        Trip trip = setupUndecidedTripAndPersist(tripperId);
 
-            em.clear();
+        setupTemporaryScheduleAndPersist(trip, 30_000_000L);
+        setupTemporaryScheduleAndPersist(trip, 50_000_000L);
+        setupTemporaryScheduleAndPersist(trip, -10_000_000L);
+        em.flush();
+        em.clear();
 
-            // when
-            Trip findTrip = tripRepositoryImpl.findByIdWithDays(trip.getId()).get();
+        // when
+        Trip findTrip = tripRepositoryImpl.findById(trip.getId()).orElseThrow(IllegalStateException::new); // 같은 id로 조회해옴
+        List<Schedule> temporaryStorage = findTrip.getTemporaryStorage(); // 임시보관함을 지연로딩으로 불러옴
 
-            // then
-            assertThat(findTrip.getTripTitle()).isEqualTo(trip.getTripTitle());
-            assertThat(findTrip.getId()).isEqualTo(trip.getId());
-            assertThat(findTrip.getDays()).isEmpty();
-        }
+        // then
+        assertThat(temporaryStorage).map(sch -> sch.getScheduleIndex().getValue())
+                .containsExactly(-10_000_000L, 30_000_000L, 50_000_000L); // 일정 순서값 기준 오름차순으로 가져와짐 검증
+    }
 
-        @Test
-        @DirtiesContext
-        @DisplayName("findByIdWithDays -> Trip이 Day들을 가진 채 조회된다.")
-        void testFindByIdWithDays(){
-            // given
-            Long tripperId = setupTripperId();
-            LocalDate startDate = LocalDate.of(2023,5,2);
-            LocalDate endDate = LocalDate.of(2023,5,3);
 
-            Trip trip = setupDecidedTripAndPersist(tripperId, startDate, endDate);
-            Day day1 = trip.getDays().get(0);
-            Day day2 = trip.getDays().get(1);
+    @Test
+    @DirtiesContext
+    @DisplayName("findByIdWithDays -> Trip이 Day들을 가진 채 조회된다.")
+    void testFindByIdWithDays(){
+        // given
+        Long tripperId = setupTripperId();
+        LocalDate startDate = LocalDate.of(2023,5,2);
+        LocalDate endDate = LocalDate.of(2023,5,3);
 
-            em.flush();
-            em.clear();
+        Trip trip = setupDecidedTripAndPersist(tripperId, startDate, endDate);
+        Day day1 = trip.getDays().get(0);
+        Day day2 = trip.getDays().get(1);
 
-            // when
-            Trip findTrip = tripRepositoryImpl.findByIdWithDays(trip.getId()).get();
+        em.flush();
+        em.clear();
 
-            // then
-            assertThat(findTrip.getTripTitle()).isEqualTo(trip.getTripTitle());
-            assertThat(findTrip.getId()).isEqualTo(trip.getId());
-            assertThat(findTrip.getDays().size()).isEqualTo(2);
-            assertThat(findTrip.getDays()).map(Day::getTripDate).containsExactly(day1.getTripDate(), day2.getTripDate());
-        }
+        // when
+        Trip findTrip = tripRepositoryImpl.findByIdWithDays(trip.getId()).get();
+
+        // then
+        assertThat(findTrip.getTripTitle()).isEqualTo(trip.getTripTitle());
+        assertThat(findTrip.getId()).isEqualTo(trip.getId());
+        assertThat(findTrip.getDays().size()).isEqualTo(2);
+        assertThat(findTrip.getDays()).map(Day::getTripDate).containsExactly(day1.getTripDate(), day2.getTripDate());
     }
 
     @Test
@@ -174,22 +171,48 @@ public class TripRepositoryImplTest {
         }
     }
 
+    /**
+     * 저장소에 사용자를 저장하여 셋팅하고, 해당 사용자의 id를 발급받아 옵니다.
+     * @return 새로 저장된 사용자의 id
+     */
     private Long setupTripperId() {
         User user = UserFixture.googleUser_NullId();
         em.persist(user);
         return user.getId();
     }
 
+    /**
+     * {@link TripStatus#UNDECIDED} 상태의 여행을 생성하고, 저장소에 저장하여 셋팅합니다.
+     * @param tripperId 사용자(여행자)의 id
+     * @return 여행
+     */
     private Trip setupUndecidedTripAndPersist(Long tripperId) {
         Trip trip = TripFixture.undecided_nullId(tripperId);
         em.persist(trip);
         return trip;
     }
 
+    /**
+     * {@link TripStatus#DECIDED} 상태의 여행 및 여행에 소속된 Day들을 생성하고, 저장소에 저장하여 셋팅합니다.
+     * @param tripperId 사용자(여행자)의 id
+     * @return 여행
+     */
     private Trip setupDecidedTripAndPersist(Long tripperId, LocalDate startDate, LocalDate endDate) {
         Trip trip = TripFixture.decided_nullId(tripperId, startDate, endDate);
         em.persist(trip);
         trip.getDays().forEach(em::persist);
         return trip;
+    }
+
+    /**
+     * 임시보관함 일정을 생성 및 저장하여 셋팅하고 그 일정을 반환합니다.
+     * @param trip 일정이 소속된 여행
+     * @param scheduleIndexValue 일정의 순서값({@link ScheduleIndex})의 원시값({@link Long})
+     * @return 일정
+     */
+    private Schedule setupTemporaryScheduleAndPersist(Trip trip, long scheduleIndexValue) {
+        Schedule schedule = ScheduleFixture.temporaryStorage_NullId(trip, scheduleIndexValue);
+        em.persist(schedule);
+        return schedule;
     }
 }

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/TripCreateControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/TripCreateControllerTest.java
@@ -25,39 +25,64 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+/**
+ * 여행 생성을 담당하는 Controller({@link TripCreateController})의 테스트 코드 클래스입니다.
+ * @see TripCreateController
+ */
 @DisplayName("여행 생성 API 테스트")
 @WebMvcTest(TripCreateController.class)
 class TripCreateControllerTest extends RestControllerTest {
 
+    /**
+     * TripCreateController의 의존성
+     */
     @MockBean
     private TripCreateService tripCreateService;
 
+    /**
+     * 테스트에서 사용할 가짜 Authorization Header 값
+     */
     private final static String ACCESS_TOKEN = "Bearer accessToken";
 
+    /**
+     * <p>여행 생성 요청을 했을 때, 컨트롤러 내부적으로 의도한 대로 동작하는 지 검증합니다.</p>
+     * <ul>
+     *     <li>생성이 성공됐다는 응답이 와야합니다. (201 Created, 생성된 사용자 식별자)</li>
+     *     <li>내부 의존성이 호출되어야 합니다</li>
+     * </ul>
+     */
     @Test
     @DisplayName("인증된 사용자의 여행 생성 요청 -> 성공")
     public void successTest() throws Exception {
         // given
-        Long tripperId = 1L;
-        mockingForLoginUserAnnotation(tripperId);
+        long requestTripperId = 1L;
+        mockingForLoginUserAnnotation(requestTripperId); // 인증된 사용자 mocking 됨
 
         String rawTitle = "제목";
-        TripCreateRequest request = new TripCreateRequest(rawTitle);
+        var request = new TripCreateRequest(rawTitle);
 
-        Long tripId = 1L;
-        TripCreateCommand command = TripCreateCommand.of(tripperId, rawTitle);
-        given(tripCreateService.createTrip(eq(command))).willReturn(tripId);
+        Long createdTripId = 1L;
+        var command = TripCreateCommand.of(requestTripperId, rawTitle);
+        given(tripCreateService.createTrip(eq(command))).willReturn(createdTripId); // 여행 생성 후 서비스에서 반환받을 여행 식별자 mocking
 
         // when
-        ResultActions resultActions = runTest(createJson(request));
+        ResultActions resultActions = runTest(createJson(request)); // 정상적으로 인증된 사용자가 요청했을 때
 
         // then
         resultActions
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.tripId").value(tripId));
-        verify(tripCreateService, times(1)).createTrip(eq(command));
+                .andExpect(jsonPath("$.tripId").value(createdTripId)); // 상태코드 및 응답 필드 검증
+
+        verify(tripCreateService, times(1)).createTrip(eq(command)); // 내부 의존성 호출 검증
     }
 
+    /**
+     * <p>Authorization Header에 토큰을 담지 않은 사용자가 요청하면 인증 실패 오류가 발생함을 검증합니다.</p>
+     * <ul>
+     *     <li>에러 응답이 와야합니다. (401 UnAuthorized, 토큰 없음)</li>
+     *     <li>내부 의존성이 호출되지 않아야합니다.</li>
+     * </ul>
+     */
     @Test
     @DisplayName("토큰이 없는 사용자 요청 -> 인증 실패 401")
     public void createTrip_without_token() throws Exception {
@@ -66,7 +91,7 @@ class TripCreateControllerTest extends RestControllerTest {
         TripCreateRequest request = new TripCreateRequest(rawTitle);
 
         // when
-        ResultActions resultActions = runTestWithoutAuthorization(createJson(request));
+        ResultActions resultActions = runTestWithoutAuthorization(createJson(request)); // 인증하지 않은 사용자가 요청
 
         // then
         resultActions
@@ -74,21 +99,30 @@ class TripCreateControllerTest extends RestControllerTest {
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorCode").value("auth-0001"))
                 .andExpect(jsonPath("$.errorMessage").exists())
-                .andExpect(jsonPath("$.errorDetail").exists());
-        verify(tripCreateService, times(0)).createTrip(any(TripCreateCommand.class));
+                .andExpect(jsonPath("$.errorDetail").exists()); // 상태 코드 및 에러 응답 검증
+
+        verify(tripCreateService, times(0)).createTrip(any(TripCreateCommand.class)); // 서비스 호출 안 됨 검증
     }
 
 
+    /**
+     * <p>비어있는 본문으로 요청 시, 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외가 발생되는 지 검증합니다.</p>
+     * <ul>
+     *     <li>에러 응답이 와야합니다. (400 Bad Request, 형식이 올바르지 않은 바디 관련 에러)</li>
+     *     <li>내부 의존성이 호출되지 않아야합니다.</li>
+     * </ul>
+     */
     @Test
     @DisplayName("비어있는 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
     public void createTrip_with_emptyContent() throws Exception {
+        // given
         Long tripperId = 1L;
         mockingForLoginUserAnnotation(tripperId);
 
         String emptyContent = "";
 
         // when
-        ResultActions resultActions = runTest(emptyContent);
+        ResultActions resultActions = runTest(emptyContent); // 비어있는 본문으로 요청할 때
 
         // given
         resultActions
@@ -96,11 +130,19 @@ class TripCreateControllerTest extends RestControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errorCode").value("request-0001"))
                 .andExpect(jsonPath("$.errorMessage").exists())
-                .andExpect(jsonPath("$.errorDetail").exists());
-        verify(tripCreateService, times(0)).createTrip(any(TripCreateCommand.class));
+                .andExpect(jsonPath("$.errorDetail").exists()); // 상태 코드 및 응답 에러 메시지 검증
+
+        verify(tripCreateService, times(0)).createTrip(any(TripCreateCommand.class)); // 서비스 호출 안 됨 검증
     }
 
 
+    /**
+     * 형식이 올바르지 않은 본문을 바디에 담아 요청할 때 에러가 발생함을 검증합니다.
+     * <ul>
+     *     <li>에러 응답이 와야합니다. (400 BadRequest, 형식이 올바르지 않은 바디 관련 에러)</li>
+     *     <li>내부 의존성이 호출되지 않아야합니다.</li>
+     * </ul>
+     */
     @Test
     @DisplayName("형식이 올바르지 않은 바디 -> 올바르지 않은 요청 데이터 형식으로 간주하고 400 예외")
     public void createTrip_with_invalidContent() throws Exception {
@@ -113,7 +155,7 @@ class TripCreateControllerTest extends RestControllerTest {
                 """;
 
         // when
-        ResultActions resultActions = runTest(invalidContent);
+        ResultActions resultActions = runTest(invalidContent); // 형식이 올바르지 않은 body를 담아 요청할 때
 
         // then
         resultActions
@@ -122,117 +164,14 @@ class TripCreateControllerTest extends RestControllerTest {
                 .andExpect(jsonPath("$.errorCode").value("request-0001"))
                 .andExpect(jsonPath("$.errorMessage").exists())
                 .andExpect(jsonPath("$.errorDetail").exists());
-        verify(tripCreateService, times(0)).createTrip(any(TripCreateCommand.class));
+        verify(tripCreateService, times(0)).createTrip(any(TripCreateCommand.class)); // 서비스가 호출되지 않음을 검증
     }
 
-    @DisplayName("제목 null -> 검증예외 발생")
-    @Test
-    public void testNullTitle() throws Exception {
-        // given
-        Long tripperId = 1L;
-        mockingForLoginUserAnnotation(tripperId);
-
-        String nullTitle = null;
-        TripCreateRequest request = new TripCreateRequest(nullTitle);
-
-        // when
-        ResultActions resultActions = runTest(createJson(request));
-
-        // then
-        resultActions
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errorCode").value("request-0003"))
-                .andExpect(jsonPath("$.errorMessage").exists())
-                .andExpect(jsonPath("$.errorDetail").exists())
-                .andExpect(jsonPath("$.errors").exists())
-                .andExpect(jsonPath("$.errors[0].errorCode").value("trip-0002"))
-                .andExpect(jsonPath("$.errors[0].errorMessage").exists())
-                .andExpect(jsonPath("$.errors[0].errorDetail").exists());
-        verify(tripCreateService, times(0)).createTrip(any(TripCreateCommand.class));
-    }
-
-    @DisplayName("제목 빈문자열 -> 검증예외 발생")
-    @Test
-    public void emptyTitle() throws Exception {
-        // given
-        Long tripperId = 1L;
-        mockingForLoginUserAnnotation(tripperId);
-
-        String emptyTitle = "";
-        TripCreateRequest request = new TripCreateRequest(emptyTitle);
-
-        // when
-        ResultActions resultActions = runTest(createJson(request));
-
-        // then
-        resultActions
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errorCode").value("request-0003"))
-                .andExpect(jsonPath("$.errorMessage").exists())
-                .andExpect(jsonPath("$.errorDetail").exists())
-                .andExpect(jsonPath("$.errors").exists())
-                .andExpect(jsonPath("$.errors[0].errorCode").value("trip-0002"))
-                .andExpect(jsonPath("$.errors[0].errorMessage").exists())
-                .andExpect(jsonPath("$.errors[0].errorDetail").exists());
-        verify(tripCreateService, times(0)).createTrip(any(TripCreateCommand.class));
-    }
-
-    @DisplayName("제목 공백으로만 구성 -> 검증예외 발생")
-    @Test
-    public void whiteSpaceTitle() throws Exception {
-        // given
-        Long tripperId = 1L;
-        mockingForLoginUserAnnotation(tripperId);
-
-        String emptyTitle = "     ";
-        TripCreateRequest request = new TripCreateRequest(emptyTitle);
-
-        // when
-        ResultActions resultActions = runTest(createJson(request));
-
-        // then
-        resultActions
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errorCode").value("request-0003"))
-                .andExpect(jsonPath("$.errorMessage").exists())
-                .andExpect(jsonPath("$.errorDetail").exists())
-                .andExpect(jsonPath("$.errors").exists())
-                .andExpect(jsonPath("$.errors[0].errorCode").value("trip-0002"))
-                .andExpect(jsonPath("$.errors[0].errorMessage").exists())
-                .andExpect(jsonPath("$.errors[0].errorDetail").exists());
-        verify(tripCreateService, times(0)).createTrip(any(TripCreateCommand.class));
-    }
-
-    @DisplayName("20자보다 긴 제목 -> 검증예외 발생")
-    @Test
-    public void tooLongTitle() throws Exception{
-        // given
-        Long tripperId = 1L;
-        mockingForLoginUserAnnotation(tripperId);
-
-        String emptyTitle = "가".repeat(21);
-        TripCreateRequest request = new TripCreateRequest(emptyTitle);
-
-        // when
-        ResultActions resultActions = runTest(createJson(request));
-
-        // then
-        resultActions
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errorCode").value("request-0003"))
-                .andExpect(jsonPath("$.errorMessage").exists())
-                .andExpect(jsonPath("$.errorDetail").exists())
-                .andExpect(jsonPath("$.errors").exists())
-                .andExpect(jsonPath("$.errors[0].errorCode").value("trip-0002"))
-                .andExpect(jsonPath("$.errors[0].errorMessage").exists())
-                .andExpect(jsonPath("$.errors[0].errorDetail").exists());
-        verify(tripCreateService, times(0)).createTrip(any(TripCreateCommand.class));
-    }
-
+    /**
+     * 인증된 사용자의 요청을 mocking하여 수행하고, 그 결과를 객체로 얻어옵니다.
+     * @param content : 요청 본문(body)
+     * @return 실제 요청 실행 결과
+     */
     private ResultActions runTest(String content) throws Exception {
         return mockMvc.perform(post("/api/trips")
                 .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
@@ -242,6 +181,11 @@ class TripCreateControllerTest extends RestControllerTest {
         );
     }
 
+    /**
+     * 미인증 사용자의 요청을 mocking하여 수행하고, 그 결과를 객체로 얻어옵니다.
+     * @param content : 요청 본문(body)
+     * @return 실제 요청 실행 결과
+     */
     private ResultActions runTestWithoutAuthorization(String content) throws Exception {
         return mockMvc.perform(post("/api/trips")
                 .content(content)

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/docs/TripCreateControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/docs/TripCreateControllerDocsTest.java
@@ -17,6 +17,8 @@ import java.nio.charset.StandardCharsets;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -27,57 +29,92 @@ import static org.springframework.restdocs.snippet.Attributes.key;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+/**
+ * 여행 생성을 담당하는 Controller({@link TripCreateController})의 문서화 테스트 코드 클래스입니다.
+ * @see TripCreateController
+ */
 @WebMvcTest(TripCreateController.class)
 @DisplayName("여행 생성 API DOCS 테스트")
 public class TripCreateControllerDocsTest extends RestDocsTestSupport {
 
+    /**
+     * TripCreateController의 의존성
+     */
     @MockBean
     private TripCreateService tripCreateService;
 
-    private final String BASE_URL = "/api/trips";
+    /**
+     * 테스트에서 사용할 가짜 Authorization Header 값
+     */
     private final String ACCESS_TOKEN = "Bearer accessToken";
 
+
+    /**
+     * <p>여행 생성 요청을 했을 때, 컨트롤러 내부적으로 의도한 대로 동작하는 지 검증하고, 해당 API를 문서화합니다.</p>
+     * <ul>
+     *     <li>생성이 성공됐다는 응답이 와야합니다. (201 Created, 생성된 사용자 식별자)</li>
+     *     <li>내부 의존성이 호출되어야 합니다</li>
+     * </ul>
+     */
     @Test
     @DisplayName("인증된 사용자의 여행 생성 요청 -> 성공")
     void successTest() throws Exception {
         // given
         Long tripperId= 1L;
-        mockingForLoginUserAnnotation(tripperId);
+        mockingForLoginUserAnnotation(tripperId); // 인증된 사용자 mocking 됨
 
         String rawTitle = "제목";
-        TripCreateRequest request = new TripCreateRequest(rawTitle);
+        var request = new TripCreateRequest(rawTitle);
 
-        Long tripId = 1L;
-        TripCreateCommand command = TripCreateCommand.of(tripperId, rawTitle);
-        given(tripCreateService.createTrip(eq(command))).willReturn(tripId);
+        Long createdTripId = 1L;
+        var command = TripCreateCommand.of(tripperId, rawTitle);
+        given(tripCreateService.createTrip(eq(command))).willReturn(createdTripId); // 여행 생성 후 서비스에서 반환받을 여행 식별자 mocking
 
         // when
-        ResultActions resultActions = mockMvc.perform(post(BASE_URL)
-                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
-                        .content(createJson(request))
-                        .characterEncoding(StandardCharsets.UTF_8)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.tripId").value(tripId));
+        ResultActions resultActions = runTest(createJson(request)); // 정상적으로 인증된 사용자가 요청했을 때
 
         // then
         resultActions
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.tripId").value(createdTripId)); // 상태코드 및 응답 필드 검증
+
+        verify(tripCreateService, times(1)).createTrip(eq(command)); // 내부 의존성 호출 검증
+
+
+        // 문서화
+        resultActions
                 .andDo(restDocs.document(
+                        // 헤더 문서화
                         requestHeaders(
                                 headerWithName(HttpHeaders.AUTHORIZATION)
                                         .description("Bearer 타입 AccessToken")
                         ),
+                        // 요청 필드 문서화
                         requestFields(
                                 fieldWithPath("title")
                                         .type(STRING)
                                         .description("여행의 제목")
                                         .attributes(key("constraints").value("null 또는 공백일 수 없으며, 길이는 1-20자까지만 허용됩니다."))
                         ),
+                        // 응답 필드 문서화
                         responseFields(
                                 fieldWithPath("tripId")
                                         .type(NUMBER)
                                         .description("생성된 여행의 식별자(id)")
                         )
                 ));
+    }
+
+    /**
+     * 인증된 사용자의 요청을 mocking하여 수행하고, 그 결과를 객체로 얻어옵니다.
+     * @param content : 요청 본문(body)
+     * @return 실제 요청 실행 결과
+     */
+    private ResultActions runTest(String content) throws Exception {
+        return mockMvc.perform(post("/api/trips")
+                .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                .content(content)
+                .characterEncoding(StandardCharsets.UTF_8)
+                .contentType(MediaType.APPLICATION_JSON));
     }
 }


### PR DESCRIPTION
# JIRA 티켓
- [TRL-451]

# 작업 내역
- [x] InvalidTripTitleException 패키지 이동(domain -> common)
- [x] 표현 계층 주석 추가 및 JavaDoc 작성
- [x] 애플리케이션 계층 주석 추가 및 JavaDoc 작성
- [x] infra 계층 주석 추가 및 JavaDoc 작성
- [x] 테스트 코드 주석 추가 및 JavaDoc 작성

# 설명
![image](https://github.com/teamCoSaIn/trilo-be/assets/88282356/a4fd3ce6-b1ce-4aeb-837c-108ccead8fa9)

![image](https://github.com/teamCoSaIn/trilo-be/assets/88282356/08ab4738-5efe-4c55-a332-0212f3d24ee3)


- 여행 생성 기능과 관련된 클래스, 메서드, 필드들에 주석, JavaDoc을 작성했습니다.


# 참고자료


[TRL-451]: https://cosain.atlassian.net/browse/TRL-451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ