### PR TITLE
[TRL-444] refactor: 회원 탈퇴 시 비동기처리 및 flag 컬럼을 통한 삭제 Scheduling 

### DIFF
--- a/src/main/java/com/cosain/trilo/config/AsyncConfig.java
+++ b/src/main/java/com/cosain/trilo/config/AsyncConfig.java
@@ -1,9 +1,28 @@
 package com.cosain.trilo.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
 
 @Configuration
 @EnableAsync
 public class AsyncConfig {
+    private static int CORE_POOL_SIZE = 15; // 동시에 실행시킬 쓰레드의 개수 ( default : 1 )
+    private static int MAX_POOL_SIZE = 25; // 쓰레드 풀의 최대 사이즈를 지정 ( default : Integer.MAX_VALUE )
+    private static int QUEUE_CAPACITY = 10; // 큐의 사이즈 ( default : Integer.MAX_VALUE )
+    private static String THREAD_NAME_PREFIX = "async-task"; // Thread name prefix
+
+    @Bean(name = "threadPoolTaskExecutor")
+    public Executor asyncTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(CORE_POOL_SIZE);
+        executor.setMaxPoolSize(MAX_POOL_SIZE);
+        executor.setQueueCapacity(QUEUE_CAPACITY);
+        executor.setThreadNamePrefix(THREAD_NAME_PREFIX);
+        executor.initialize();
+        return executor;
+    }
 }

--- a/src/main/java/com/cosain/trilo/config/AsyncConfig.java
+++ b/src/main/java/com/cosain/trilo/config/AsyncConfig.java
@@ -10,10 +10,10 @@ import java.util.concurrent.Executor;
 @Configuration
 @EnableAsync
 public class AsyncConfig {
-    private static int CORE_POOL_SIZE = 15; // 동시에 실행시킬 쓰레드의 개수 ( default : 1 )
-    private static int MAX_POOL_SIZE = 25; // 쓰레드 풀의 최대 사이즈를 지정 ( default : Integer.MAX_VALUE )
-    private static int QUEUE_CAPACITY = 10; // 큐의 사이즈 ( default : Integer.MAX_VALUE )
-    private static String THREAD_NAME_PREFIX = "async-task"; // Thread name prefix
+    private static final int CORE_POOL_SIZE = 15; // 동시에 실행시킬 쓰레드의 개수 ( default : 1 )
+    private static final int MAX_POOL_SIZE = 25; // 쓰레드 풀의 최대 사이즈를 지정 ( default : Integer.MAX_VALUE )
+    private static final int QUEUE_CAPACITY = 10; // 큐의 사이즈 ( default : Integer.MAX_VALUE )
+    private static final String THREAD_NAME_PREFIX = "async-task"; // Thread name prefix
 
     @Bean(name = "threadPoolTaskExecutor")
     public Executor asyncTaskExecutor() {

--- a/src/main/java/com/cosain/trilo/config/ScheduleConfig.java
+++ b/src/main/java/com/cosain/trilo/config/ScheduleConfig.java
@@ -1,0 +1,9 @@
+package com.cosain.trilo.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class ScheduleConfig {
+}

--- a/src/main/java/com/cosain/trilo/trip/application/event/TripEventListener.java
+++ b/src/main/java/com/cosain/trilo/trip/application/event/TripEventListener.java
@@ -3,8 +3,9 @@ package com.cosain.trilo.trip.application.event;
 import com.cosain.trilo.trip.application.trip.service.trip_all_delete.TripAllDeleteService;
 import com.cosain.trilo.user.application.event.UserDeleteEvent;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
@@ -12,7 +13,8 @@ public class TripEventListener {
 
     private final TripAllDeleteService tripAllDeleteService;
 
-    @EventListener
+    @Async("threadPoolTaskExecutor")
+    @TransactionalEventListener
     public void handle(UserDeleteEvent event){
         Long tripperId = event.getUserId();
         tripAllDeleteService.deleteAllByTripperId(tripperId);

--- a/src/main/java/com/cosain/trilo/user/application/UserScheduledService.java
+++ b/src/main/java/com/cosain/trilo/user/application/UserScheduledService.java
@@ -1,0 +1,21 @@
+package com.cosain.trilo.user.application;
+
+import com.cosain.trilo.user.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class UserScheduledService {
+
+    private final UserRepository userRepository;
+
+    // 매주 월요일 오전 5시
+    @Scheduled(cron = "0 0 5 ? * MON")
+    @Transactional
+    public void deleteAllUserWithDelFlag(){
+        userRepository.deleteAllWhereIsDelTrue();
+    }
+}

--- a/src/main/java/com/cosain/trilo/user/application/UserService.java
+++ b/src/main/java/com/cosain/trilo/user/application/UserService.java
@@ -79,7 +79,8 @@ public class UserService {
                 .orElseThrow(UserNotFoundException::new);
 
         eventPublisher.publishEvent(new UserDeleteEvent(findUser.getId())); // 비동기적으로 사용자 관련된 여행 정보 삭제
-        userRepository.deleteById(targetUserId);
+        findUser.updateIsDel(true);
+        userRepository.save(findUser);
     }
 
     private void validateUserDeleteAuthority(Long targetUserId, Long requestUserId){

--- a/src/main/java/com/cosain/trilo/user/domain/User.java
+++ b/src/main/java/com/cosain/trilo/user/domain/User.java
@@ -66,11 +66,14 @@ public class User {
     public void updateUserByOauthProfile(OAuthProfileDto oAuthProfileDto) {
         this.nickName = oAuthProfileDto.getName();
         this.profileImageURL = oAuthProfileDto.getProfileImageUrl();
-        this.isDeleted = false;
     }
 
-    public void updateIsDel(boolean flag){
-        this.isDeleted = flag;
+    public void proceedWithdrawal(){
+        this.isDeleted = true;
+    }
+
+    public void cancelWithdrawal(){
+        this.isDeleted = false;
     }
 
     public void update(UserUpdateRequest userUpdateRequest){

--- a/src/main/java/com/cosain/trilo/user/domain/User.java
+++ b/src/main/java/com/cosain/trilo/user/domain/User.java
@@ -34,14 +34,14 @@ public class User {
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    @Column(name = "is_del")
-    private boolean isDel;
+    @Column(name = "is_deleted")
+    private boolean isDeleted;
 
     @Embedded
     private MyPageImage myPageImage;
 
     @Builder(access = AccessLevel.PUBLIC)
-    private User(Long id, String nickName, String email, String profileImageUrl, AuthProvider authProvider, Role role, MyPageImage myPageImage, boolean isDel) {
+    private User(Long id, String nickName, String email, String profileImageUrl, AuthProvider authProvider, Role role, MyPageImage myPageImage, boolean isDeleted) {
         this.id = id;
         this.nickName = nickName;
         this.email = email;
@@ -49,7 +49,7 @@ public class User {
         this.authProvider = authProvider;
         this.role = role;
         this.myPageImage = myPageImage == null ? MyPageImage.initializeMyPageImage() : myPageImage;
-        this.isDel = isDel;
+        this.isDeleted = isDeleted;
     }
 
     public static User from(OAuthProfileDto oAuthProfileDto) {
@@ -59,18 +59,18 @@ public class User {
                 .profileImageUrl(oAuthProfileDto.getProfileImageUrl())
                 .role(Role.MEMBER)
                 .authProvider(oAuthProfileDto.getProvider())
-                .isDel(false)
+                .isDeleted(false)
                 .build();
     }
 
     public void updateUserByOauthProfile(OAuthProfileDto oAuthProfileDto) {
         this.nickName = oAuthProfileDto.getName();
         this.profileImageURL = oAuthProfileDto.getProfileImageUrl();
-        this.isDel = false;
+        this.isDeleted = false;
     }
 
     public void updateIsDel(boolean flag){
-        this.isDel = flag;
+        this.isDeleted = flag;
     }
 
     public void update(UserUpdateRequest userUpdateRequest){

--- a/src/main/java/com/cosain/trilo/user/domain/User.java
+++ b/src/main/java/com/cosain/trilo/user/domain/User.java
@@ -34,11 +34,14 @@ public class User {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    @Column(name = "is_del")
+    private boolean isDel;
+
     @Embedded
     private MyPageImage myPageImage;
 
     @Builder(access = AccessLevel.PUBLIC)
-    private User(Long id, String nickName, String email, String profileImageUrl, AuthProvider authProvider, Role role, MyPageImage myPageImage) {
+    private User(Long id, String nickName, String email, String profileImageUrl, AuthProvider authProvider, Role role, MyPageImage myPageImage, boolean isDel) {
         this.id = id;
         this.nickName = nickName;
         this.email = email;
@@ -46,6 +49,7 @@ public class User {
         this.authProvider = authProvider;
         this.role = role;
         this.myPageImage = myPageImage == null ? MyPageImage.initializeMyPageImage() : myPageImage;
+        this.isDel = isDel;
     }
 
     public static User from(OAuthProfileDto oAuthProfileDto) {
@@ -55,12 +59,14 @@ public class User {
                 .profileImageUrl(oAuthProfileDto.getProfileImageUrl())
                 .role(Role.MEMBER)
                 .authProvider(oAuthProfileDto.getProvider())
+                .isDel(false)
                 .build();
     }
 
     public void updateUserByOauthProfile(OAuthProfileDto oAuthProfileDto) {
         this.nickName = oAuthProfileDto.getName();
         this.profileImageURL = oAuthProfileDto.getProfileImageUrl();
+        this.isDel = false;
     }
 
     public void update(UserUpdateRequest userUpdateRequest){

--- a/src/main/java/com/cosain/trilo/user/domain/User.java
+++ b/src/main/java/com/cosain/trilo/user/domain/User.java
@@ -69,6 +69,10 @@ public class User {
         this.isDel = false;
     }
 
+    public void updateIsDel(boolean flag){
+        this.isDel = flag;
+    }
+
     public void update(UserUpdateRequest userUpdateRequest){
         this.nickName = userUpdateRequest.getNickName();
     }

--- a/src/main/java/com/cosain/trilo/user/domain/UserRepository.java
+++ b/src/main/java/com/cosain/trilo/user/domain/UserRepository.java
@@ -1,6 +1,8 @@
 package com.cosain.trilo.user.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -10,4 +12,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
 
+    @Modifying
+    @Query("delete from User u where u.isDel = true")
+    void deleteAllWhereIsDelTrue();
 }

--- a/src/main/java/com/cosain/trilo/user/domain/UserRepository.java
+++ b/src/main/java/com/cosain/trilo/user/domain/UserRepository.java
@@ -13,6 +13,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     @Modifying
-    @Query("delete from User u where u.isDel = true")
+    @Query("delete from User u where u.isDeleted = true")
     void deleteAllWhereIsDelTrue();
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -11,6 +11,7 @@ CREATE TABLE IF NOT EXISTS `trilo_db`.`users` (
     auth_provider           VARCHAR(20)  NOT NULL,
     user_role               VARCHAR(255) NOT NULL,
     my_page_image_file_name VARCHAR(255) NOT NULL,
+    is_del                  BOOLEAN      NOT NULL,
     PRIMARY KEY (user_id)
 );
 

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS `trilo_db`.`users` (
     auth_provider           VARCHAR(20)  NOT NULL,
     user_role               VARCHAR(255) NOT NULL,
     my_page_image_file_name VARCHAR(255) NOT NULL,
-    is_del                  BOOLEAN      NOT NULL,
+    is_deleted              BOOLEAN      NOT NULL,
     INDEX idx_email (email),
     PRIMARY KEY (user_id)
 );

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS `trilo_db`.`users` (
     user_role               VARCHAR(255) NOT NULL,
     my_page_image_file_name VARCHAR(255) NOT NULL,
     is_del                  BOOLEAN      NOT NULL,
+    INDEX idx_email (email),
     PRIMARY KEY (user_id)
 );
 

--- a/src/test/java/com/cosain/trilo/fixture/UserFixture.java
+++ b/src/test/java/com/cosain/trilo/fixture/UserFixture.java
@@ -40,6 +40,7 @@ public class UserFixture {
                 .authProvider(authProvider)
                 .role(Role.MEMBER)
                 .myPageImage(MyPageImage.initializeMyPageImage())
+                .isDel(false)
                 .build();
     }
 }

--- a/src/test/java/com/cosain/trilo/fixture/UserFixture.java
+++ b/src/test/java/com/cosain/trilo/fixture/UserFixture.java
@@ -40,7 +40,7 @@ public class UserFixture {
                 .authProvider(authProvider)
                 .role(Role.MEMBER)
                 .myPageImage(MyPageImage.initializeMyPageImage())
-                .isDel(false)
+                .isDeleted(false)
                 .build();
     }
 }

--- a/src/test/java/com/cosain/trilo/integration/user/UserIntegrationTest.java
+++ b/src/test/java/com/cosain/trilo/integration/user/UserIntegrationTest.java
@@ -100,7 +100,7 @@ public class UserIntegrationTest extends IntegrationTest {
 
             // then
             User findUser = userRepository.findById(user.getId()).orElseThrow();
-            assertThat(findUser.isDel()).isTrue();
+            assertThat(findUser.isDeleted()).isTrue();
         }
 
         @Test

--- a/src/test/java/com/cosain/trilo/integration/user/UserIntegrationTest.java
+++ b/src/test/java/com/cosain/trilo/integration/user/UserIntegrationTest.java
@@ -93,13 +93,14 @@ public class UserIntegrationTest extends IntegrationTest {
             log.info("User = {}", user);
 
             flushAndClear();
-            // when & then
+            // when
             mockMvc.perform(RestDocumentationRequestBuilders.delete(BASE_URL + "/{userId}", user.getId())
                     .header(HttpHeaders.AUTHORIZATION, authorizationHeader(user)))
                     .andExpect(status().isNoContent());
 
-            User findUser = userRepository.findById(user.getId()).orElse(null);
-            assertThat(findUser).isNull();
+            // then
+            User findUser = userRepository.findById(user.getId()).orElseThrow();
+            assertThat(findUser.isDel()).isTrue();
         }
 
         @Test

--- a/src/test/java/com/cosain/trilo/unit/user/application/UserScheduledServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/user/application/UserScheduledServiceTest.java
@@ -1,0 +1,30 @@
+package com.cosain.trilo.unit.user.application;
+
+import com.cosain.trilo.user.application.UserScheduledService;
+import com.cosain.trilo.user.domain.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class UserScheduledServiceTest {
+
+    @InjectMocks
+    private UserScheduledService userScheduledService;
+    @Mock
+    private UserRepository userRepository;
+
+    @Test
+    void 정해진_시간에_회원_벌크_삭제_실행(){
+        // when
+        userScheduledService.deleteAllUserWithDelFlag();
+
+        // then
+        verify(userRepository, times(1)).deleteAllWhereIsDelTrue();
+    }
+}

--- a/src/test/java/com/cosain/trilo/unit/user/application/UserServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/user/application/UserServiceTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
@@ -169,9 +170,9 @@ public class UserServiceTest {
             // when
             userService.delete(targetUserId, requestUserId);
             // then
-            verify(userRepository).findById(eq(targetUserId));
-            verify(eventPublisher).publishEvent(any(UserDeleteEvent.class));
-            verify(userRepository).deleteById(eq(targetUserId));
+            verify(userRepository, times(1)).findById(eq(targetUserId));
+            verify(eventPublisher, times(1)).publishEvent(any(UserDeleteEvent.class));
+            verify(userRepository, times(1)).save(any(User.class));
         }
 
         @Test

--- a/src/test/java/com/cosain/trilo/unit/user/infra/UserRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/user/infra/UserRepositoryTest.java
@@ -9,6 +9,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
@@ -49,5 +51,38 @@ class UserRepositoryTest {
 
         // then
         assertThat(findUser).isNotNull();
+    }
+
+    @Test
+    void 삭제_플래그_컬럼에_해당하는_사용자_벌크_삭제(){
+        // given
+        User userA = UserFixture.kakaoUser_NullId();
+        User userB = UserFixture.kakaoUser_NullId();
+        User userC = UserFixture.kakaoUser_NullId();
+
+        userA.updateIsDel(true);
+        userB.updateIsDel(true);
+        userC.updateIsDel(false);
+
+        User findUserA = userRepository.save(userA);
+        User findUserB = userRepository.save(userB);
+        User findUserC = userRepository.save(userC);
+
+        em.flush();
+        em.clear();
+
+        // when
+        userRepository.deleteAllWhereIsDelTrue();
+        em.flush();
+        em.clear();
+
+        // then
+        Optional<User> optionalUserA = userRepository.findById(findUserA.getId());
+        Optional<User> optionalUserB = userRepository.findById(findUserB.getId());
+        Optional<User> optionalUserC = userRepository.findById(findUserC.getId());
+
+        assertThat(optionalUserA.isEmpty()).isTrue();
+        assertThat(optionalUserB.isEmpty()).isTrue();
+        assertThat(optionalUserC.isPresent()).isTrue();
     }
 }

--- a/src/test/java/com/cosain/trilo/unit/user/infra/UserRepositoryTest.java
+++ b/src/test/java/com/cosain/trilo/unit/user/infra/UserRepositoryTest.java
@@ -60,9 +60,8 @@ class UserRepositoryTest {
         User userB = UserFixture.kakaoUser_NullId();
         User userC = UserFixture.kakaoUser_NullId();
 
-        userA.updateIsDel(true);
-        userB.updateIsDel(true);
-        userC.updateIsDel(false);
+        userA.proceedWithdrawal();
+        userB.proceedWithdrawal();
 
         User findUserA = userRepository.save(userA);
         User findUserB = userRepository.save(userB);

--- a/src/test/resources/test_schema.sql
+++ b/src/test/resources/test_schema.sql
@@ -11,6 +11,7 @@ CREATE TABLE IF NOT EXISTS `trilo_db_test`.`users` (
     auth_provider VARCHAR(20) NOT NULL,
     user_role VARCHAR(255) NOT NULL,
     my_page_image_file_name VARCHAR(255) NOT NULL,
+    is_del BOOLEAN NOT NULL,
     PRIMARY KEY (user_id)
 );
 

--- a/src/test/resources/test_schema.sql
+++ b/src/test/resources/test_schema.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS `trilo_db_test`.`users` (
     user_role VARCHAR(255) NOT NULL,
     my_page_image_file_name VARCHAR(255) NOT NULL,
     is_del BOOLEAN NOT NULL,
+    INDEX idx_email (email),
     PRIMARY KEY (user_id)
 );
 

--- a/src/test/resources/test_schema.sql
+++ b/src/test/resources/test_schema.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS `trilo_db_test`.`users` (
     auth_provider VARCHAR(20) NOT NULL,
     user_role VARCHAR(255) NOT NULL,
     my_page_image_file_name VARCHAR(255) NOT NULL,
-    is_del BOOLEAN NOT NULL,
+    is_deleted BOOLEAN NOT NULL,
     INDEX idx_email (email),
     PRIMARY KEY (user_id)
 );


### PR DESCRIPTION
# JIRA 티켓
[TRL-444]

# 작업 내역

- [x] USER 테이블 FLAG 컬럼 추가
- [x] 회원 삭제 기능 수정 → 삭제 쿼리가 아닌 (삭제)플래그 컬럼 수정 쿼리 발행하도록 
- [x] 스레드 풀 설정 추가
- [x] 회원 탈퇴 이벤트를 동기에서 비동기로 수정
- [x] 스프링 스케쥴러 활용하여 매일 오전 5시에 플래그 컬럼에 해당하는 모든 User Table row 벌크 삭제

---

- [x] User 테이블 email 컬럼에 대한 인덱스 추가

# 설명

일전에 SQL 스크립트를 추가하며 Trip 테이블에 설정해놓은 FK 로 인해 USER 테이블 삭제 완료(commit) 후 이벤트를 처리하게 되면 외래키 제약조건에 위배되는 문제가 발생했었습니다. 때문에 #162 를 통해 잠시 이벤트 처리 방식으로 동기적으로 처리할 수 있게끔 변경해놓았었습니다.

다만 비동기로 얻을 수 있는 성능 상의 이점을 포기할 수는 없으니, 여러가지 방법을 고민해보던 중에 질문글을 통해 힌트를 얻고 

- [인프런 질문에 대한 김영한 님의 답변](https://www.inflearn.com/questions/949033/jpa-gt-ddd-%EC%84%9C%EB%A1%9C-%EB%8B%A4%EB%A5%B8-%EC%95%A0%EA%B7%B8%EB%A6%AC%EA%B1%B0%ED%8A%B8-%EC%82%AC%EC%9D%B4%EC%9D%98-%EA%B0%84%EC%A0%91%EC%B0%B8%EC%A1%B0)
- [OKKY 커뮤니티 질문](https://okky.kr/questions/1459425#answer-674754)

플래그 컬럼과 스프링 스케줄러를 통해 해결해보았습니다. 사용자가 가장 적을 것으로 생각되는 매주 월요일 오전 5시에 벌크 삭제를 통해 플래그 컬럼에 해당하는 모든 User 를 삭제하도록 했습니다.

더불어 이전에 설정이 안되어 있었던 email 에 대한 인덱스를 추가했고, 쓰레드 풀에 대한 설정도 추가했습니다.

# 관련 PR

#135 
#162 

# 참고자료
https://www.baeldung.com/spring-async
https://woodcock.tistory.com/31

[TRL-444]: https://cosain.atlassian.net/browse/TRL-444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ