### PR TITLE
[TRL-456] fix: 사용자 여행 목록 조회 API 엔드포인트 변경

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -397,12 +397,14 @@ include::{snippets}/single-trip-query-controller-docs-test/여행_단건_조회/
 ==== 기본 정보
 
 - 메서드 : GET
-- URL : `/api/trips`
+- URL : `/api/tripper/{tripperId}/trips`
 - 인증 방식 : 엑세스 토큰
 
 ==== 요청
 ===== 헤더
 include::{snippets}/tripper-trip-list-query-controller-docs-test/사용자_여행_목록_조회/request-headers.adoc[]
+===== 경로 변수
+include::{snippets}/tripper-trip-list-query-controller-docs-test/사용자_여행_목록_조회/path-parameters.adoc[]
 ===== 쿼리 변수
 include::{snippets}/tripper-trip-list-query-controller-docs-test/사용자_여행_목록_조회/query-parameters.adoc[]
 

--- a/src/main/java/com/cosain/trilo/trip/presentation/trip/TripperTripListQueryController.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/trip/TripperTripListQueryController.java
@@ -7,10 +7,7 @@ import com.cosain.trilo.trip.presentation.trip.dto.request.TripListSearchRequest
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -18,10 +15,10 @@ import org.springframework.web.bind.annotation.RestController;
 public class TripperTripListQueryController {
 
     private final TripListSearchService tripListSearchService;
-    @GetMapping("/api/trips")
+    @GetMapping("/api/tripper/{tripperId}/trips")
     @ResponseStatus(HttpStatus.OK)
-    public TripListSearchResult findTripperTripList(@ModelAttribute TripListSearchRequest request) {
-        var queryParam = TripListQueryParam.of(request.getTripperId(), request.getTripId(), request.getSize());
+    public TripListSearchResult findTripperTripList(@ModelAttribute TripListSearchRequest request, @PathVariable Long tripperId) {
+        var queryParam = TripListQueryParam.of(tripperId, request.getTripId(), request.getSize());
         return tripListSearchService.searchTripList(queryParam);
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/presentation/trip/TripperTripListQueryController.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/trip/TripperTripListQueryController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 public class TripperTripListQueryController {
 
     private final TripListSearchService tripListSearchService;
-    @GetMapping("/api/tripper/{tripperId}/trips")
+    @GetMapping("/api/trippers/{tripperId}/trips")
     @ResponseStatus(HttpStatus.OK)
     public TripListSearchResult findTripperTripList(@ModelAttribute TripListSearchRequest request, @PathVariable Long tripperId) {
         var queryParam = TripListQueryParam.of(tripperId, request.getTripId(), request.getSize());

--- a/src/main/java/com/cosain/trilo/trip/presentation/trip/dto/request/TripListSearchRequest.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/trip/dto/request/TripListSearchRequest.java
@@ -5,12 +5,10 @@ import lombok.Getter;
 @Getter
 public class TripListSearchRequest {
 
-    private final Long tripperId;
     private final Long tripId;
     private final Integer size;
 
-    public TripListSearchRequest(Long tripperId, Long tripId, Integer size) {
-        this.tripperId = tripperId;
+    public TripListSearchRequest(Long tripId, Integer size) {
         this.tripId = tripId;
         this.size = size;
     }

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/TripperTripListQueryControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/TripperTripListQueryControllerTest.java
@@ -53,8 +53,7 @@ class TripperTripListQueryControllerTest extends RestControllerTest {
         given(tripListSearchService.searchTripList(eq(queryParam))).willReturn(searchResult);
 
         // when & then
-        mockMvc.perform(get("/api/trips")
-                        .param("tripperId", String.valueOf(tripperId))
+        mockMvc.perform(get("/api/tripper/{tripperId}/trips", tripperId)
                         .param("size", String.valueOf(size))
                         .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
                         .characterEncoding(StandardCharsets.UTF_8)
@@ -66,9 +65,6 @@ class TripperTripListQueryControllerTest extends RestControllerTest {
                 .andExpect(jsonPath("$.trips.[0].tripId").value(tripSummary3.getTripId()))
                 .andExpect(jsonPath("$.trips.[1].tripId").value(tripSummary2.getTripId()))
                 .andExpect(jsonPath("$.trips.[2].tripId").value(tripSummary1.getTripId()))
-                .andExpect(jsonPath("$.trips.[0].tripperId").value(tripSummary3.getTripperId()))
-                .andExpect(jsonPath("$.trips.[1].tripperId").value(tripSummary2.getTripperId()))
-                .andExpect(jsonPath("$.trips.[2].tripperId").value(tripSummary1.getTripperId()))
                 .andExpect(jsonPath("$.trips.[0].title").value(tripSummary3.getTitle()))
                 .andExpect(jsonPath("$.trips.[1].title").value(tripSummary2.getTitle()))
                 .andExpect(jsonPath("$.trips.[2].title").value(tripSummary1.getTitle()))
@@ -103,8 +99,7 @@ class TripperTripListQueryControllerTest extends RestControllerTest {
         given(tripListSearchService.searchTripList(eq(queryParam))).willReturn(searchResult);
 
         // when & then
-        mockMvc.perform(get("/api/trips")
-                        .param("tripperId", String.valueOf(tripperId))
+        mockMvc.perform(get("/api/tripper/{tripperId}/trips", tripperId)
                         .param("size", String.valueOf(size))
                         .characterEncoding(StandardCharsets.UTF_8)
                         .contentType(MediaType.APPLICATION_JSON))
@@ -115,9 +110,6 @@ class TripperTripListQueryControllerTest extends RestControllerTest {
                 .andExpect(jsonPath("$.trips.[0].tripId").value(tripSummary3.getTripId()))
                 .andExpect(jsonPath("$.trips.[1].tripId").value(tripSummary2.getTripId()))
                 .andExpect(jsonPath("$.trips.[2].tripId").value(tripSummary1.getTripId()))
-                .andExpect(jsonPath("$.trips.[0].tripperId").value(tripSummary3.getTripperId()))
-                .andExpect(jsonPath("$.trips.[1].tripperId").value(tripSummary2.getTripperId()))
-                .andExpect(jsonPath("$.trips.[2].tripperId").value(tripSummary1.getTripperId()))
                 .andExpect(jsonPath("$.trips.[0].title").value(tripSummary3.getTitle()))
                 .andExpect(jsonPath("$.trips.[1].title").value(tripSummary2.getTitle()))
                 .andExpect(jsonPath("$.trips.[2].title").value(tripSummary1.getTitle()))

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/TripperTripListQueryControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/TripperTripListQueryControllerTest.java
@@ -53,7 +53,7 @@ class TripperTripListQueryControllerTest extends RestControllerTest {
         given(tripListSearchService.searchTripList(eq(queryParam))).willReturn(searchResult);
 
         // when & then
-        mockMvc.perform(get("/api/tripper/{tripperId}/trips", tripperId)
+        mockMvc.perform(get("/api/trippers/{tripperId}/trips", tripperId)
                         .param("size", String.valueOf(size))
                         .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
                         .characterEncoding(StandardCharsets.UTF_8)
@@ -99,7 +99,7 @@ class TripperTripListQueryControllerTest extends RestControllerTest {
         given(tripListSearchService.searchTripList(eq(queryParam))).willReturn(searchResult);
 
         // when & then
-        mockMvc.perform(get("/api/tripper/{tripperId}/trips", tripperId)
+        mockMvc.perform(get("/api/trippers/{tripperId}/trips", tripperId)
                         .param("size", String.valueOf(size))
                         .characterEncoding(StandardCharsets.UTF_8)
                         .contentType(MediaType.APPLICATION_JSON))

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/docs/TripperTripListQueryControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/docs/TripperTripListQueryControllerDocsTest.java
@@ -50,7 +50,7 @@ public class TripperTripListQueryControllerDocsTest extends RestDocsTestSupport 
         given(TripListSearchService.searchTripList(eq(queryParam))).willReturn(searchResult);
 
         // when & then
-        mockMvc.perform(RestDocumentationRequestBuilders.get("/api/tripper/{tripperId}/trips", tripperId)
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/api/trippers/{tripperId}/trips", tripperId)
                         .param("tripId", String.valueOf(tripId))
                         .param("size", String.valueOf(size))
                         .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/docs/TripperTripListQueryControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/docs/TripperTripListQueryControllerDocsTest.java
@@ -23,8 +23,7 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.headerWit
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -33,7 +32,6 @@ public class TripperTripListQueryControllerDocsTest extends RestDocsTestSupport 
 
     @MockBean
     private TripListSearchService TripListSearchService;
-    private final String BASE_URL = "/api/trips";
     private final String ACCESS_TOKEN = "Bearer accessToken";
 
     @Test
@@ -52,8 +50,7 @@ public class TripperTripListQueryControllerDocsTest extends RestDocsTestSupport 
         given(TripListSearchService.searchTripList(eq(queryParam))).willReturn(searchResult);
 
         // when & then
-        mockMvc.perform(RestDocumentationRequestBuilders.get(BASE_URL)
-                        .param("tripperId", String.valueOf(tripperId))
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/api/tripper/{tripperId}/trips", tripperId)
                         .param("tripId", String.valueOf(tripId))
                         .param("size", String.valueOf(size))
                         .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
@@ -65,9 +62,6 @@ public class TripperTripListQueryControllerDocsTest extends RestDocsTestSupport 
                 .andExpect(jsonPath("$.trips.[0].tripId").value(tripSummary1.getTripId()))
                 .andExpect(jsonPath("$.trips.[1].tripId").value(tripSummary2.getTripId()))
                 .andExpect(jsonPath("$.trips.[2].tripId").value(tripSummary3.getTripId()))
-                .andExpect(jsonPath("$.trips.[0].tripperId").value(tripSummary1.getTripperId()))
-                .andExpect(jsonPath("$.trips.[1].tripperId").value(tripSummary2.getTripperId()))
-                .andExpect(jsonPath("$.trips.[2].tripperId").value(tripSummary3.getTripperId()))
                 .andExpect(jsonPath("$.trips.[0].title").value(tripSummary1.getTitle()))
                 .andExpect(jsonPath("$.trips.[1].title").value(tripSummary2.getTitle()))
                 .andExpect(jsonPath("$.trips.[2].title").value(tripSummary3.getTitle()))
@@ -88,8 +82,10 @@ public class TripperTripListQueryControllerDocsTest extends RestDocsTestSupport 
                                 headerWithName(HttpHeaders.AUTHORIZATION)
                                         .description("Bearer 타입 AccessToken")
                         ),
+                        pathParameters(
+                                parameterWithName("tripperId").description("여행자 ID")
+                        ),
                         queryParameters(
-                                parameterWithName("tripperId").description("여행자 ID"),
                                 parameterWithName("tripId").optional().description("기준이 되는 여행 ID (하단 설명 참고)"),
                                 parameterWithName("size").description("가져올 데이터의 개수")
                         ),


### PR DESCRIPTION
# JIRA 티켓
[TRL-456]

# 작업 내역

- [x] 사용자 여행 목록 조회 API 엔드포인트 변경 

# 설명

`/api/trips` → `/api/trippers/{tripperId}/trips`

# 참고자료


[TRL-456]: https://cosain.atlassian.net/browse/TRL-456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ