### PR TITLE
[TRL-458] feat: 여행 좋아요 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,9 @@ dependencies {
 	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	// Redisson
+	implementation group: 'org.redisson', name: 'redisson-spring-boot-starter', version: '3.19.0'
 }
 
 test {

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -367,6 +367,45 @@ include::{snippets}/trip-delete-controller-docs-test/trip-delete-doc-test/http-r
 
 
 '''
+=== 좋아요 등록
+
+==== 기본 정보
+- 메서드 : POST
+- URL : `/api/trips/{tripId}/likes`
+- 인증방식 : 엑세스 토큰
+
+==== 요청
+===== 헤더
+include::{snippets}/trip-like-controller-docs-test/좋아요_등록/request-headers.adoc[]
+===== 경로 변수
+include::{snippets}/trip-like-controller-docs-test/좋아요_등록/path-parameters.adoc[]
+==== 예제
+===== 요청
+include::{snippets}/trip-like-controller-docs-test/좋아요_등록/http-request.adoc[]
+===== 응답
+include::{snippets}/trip-like-controller-docs-test/좋아요_등록/http-response.adoc[]
+
+'''
+
+=== 좋아요 취소
+
+==== 기본 정보
+- 메서드 : DELETE
+- URL : `/api/trips/{tripId}/likes`
+- 인증방식 : 엑세스 토큰
+
+==== 요청
+===== 헤더
+include::{snippets}/trip-like-controller-docs-test/좋아요_취소/request-headers.adoc[]
+===== 경로 변수
+include::{snippets}/trip-like-controller-docs-test/좋아요_취소/path-parameters.adoc[]
+==== 예제
+===== 요청
+include::{snippets}/trip-like-controller-docs-test/좋아요_취소/http-request.adoc[]
+===== 응답
+include::{snippets}/trip-like-controller-docs-test/좋아요_취소/http-response.adoc[]
+
+'''
 
 === Trip 조회
 
@@ -390,6 +429,30 @@ include::{snippets}/single-trip-query-controller-docs-test/여행_단건_조회/
 include::{snippets}/single-trip-query-controller-docs-test/여행_단건_조회/http-request.adoc[]
 ===== 응답
 include::{snippets}/single-trip-query-controller-docs-test/여행_단건_조회/http-response.adoc[]
+
+'''
+
+=== 여행 목록 조회
+
+==== 기본 정보
+
+- 메서드 : GET
+- URL : `/api/trips`
+
+==== 요청
+===== 쿼리 변수
+include::{snippets}/trip-condition-search-controller-docs-test/여행_목록_조회/query-parameters.adoc[]
+==== 응답
+===== 본문
+include::{snippets}/trip-condition-search-controller-docs-test/여행_목록_조회/response-fields.adoc[]
+==== 예제
+===== 요청
+include::{snippets}/trip-condition-search-controller-docs-test/여행_목록_조회/http-request.adoc[]
+===== Trips
+include::{snippets}/trip-condition-search-controller-docs-test/여행_목록_조회/response-fields-trips.adoc[]
+===== 응답
+include::{snippets}/trip-condition-search-controller-docs-test/여행_목록_조회/http-response.adoc[]
+
 
 '''
 
@@ -917,25 +980,4 @@ include::{snippets}/user-rest-controller-docs-test/회원_정보_수정/request-
 include::{snippets}/user-rest-controller-docs-test/회원_정보_수정/http-request.adoc[]
 ===== 응답
 include::{snippets}/user-rest-controller-docs-test/회원_정보_수정/http-response.adoc[]
-
-=== 여행 목록 조회
-
-==== 기본 정보
-
-- 메서드 : GET
-- URL : `/api/trips`
-
-==== 요청
-===== 쿼리 변수
-include::{snippets}/trip-condition-search-controller-docs-test/여행_목록_조회/query-parameters.adoc[]
-==== 응답
-===== 본문
-include::{snippets}/trip-condition-search-controller-docs-test/여행_목록_조회/response-fields.adoc[]
-==== 예제
-===== 요청
-include::{snippets}/trip-condition-search-controller-docs-test/여행_목록_조회/http-request.adoc[]
-===== Trips
-include::{snippets}/trip-condition-search-controller-docs-test/여행_목록_조회/response-fields-trips.adoc[]
-===== 응답
-include::{snippets}/trip-condition-search-controller-docs-test/여행_목록_조회/http-response.adoc[]
 

--- a/src/main/java/com/cosain/trilo/common/exception/LockNotAcquiredException.java
+++ b/src/main/java/com/cosain/trilo/common/exception/LockNotAcquiredException.java
@@ -1,0 +1,18 @@
+package com.cosain.trilo.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class LockNotAcquiredException extends CustomException{
+
+    private static final String ERROR_CODE = "lock-0001";
+    private static final HttpStatus HTTP_STATUS = HttpStatus.LOCKED;
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HTTP_STATUS;
+    }
+}

--- a/src/main/java/com/cosain/trilo/common/exception/trip/LikeNotFoundException.java
+++ b/src/main/java/com/cosain/trilo/common/exception/trip/LikeNotFoundException.java
@@ -1,0 +1,20 @@
+package com.cosain.trilo.common.exception.trip;
+
+import com.cosain.trilo.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class LikeNotFoundException extends CustomException {
+
+    private static final String ERROR_CODE = "trip-0011";
+    private static final HttpStatus HTTP_STATUS = HttpStatus.NOT_FOUND;
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HTTP_STATUS;
+    }
+}

--- a/src/main/java/com/cosain/trilo/common/exception/trip/TripAlreadyLikedException.java
+++ b/src/main/java/com/cosain/trilo/common/exception/trip/TripAlreadyLikedException.java
@@ -1,0 +1,20 @@
+package com.cosain.trilo.common.exception.trip;
+
+import com.cosain.trilo.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class TripAlreadyLikedException extends CustomException {
+
+    private static final String ERROR_CODE = "trip-0012";
+    private static final HttpStatus HTTP_STATUS = HttpStatus.CONFLICT;
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HTTP_STATUS;
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/application/trip/service/trip_like/TripLikeFacade.java
+++ b/src/main/java/com/cosain/trilo/trip/application/trip/service/trip_like/TripLikeFacade.java
@@ -1,0 +1,44 @@
+package com.cosain.trilo.trip.application.trip.service.trip_like;
+
+import com.cosain.trilo.common.exception.LockNotAcquiredException;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class TripLikeFacade {
+
+    private final RedissonClient redissonClient;
+    private final TripLikeService tripLikeService;
+
+    private void performWithLock(Long tripId, Long tripperId, TripLikeOperation operation){
+        RLock lock = redissonClient.getLock(tripId.toString());
+
+        try{
+            boolean available = lock.tryLock(1, 3, TimeUnit.SECONDS);
+
+            if(!available){
+                throw new LockNotAcquiredException();
+            }
+
+            operation.perform(tripId, tripperId);
+        }catch (InterruptedException e){
+            throw new LockNotAcquiredException();
+        }finally {
+            lock.unlock();
+        }
+    }
+
+    public void addLike(Long tripId, Long tripperId){
+        performWithLock(tripId, tripperId, tripLikeService::addLike);
+    }
+
+    public void removeLike(Long tripId, Long tripperId){
+        performWithLock(tripId, tripperId, tripLikeService::removeLike);
+    }
+
+}

--- a/src/main/java/com/cosain/trilo/trip/application/trip/service/trip_like/TripLikeOperation.java
+++ b/src/main/java/com/cosain/trilo/trip/application/trip/service/trip_like/TripLikeOperation.java
@@ -1,0 +1,6 @@
+package com.cosain.trilo.trip.application.trip.service.trip_like;
+
+@FunctionalInterface
+public interface TripLikeOperation {
+    void perform(Long tripId, Long tripperId);
+}

--- a/src/main/java/com/cosain/trilo/trip/application/trip/service/trip_like/TripLikeService.java
+++ b/src/main/java/com/cosain/trilo/trip/application/trip/service/trip_like/TripLikeService.java
@@ -1,0 +1,51 @@
+package com.cosain.trilo.trip.application.trip.service.trip_like;
+
+import com.cosain.trilo.common.exception.trip.LikeNotFoundException;
+import com.cosain.trilo.common.exception.trip.TripAlreadyLikedException;
+import com.cosain.trilo.common.exception.trip.TripNotFoundException;
+import com.cosain.trilo.trip.domain.entity.Like;
+import com.cosain.trilo.trip.domain.entity.Trip;
+import com.cosain.trilo.trip.domain.repository.LikeRepository;
+import com.cosain.trilo.trip.domain.repository.TripRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TripLikeService {
+
+    private final TripRepository tripRepository;
+    private final LikeRepository likeRepository;
+
+    public void addLike(Long tripId, Long tripperId){
+        validateNotLiked(tripId, tripperId);
+        Trip trip = findTrip(tripId);
+        likeRepository.save(Like.of(tripId, tripperId));
+        trip.increaseLikeCount();
+    }
+
+    private void validateNotLiked(Long tripId, Long tripperId){
+        if(likeRepository.existsByTripIdAndTripperId(tripId, tripperId)){
+            throw new TripAlreadyLikedException();
+        }
+    }
+
+    public void removeLike(Long tripId, Long tripperId){
+        Trip trip = findTrip(tripId);
+        Like likeRelation = findLikeRelation(tripId, tripperId);
+        likeRepository.delete(likeRelation);
+        trip.decreaseLikeCount();
+    }
+
+    private Trip findTrip(Long tripId){
+        return tripRepository.findById(tripId)
+                .orElseThrow(TripNotFoundException::new);
+    }
+
+    private Like findLikeRelation(Long tripId, Long tripperId){
+        return likeRepository.findByTripIdAndTripperId(tripId, tripperId)
+                .orElseThrow(LikeNotFoundException::new);
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/domain/entity/Like.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/entity/Like.java
@@ -1,0 +1,36 @@
+package com.cosain.trilo.trip.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "likes")
+@EqualsAndHashCode(of = {"tripperId", "tripId"})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Like {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column
+    private Long id;
+
+    @Column(name = "tripper_id")
+    private Long tripperId;
+
+    @Column(name = "trip_id")
+    private Long tripId;
+
+    private Like(Long tripId, Long tripperId){
+        this.tripId = tripId;
+        this.tripperId = tripperId;
+    }
+
+    public static Like of(Long tripId, Long tripperId){
+        return new Like(tripId, tripperId);
+    }
+
+}

--- a/src/main/java/com/cosain/trilo/trip/domain/entity/Trip.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/entity/Trip.java
@@ -49,6 +49,12 @@ public class Trip {
     private Long tripperId;
 
     /**
+     * 좋아요 수
+     */
+    @Column(name = "like_count")
+    private Long likeCount;
+
+    /**
      * 여행의 제목
      *
      * @see TripTitle
@@ -125,6 +131,7 @@ public class Trip {
                 .status(TripStatus.UNDECIDED)
                 .tripImage(TripImage.defaultImage())
                 .tripPeriod(TripPeriod.empty())
+                .likeCount(0L)
                 .build();
     }
 
@@ -132,7 +139,7 @@ public class Trip {
      * 테스트의 편의성을 위해 Builder accessLevel = PUBLIC 으로 설정
      */
     @Builder(access = AccessLevel.PUBLIC)
-    private Trip(Long id, Long tripperId, TripTitle tripTitle, TripStatus status, TripPeriod tripPeriod, TripImage tripImage, List<Day> days, List<Schedule> temporaryStorage) {
+    private Trip(Long id, Long tripperId, TripTitle tripTitle, TripStatus status, TripPeriod tripPeriod, TripImage tripImage, List<Day> days, List<Schedule> temporaryStorage, Long likeCount) {
         this.id = id;
         this.tripperId = tripperId;
         this.tripTitle = tripTitle;
@@ -145,6 +152,7 @@ public class Trip {
         if (temporaryStorage != null) {
             this.temporaryStorage.addAll(temporaryStorage);
         }
+        this.likeCount = likeCount;
     }
 
     /**
@@ -409,5 +417,13 @@ public class Trip {
      */
     void attachScheduleToTemporaryStorage(Schedule schedule) {
         this.temporaryStorage.add(schedule);
+    }
+
+    public void increaseLikeCount(){
+        this.likeCount += 1;
+    }
+
+    public void decreaseLikeCount(){
+        this.likeCount -= 1;
     }
 }

--- a/src/main/java/com/cosain/trilo/trip/domain/repository/LikeRepository.java
+++ b/src/main/java/com/cosain/trilo/trip/domain/repository/LikeRepository.java
@@ -1,0 +1,15 @@
+package com.cosain.trilo.trip.domain.repository;
+
+import com.cosain.trilo.trip.domain.entity.Like;
+
+import java.util.Optional;
+
+public interface LikeRepository {
+    Like save(Like like);
+
+    void delete(Like like);
+
+    boolean existsByTripIdAndTripperId(Long tripId, Long tripperId);
+
+    Optional<Like> findByTripIdAndTripperId(Long tripId, Long tripperId);
+}

--- a/src/main/java/com/cosain/trilo/trip/infra/repository/LikeRepositoryImpl.java
+++ b/src/main/java/com/cosain/trilo/trip/infra/repository/LikeRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.cosain.trilo.trip.infra.repository;
+
+import com.cosain.trilo.trip.domain.entity.Like;
+import com.cosain.trilo.trip.domain.repository.LikeRepository;
+import com.cosain.trilo.trip.infra.repository.jpa.JpaLikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class LikeRepositoryImpl implements LikeRepository {
+
+    private final JpaLikeRepository jpaLikeRepository;
+
+    @Override
+    public Like save(Like like) {
+        return jpaLikeRepository.save(like);
+    }
+
+    @Override
+    public void delete(Like like) {
+        jpaLikeRepository.delete(like);
+    }
+
+    @Override
+    public boolean existsByTripIdAndTripperId(Long tripId, Long tripperId) {
+        return jpaLikeRepository.existsByTripIdAndTripperId(tripId, tripperId);
+    }
+
+    @Override
+    public Optional<Like> findByTripIdAndTripperId(Long tripId, Long tripperId) {
+        return jpaLikeRepository.findByTripperIdAndTripId(tripId, tripperId);
+    }
+}

--- a/src/main/java/com/cosain/trilo/trip/infra/repository/jpa/JpaLikeRepository.java
+++ b/src/main/java/com/cosain/trilo/trip/infra/repository/jpa/JpaLikeRepository.java
@@ -1,0 +1,12 @@
+package com.cosain.trilo.trip.infra.repository.jpa;
+
+import com.cosain.trilo.trip.domain.entity.Like;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface JpaLikeRepository extends JpaRepository<Like, Long> {
+    Optional<Like> findByTripperIdAndTripId(Long tripId, Long tripperId);
+
+    boolean existsByTripIdAndTripperId(Long tripId, Long tripperId);
+}

--- a/src/main/java/com/cosain/trilo/trip/presentation/trip/TripLikeController.java
+++ b/src/main/java/com/cosain/trilo/trip/presentation/trip/TripLikeController.java
@@ -1,0 +1,31 @@
+package com.cosain.trilo.trip.presentation.trip;
+
+import com.cosain.trilo.auth.application.token.UserPayload;
+import com.cosain.trilo.auth.presentation.Login;
+import com.cosain.trilo.auth.presentation.LoginUser;
+import com.cosain.trilo.trip.application.trip.service.trip_like.TripLikeFacade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/trips/{tripId}/likes")
+public class TripLikeController {
+
+    private final TripLikeFacade tripLikeFacade;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.OK)
+    @Login
+    public void create(@PathVariable Long tripId, @LoginUser UserPayload userPayload){
+        tripLikeFacade.addLike(tripId, userPayload.getId());
+    }
+
+    @DeleteMapping
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Login
+    public void delete(@PathVariable Long tripId, @LoginUser UserPayload userPayload){
+        tripLikeFacade.removeLike(tripId, userPayload.getId());
+    }
+}

--- a/src/main/resources/exceptions/exception.yml
+++ b/src/main/resources/exceptions/exception.yml
@@ -29,6 +29,12 @@ request-0005:
   message: Not Multipart request
   detail: 이 API는 Multipart 요청을 필요로 합니다. Multipart 요청으로 보내주세요.
 
+# Lock 관련
+
+lock-0001:
+  message: Lock Not Acquired
+  detail: 요청을 처리하기 위한 락을 획득하지 못했습니다. 나중에 다시 시도해주세요.
+
 # 인증/인가 관련
 
 auth-0001:
@@ -109,6 +115,14 @@ trip-0009:
 trip-0010:
   message: TripImage Upload Failed
   detail: 이미지 저장소에 여행 이미지를 저장하는데 실패했습니다.
+
+trip-0011:
+  message: LikeNotFoundException
+  detail: 해당 여행을 좋아요 하고 있지 않습니다.
+
+trip-0012:
+  message: TripAlreadyLikedException
+  detail: 여행을 이미 좋아요하고 있습니다.
 
 # Day 관련
 day-0001:

--- a/src/main/resources/exceptions/exception_en.yml
+++ b/src/main/resources/exceptions/exception_en.yml
@@ -29,6 +29,11 @@ request-0005:
   message: Not Multipart request
   detail: This API requires a multipart request. Please send it as a multipart request.
 
+# Lock 관련
+
+lock-0001:
+  message: Lock Not Acquired
+  detail: The lock for the requested resource could not be acquired. Please try again later.
 
 # 인증/인가 관련
 
@@ -111,6 +116,14 @@ trip-0009:
 trip-0010:
   message: TripImage Upload Failed
   detail: Failed to save the trip image to the image repository.
+
+trip-0011:
+  message: LikeNotFoundException
+  detail: This trip is not liked. Please check again.
+
+trip-0012:
+  message: TripAlreadyLikedException
+  detail: You have already liked this trip.
 
 # Day 관련
 day-0001:

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,5 +1,6 @@
 DROP TABLE IF EXISTS `trilo_db`.`schedules`;
 DROP TABLE IF EXISTS `trilo_db`.`days`;
+DROP TABLE IF EXISTS `trilo_db`.`likes`;
 DROP TABLE IF EXISTS `trilo_db`.`trip`;
 DROP TABLE IF EXISTS `trilo_db`.`users`;
 
@@ -21,6 +22,7 @@ CREATE TABLE IF NOT EXISTS `trilo_db`.`trip`(
     tripper_id           BIGINT      NOT NULL,
     trip_title           VARCHAR(20) NOT NULL,
     trip_status          VARCHAR(20) NOT NULL,
+    like_count           BIGINT,
     start_date           DATE,
     end_date             DATE,
     trip_image_file_name VARCHAR(255),
@@ -53,6 +55,13 @@ CREATE TABLE IF NOT EXISTS `trilo_db`.`schedules` (
     PRIMARY KEY (schedule_id)
 );
 
+CREATE TABLE IF NOT EXISTS `trilo_db`.`likes` (
+    id              BIGINT       NOT NULL AUTO_INCREMENT,
+    trip_id         BIGINT       NOT NULL,
+    tripper_id      BIGINT       NOT NULL,
+    PRIMARY KEY (id)
+);
+
 ALTER TABLE `trilo_db`.`trip`
 ADD FOREIGN KEY (tripper_id) REFERENCES `trilo_db`.`users` (user_id);
 
@@ -64,3 +73,9 @@ ADD FOREIGN KEY (trip_id) REFERENCES `trilo_db`.`trip` (trip_id);
 
 ALTER TABLE `trilo_db`.`schedules`
 ADD FOREIGN KEY (day_id) REFERENCES `trilo_db`.`days` (day_id);
+
+ALTER TABLE `trilo_db`.`likes`
+ADD FOREIGN KEY (trip_id) REFERENCES  `trilo_db`.`trip` (trip_id);
+
+ALTER TABLE `trilo_db`.`likes`
+ADD FOREIGN KEY (tripper_id) REFERENCES `trilo_db`.`users` (user_id);

--- a/src/test/java/com/cosain/trilo/fixture/TripFixture.java
+++ b/src/test/java/com/cosain/trilo/fixture/TripFixture.java
@@ -138,6 +138,7 @@ public class TripFixture {
                 .status(tripStatus)
                 .tripPeriod(tripPeriod)
                 .tripImage(TripImage.defaultImage())
+                .likeCount(0L)
                 .build();
     }
 

--- a/src/test/java/com/cosain/trilo/unit/trip/application/trip/service/trip_like/TripLikeServiceTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/application/trip/service/trip_like/TripLikeServiceTest.java
@@ -1,0 +1,125 @@
+package com.cosain.trilo.unit.trip.application.trip.service.trip_like;
+
+import com.cosain.trilo.common.exception.trip.LikeNotFoundException;
+import com.cosain.trilo.common.exception.trip.TripAlreadyLikedException;
+import com.cosain.trilo.common.exception.trip.TripNotFoundException;
+import com.cosain.trilo.fixture.TripFixture;
+import com.cosain.trilo.trip.application.trip.service.trip_like.TripLikeService;
+import com.cosain.trilo.trip.domain.entity.Like;
+import com.cosain.trilo.trip.domain.entity.Trip;
+import com.cosain.trilo.trip.domain.repository.LikeRepository;
+import com.cosain.trilo.trip.domain.repository.TripRepository;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+@ExtendWith(MockitoExtension.class)
+public class TripLikeServiceTest {
+    @InjectMocks
+    private TripLikeService tripLikeService;
+    @Mock
+    private LikeRepository likeRepository;
+    @Mock
+    private TripRepository tripRepository;
+
+    @Nested
+    class 좋아요_테스트{
+        @Test
+        void 성공시_메서드_호출_테스트(){
+            // given
+            Long tripId = 1L;
+            Long tripperId = 1L;
+            Trip trip = TripFixture.undecided_Id(tripId, tripperId);
+            given(tripRepository.findById(eq(tripId))).willReturn(Optional.of(trip));
+            given(likeRepository.existsByTripIdAndTripperId(eq(tripId), eq(tripperId))).willReturn(false);
+
+            // when
+            tripLikeService.addLike(tripId, tripperId);
+
+            // then
+            verify(likeRepository, times(1)).save(any(Like.class));
+            verify(tripRepository, times(1)).findById(tripId);
+        }
+
+        @Test
+        void 이미_좋아요를_했던_여행을_다시_좋아요할_경우_TripAlreadyLikedException_예외가_발생한다(){
+            // given
+            Long tripId = 1L;
+            Long tripperId = 1L;
+            given(likeRepository.existsByTripIdAndTripperId(eq(tripId), eq(tripperId))).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> tripLikeService.addLike(tripId, tripperId)).isInstanceOf(TripAlreadyLikedException.class);
+
+        }
+
+        @Test
+        void 존재하지_않는_여행일_경우_TripNotFoundException_예외가_발생한다(){
+            // given
+            Long tripId = 1L;
+            Long tripperId = 1L;
+            given(tripRepository.findById(eq(tripId))).willReturn(Optional.empty());
+
+            // when
+            assertThatThrownBy(() -> tripLikeService.addLike(tripId, tripperId)).isInstanceOf(TripNotFoundException.class);
+
+        }
+    }
+
+    @Nested
+    class 좋아요_취소_테스트{
+
+        @Test
+        void 성공시_메서드_호출_테스트 (){
+
+            // given
+            Long tripId = 1L;
+            Long tripperId = 1L;
+            Trip trip = TripFixture.undecided_Id(tripId, tripperId);
+            given(tripRepository.findById(eq(tripId))).willReturn(Optional.of(trip));
+            given(likeRepository.findByTripIdAndTripperId(eq(tripId), eq(tripperId))).willReturn(Optional.of(Like.of(tripId, tripperId)));
+
+            // when
+            tripLikeService.removeLike(tripId, tripperId);
+
+            // then
+            verify(likeRepository).delete(any(Like.class));
+        }
+
+        @Test
+        void 존재하지_않는_여행일_경우_TripNotFoundException_예외가_발생한다(){
+            // given
+            Long tripId = 1L;
+            Long tripperId = 1L;
+            given(tripRepository.findById(eq(tripId))).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> tripLikeService.removeLike(tripId, tripperId)).isInstanceOf(TripNotFoundException.class);
+        }
+
+        @Test
+        void 좋아요_하지_않았던_여행에_대해_좋아요_취소_요청을_하면_LikeNotFoundException_예외가_발생한다(){
+            // given
+            Long tripId = 1L;
+            Long tripperId = 1L;
+            Trip trip = TripFixture.undecided_Id(tripId, tripperId);
+            given(tripRepository.findById(eq(tripId))).willReturn(Optional.of(trip));
+            given(likeRepository.findByTripIdAndTripperId(eq(tripId), eq(tripperId))).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> tripLikeService.removeLike(tripId, tripperId)).isInstanceOf(LikeNotFoundException.class);
+        }
+    }
+
+}

--- a/src/test/java/com/cosain/trilo/unit/trip/infra/repository/LikeRepositoryImplTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/infra/repository/LikeRepositoryImplTest.java
@@ -1,0 +1,75 @@
+package com.cosain.trilo.unit.trip.infra.repository;
+
+import com.cosain.trilo.support.RepositoryTest;
+import com.cosain.trilo.trip.domain.entity.Like;
+import com.cosain.trilo.trip.domain.entity.Trip;
+import com.cosain.trilo.trip.infra.repository.LikeRepositoryImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("LikeRepositoryImpl 테스트")
+public class LikeRepositoryImplTest extends RepositoryTest {
+
+    @Autowired
+    private LikeRepositoryImpl likeRepositoryImpl;
+
+    @Test
+    @DisplayName("delete 테스트")
+    void deleteTest() {
+        // given
+        Long tripperId = setupTripperId();
+        Trip trip = setupUndecidedTrip(tripperId);
+        Long tripId = trip.getId();
+        Like like = Like.of(tripId, tripperId);
+        likeRepositoryImpl.save(like);
+        flushAndClear();
+
+        // when
+        likeRepositoryImpl.delete(like);
+        flushAndClear();
+
+        // then
+        assertThat(likeRepositoryImpl.existsByTripIdAndTripperId(tripId, tripperId)).isFalse();
+    }
+
+    @Test
+    @DisplayName("existsByTripIdAndTripperId 테스트")
+    void existsByTripIdAndTripperIdTest(){
+        // given
+        Long tripperId = setupTripperId();
+        Trip trip = setupUndecidedTrip(tripperId);
+        Long tripId = trip.getId();
+        Like like = Like.of(tripId, tripperId);
+        likeRepositoryImpl.save(like);
+        flushAndClear();
+
+        // when & then
+        assertThat(likeRepositoryImpl.existsByTripIdAndTripperId(tripId, tripperId)).isTrue();
+    }
+
+    @Test
+    @DisplayName("findByTripIdAndTripperId 테스트")
+    void findByTripIdAndTripperIdTest(){
+        // given
+        Long tripperId = setupTripperId();
+        Trip trip = setupUndecidedTrip(tripperId);
+        Long tripId = trip.getId();
+        Like like = Like.of(tripId, tripperId);
+        likeRepositoryImpl.save(like);
+        flushAndClear();
+
+        // when
+        Optional<Like> likeOptional = likeRepositoryImpl.findByTripIdAndTripperId(tripId, tripperId);
+
+        // then
+        assertThat(likeOptional.isPresent()).isTrue();
+        assertThat(likeOptional.get()).isEqualTo(like);
+
+    }
+
+}

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/TripLikeControllerTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/TripLikeControllerTest.java
@@ -1,0 +1,91 @@
+package com.cosain.trilo.unit.trip.presentation.trip;
+
+
+import com.cosain.trilo.support.RestControllerTest;
+import com.cosain.trilo.trip.application.trip.service.trip_like.TripLikeFacade;
+import com.cosain.trilo.trip.presentation.trip.TripLikeController;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(TripLikeController.class)
+public class TripLikeControllerTest extends RestControllerTest {
+
+    @MockBean
+    private TripLikeFacade tripLikeFacade;
+
+    private static final String ACCESS_TOKEN = "accessToken";
+    private static final String BASE_URL = "/api/trips/{tripId}/likes";
+    @Nested
+    class 좋아요_요청_테스트{
+
+        @Test
+        void 인증된_사용자가_요청할_경우_200() throws Exception {
+
+            Long tripId = 1L;
+            mockingForLoginUserAnnotation(tripId);
+            mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL, tripId)
+                            .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .contentType(MediaType.APPLICATION_JSON)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        void 미인증_사용자가_요청한_경우_401() throws Exception{
+            Long tripId = 1L;
+
+            mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL, tripId)
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .contentType(MediaType.APPLICATION_JSON)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    class 좋아요_취소_요청_테스트{
+        @Test
+        void 인증된_사용자가_요청할_경우_204() throws Exception {
+
+            Long tripId = 1L;
+            mockingForLoginUserAnnotation(tripId);
+
+            mockMvc.perform(RestDocumentationRequestBuilders.delete(BASE_URL, tripId)
+                            .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .contentType(MediaType.APPLICATION_JSON)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        void 미인증_사용자가_요청한_경우_401() throws Exception{
+            Long tripId = 1L;
+
+            mockMvc.perform(RestDocumentationRequestBuilders.delete(BASE_URL, tripId)
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .contentType(MediaType.APPLICATION_JSON)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+
+
+
+}

--- a/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/docs/TripLikeControllerDocsTest.java
+++ b/src/test/java/com/cosain/trilo/unit/trip/presentation/trip/docs/TripLikeControllerDocsTest.java
@@ -1,0 +1,81 @@
+package com.cosain.trilo.unit.trip.presentation.trip.docs;
+
+import com.cosain.trilo.support.RestDocsTestSupport;
+import com.cosain.trilo.trip.application.trip.service.trip_like.TripLikeFacade;
+import com.cosain.trilo.trip.presentation.trip.TripLikeController;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(TripLikeController.class)
+public class TripLikeControllerDocsTest extends RestDocsTestSupport {
+
+    @MockBean
+    private TripLikeFacade tripLikeFacade;
+
+    private static final String ACCESS_TOKEN = "accessToken";
+    private static final String BASE_URL = "/api/trips/{tripId}/likes";
+
+    @Test
+    void 좋아요_등록() throws Exception {
+
+        Long tripId = 1L;
+        mockingForLoginUserAnnotation(tripId);
+
+        mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL, tripId)
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(restDocs.document(
+                        requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION)
+                                .description("Bearer 타입 AccessToken")
+                        ),
+                        pathParameters(
+                                parameterWithName("tripId")
+                                        .description("좋아요할 여행(Trip)의 식별자(id)")
+                        )
+                ));
+    }
+
+
+    @Test
+    void 좋아요_취소() throws Exception {
+
+        Long tripId = 1L;
+        mockingForLoginUserAnnotation(tripId);
+
+        mockMvc.perform(RestDocumentationRequestBuilders.delete(BASE_URL, tripId)
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isNoContent())
+                .andDo(restDocs.document(
+                        requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION)
+                                .description("Bearer 타입 AccessToken")
+                        ),
+                        pathParameters(
+                                parameterWithName("tripId")
+                                        .description("좋아요 취소할 여행(Trip)의 식별자(id)")
+                        )
+                ));
+    }
+
+
+}

--- a/src/test/resources/test_schema.sql
+++ b/src/test/resources/test_schema.sql
@@ -1,5 +1,6 @@
 DROP TABLE IF EXISTS `trilo_db_test`.`schedules`;
 DROP TABLE IF EXISTS `trilo_db_test`.`days`;
+DROP TABLE IF EXISTS `trilo_db_test`.`likes`;
 DROP TABLE IF EXISTS `trilo_db_test`.`trip`;
 DROP TABLE IF EXISTS `trilo_db_test`.`users`;
 
@@ -21,6 +22,7 @@ CREATE TABLE IF NOT EXISTS `trilo_db_test`.`trip` (
     tripper_id BIGINT NOT NULL,
     trip_title VARCHAR(20) NOT NULL,
     trip_status VARCHAR(20) NOT NULL,
+    like_count BIGINT,
     start_date DATE,
     end_date DATE,
     trip_image_file_name VARCHAR(255),
@@ -53,6 +55,13 @@ CREATE TABLE IF NOT EXISTS `trilo_db_test`.`schedules` (
     PRIMARY KEY (schedule_id)
 );
 
+CREATE TABLE IF NOT EXISTS `trilo_db_test`.`likes` (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    trip_id BIGINT NOT NULL,
+    tripper_id BIGINT NOT NULL,
+    PRIMARY KEY (id)
+);
+
 ALTER TABLE `trilo_db_test`.`trip`
 ADD FOREIGN KEY (tripper_id) REFERENCES `trilo_db_test`.`users` (user_id);
 
@@ -64,3 +73,9 @@ ADD FOREIGN KEY (trip_id) REFERENCES `trilo_db_test`.`trip` (trip_id);
 
 ALTER TABLE `trilo_db_test`.`schedules`
 ADD FOREIGN KEY (day_id) REFERENCES `trilo_db_test`.`days` (day_id);
+
+ALTER TABLE `trilo_db_test`.`likes`
+ADD FOREIGN KEY (trip_id) REFERENCES  `trilo_db_test`.`trip` (trip_id);
+
+ALTER TABLE `trilo_db_test`.`likes`
+ADD FOREIGN KEY (tripper_id) REFERENCES `trilo_db_test`.`users` (user_id);


### PR DESCRIPTION
# JIRA 티켓
[TRL-458]

# 작업 내역

- [x] Redisson 의존성 추가
- [x] 여행 좋아요 API 구현
- [x] RestDocs API 문서화

# 설명

### API Endpoint 
여행 좋아요 등록 : POST `/api/trips/{tripId}/likes`
여행 좋아요 취소 : DELETE `/api/trips/{tripId}/likes`

### 동시성 이슈 해결 방법 - 분산락 ( Redisson )

`Redisson` 을 활용하여 발생할 수 있는 동시성 이슈를 해결했습니다.

이미 Redis라는 기술 스택을 JWT 관리에 사용 중이어서 추가 인프라 구축이 필요 없으며 MySQL 로도 동일하게 동시성 이슈를 해결할 수 있겠지만 락을 사용하기 위해 별도의 커넥션 풀을 관리해야 하고 락에 관련된 부하를 RDS에서 받는다는 점에서 Redis를 사용하는 것이 더 효율적이라고 생각했기 때문에 분산락을 활용하여 해결했습니다.

Lettuce 의 경우 스핀락 방식으로 동작하기에 Race Condition에서 루프를 돌며 Redis 에 Lock 을 확인하는 요청을 지속적으로 보내기 때문에 Redis 트래픽이 할당되므로 Sub/Pub 방식으로 동작하며 불필요하게 발생하는 트래픽을 줄여주기 위해 Redisson 을 채택했습니다.

# 기록

[멀티 쓰레드 환경에서 좋아요❤️ 기능 구현하기](https://velog.io/@gyuseong/%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8-%EB%A9%80%ED%8B%B0-%EC%93%B0%EB%A0%88%EB%93%9C-%ED%99%98%EA%B2%BD%EC%97%90%EC%84%9C-%EC%A2%8B%EC%95%84%EC%9A%94-%EA%B8%B0%EB%8A%A5-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0)

# 참고자료

- https://yangbongsoo.gitbook.io/study/undefined-1/rest
- https://docs.github.com/ko/free-pro-team@latest/rest/users/followers?apiVersion=2022-11-28#follow-a-user
- https://techvu.dev/116
- https://suhwan.dev/2019/06/09/transaction-isolation-level-and-lock/
- https://hyperconnect.github.io/2019/11/15/redis-distributed-lock-1.html

[TRL-458]: https://cosain.atlassian.net/browse/TRL-458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ